### PR TITLE
Bug fix: Do not build and push the "latest" tag when pushing the "dev" images

### DIFF
--- a/build/src/push.js
+++ b/build/src/push.js
@@ -132,7 +132,11 @@ async function pushImage(definitionId, repo, release, updateLatest,
                 const context = devContainerJson.build ? devContainerJson.build.context || '.' : devContainerJson.context || '.';
                 const workingDir = path.resolve(dotDevContainerPath, context);
                 const imageNameParams = imageNamesWithVersionTags.reduce((prev, current) => prev.concat(['--image-name', current]), []);
-                imageNameParams.push('--image-name', imageName);
+
+                // Do not build and push the "latest" tag when pushing the "dev" images
+                if (configUtils.getVersionFromRelease(release, definitionId) !== 'dev' || !pushImages) {
+                    imageNameParams.push('--image-name', imageName);
+                }
 
                 const spawnOpts = { stdio: 'inherit', cwd: workingDir, shell: true };
                 await asyncUtils.spawn('npx --yes devcontainers-cli-0.6.3.tgz', [


### PR DESCRIPTION
Currently, when the pipeline [Build and push "dev" images](https://github.com/devcontainers/images/actions/runs/2659806989) is executed, it builds and pushes to the `latest` tag.
This is incorrect as anyone using the `latest` tag will now have the image build with the `dev` tag contents.

Hence, fixing this! 