### PR TITLE
bug fix - 'Push' action gets skipped

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,8 +20,6 @@ jobs:
       id: free_space 
       run: |
         set -e
-        echo "Check base_ref"
-        echo "${{ github.event.base_ref }}"
         # Ensure enough space is available for build
         sudo apt-get autoremove -y
         sudo apt-get clean -y


### PR DESCRIPTION
[This PR ](https://github.com/devcontainers/images/pull/43) introduced a bug which only runs the actions when `github.ref == ref/heads/main`. However, as the action is now triggered on a release, the `github.ref = ref/tags/v*`

Hence, now checking for `github.event.base_ref`