### PR TITLE
Fix bug: Action 'Update version history' gets skipped for 'push'

### DIFF
--- a/.github/workflows/version-history.yml
+++ b/.github/workflows/version-history.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   image_info:
     name: Update version history
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' || github.event.base_ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Similar to https://github.com/devcontainers/images/pull/55

Fixes: https://github.com/devcontainers/images/runs/7659461741?check_suite_focus=true