### PR TITLE
README: Fix MCR namespace and update semver examples to match existing tags

### DIFF
--- a/src/alpine/README.md
+++ b/src/alpine/README.md
@@ -9,7 +9,7 @@
 | *Categories* | Core, Other |
 | *Image type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/base:alpine |
-| *Available image variants* | 3.15, 3.14, 3.13 ([full list](https://mcr.microsoft.com/v2/devcontainers/base/tags/list)) |
+| *Available image variants* | alpine-3.15, alpine-3.14, alpine-3.13 ([full list](https://mcr.microsoft.com/v2/devcontainers/base/tags/list)) |
 | *Published image architecture(s)* | x86-64, aarch64/arm64 |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Alpine Linux |
@@ -29,8 +29,8 @@ You can also directly reference pre-built versions of `Dockerfile` by using the 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/devcontainers/base:0-alpine`
-- `mcr.microsoft.com/devcontainers/base:0.1-alpine`
-- `mcr.microsoft.com/devcontainers/base:0.1.0-alpine`
+- `mcr.microsoft.com/devcontainers/base:0.204-alpine`
+- `mcr.microsoft.com/devcontainers/base:0.204.3-alpine`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/base/tags/list).
 

--- a/src/anaconda/README.md
+++ b/src/anaconda/README.md
@@ -28,7 +28,7 @@ You can decide how often you want updates by referencing a [semantic version](ht
 
 - `mcr.microsoft.com/devcontainers/anaconda:0-3`
 - `mcr.microsoft.com/devcontainers/anaconda:0.202-3`
-- `mcr.microsoft.com/devcontainers/anaconda:0.202.0-3`
+- `mcr.microsoft.com/devcontainers/anaconda:0.202.6-3`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/anaconda/tags/list).
 

--- a/src/codespaces/README.md
+++ b/src/codespaces/README.md
@@ -26,9 +26,9 @@ The container includes the `zsh` (and Oh My Zsh!) and `fish` shells that you can
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. However, **note that only the most recent image is pre-cached in Codespaces**. For example:
 
-- `mcr.microsoft.com/devcontainers/universal:1-focal`
-- `mcr.microsoft.com/devcontainers/universal:1.3-focal`
-- `mcr.microsoft.com/devcontainers/universal:1.3.3-focal`
+- `mcr.microsoft.com/devcontainers/universal:2-focal`
+- `mcr.microsoft.com/devcontainers/universal:2.0-focal`
+- `mcr.microsoft.com/devcontainers/universal:2.0.6-focal`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/universal/tags/list).
 

--- a/src/cpp/README.md
+++ b/src/cpp/README.md
@@ -33,8 +33,8 @@ You can directly reference pre-built versions of `Dockerfile` by using the `imag
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/devcontainers/cpp:0-bullseye`
-- `mcr.microsoft.com/devcontainers/cpp:0.204-bullseye`
-- `mcr.microsoft.com/devcontainers/cpp:0.204.0-bullseye`
+- `mcr.microsoft.com/devcontainers/cpp:0.205-bullseye`
+- `mcr.microsoft.com/devcontainers/cpp:0.205.0-bullseye`
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/microsoft/vscode-dev-containers/issues/532) versions of images (e.g. `0-debian-11`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 

--- a/src/debian/README.md
+++ b/src/debian/README.md
@@ -28,8 +28,8 @@ You can directly reference pre-built versions of `Dockerfile` by using the `imag
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/devcontainers/base:0-buster`
-- `mcr.microsoft.com/devcontainers/base:0.201-buster`
-- `mcr.microsoft.com/devcontainers/base:0.201.5-buster`
+- `mcr.microsoft.com/devcontainers/base:0.202-buster`
+- `mcr.microsoft.com/devcontainers/base:0.202.6-buster`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/base/tags/list).
 

--- a/src/dotnet/README.md
+++ b/src/dotnet/README.md
@@ -31,8 +31,8 @@ You can directly reference pre-built versions of `Dockerfile` by using the `imag
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/devcontainers/dotnet:0-3.1`
-- `mcr.microsoft.com/devcontainers/dotnet:0.202-3.1`
-- `mcr.microsoft.com/devcontainers/dotnet:0.202.0-3.1`
+- `mcr.microsoft.com/devcontainers/dotnet:0.203-3.1`
+- `mcr.microsoft.com/devcontainers/dotnet:0.203.0-3.1`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/dotnet/tags/list).
 

--- a/src/go/README.md
+++ b/src/go/README.md
@@ -9,8 +9,8 @@
 | *Contributors* | The VS Code Team |
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
-| *Published images* | mcr.microsoft.com/vscode/devcontainers/go |
-| *Available image variants* | 1 / 1-bullseye, 1.18 / 1.18-bullseye, 1.17 / 1.17-bullseye, 1-buster, 1.18-buster, 1.17-buster  ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/go/tags/list)) |
+| *Published images* | mcr.microsoft.com/devcontainers/go |
+| *Available image variants* | 1 / 1-bullseye, 1.18 / 1.18-bullseye, 1.19 / 1.19-bullseye, 1-buster, 1.18-buster, 1.19-buster  ([full list](https://mcr.microsoft.com/v2/devcontainers/go/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bullseye` variants |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
@@ -19,33 +19,25 @@
 
 See **[history](history)** for information on the contents of published images.
 
-## Using this definition
+## Using this image
 
-While the definition itself works unmodified, you can select the version of Go the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
+You can directly reference pre-built versions of `Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
 
-```json
-// Or you can use 1.17-bullseye or 1.17-buster if you want to pin to an OS version
-"args": { "VARIANT": "1.17" }
-```
-
-You can also directly reference pre-built versions of `.devcontainer/base.Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
-
-- `mcr.microsoft.com/vscode/devcontainers/go` (latest)
-- `mcr.microsoft.com/vscode/devcontainers/go:1` (or `1-bullseye`, `1-buster` to pin to an OS version)
-- `mcr.microsoft.com/vscode/devcontainers/go:1.17` (or `1.17-bullseye`, `1.17-buster` to pin to an OS version)
-- `mcr.microsoft.com/vscode/devcontainers/go:1.18` (or `1.18-bullseye`, `1.18-buster` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/go` (latest)
+- `mcr.microsoft.com/devcontainers/go:1` (or `1-bullseye`, `1-buster` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/go:1.18` (or `1.18-bullseye`, `1.18-buster` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/go:1.19` (or `1.19-bullseye`, `1.19-buster` to pin to an OS version)
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/vscode/devcontainers/go:0-1.18` (or `0-1.18-bullseye`, `0-1.18-buster`)
-- `mcr.microsoft.com/vscode/devcontainers/go:0.206-1.18` (or `0.205-1.18-bullseye`, `0.205-1.18-buster`)
-- `mcr.microsoft.com/vscode/devcontainers/go:0.206.0-1.18` (or `0.205.0-1.18-bullseye`, `0.205.0-1.18-buster`)
+- `mcr.microsoft.com/devcontainers/go:0-1.19` (or `0-1.19-bullseye`, `0-1.19-buster`)
+- `mcr.microsoft.com/devcontainers/go:0.207-1.19` (or `0.207-1.19-bullseye`, `0.207-1.19-buster`)
+- `mcr.microsoft.com/devcontainers/go:0.207.1-1.19` (or `0.207.1-1.19-bullseye`, `0.207.1-1.19-buster`)
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/microsoft/vscode-dev-containers/issues/532) versions of images (e.g. `0-1.16`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 
-See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/go/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/go/tags/list).
 
-Alternatively, you can use the contents of `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
 #### Installing Node.js
 

--- a/src/java/README.md
+++ b/src/java/README.md
@@ -28,8 +28,8 @@ You can directly reference pre-built versions of `Dockerfile` by using the `imag
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/devcontainers/java:0-11` (or `0-11-bullseye`, `0-11-buster` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/java:0.203-11` (or `0.203-11-bullseye`, `0.203-11-buster` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/java:0.203.0-11` (or `0.203.0-11-bullseye`, `0.203.0-11-buster` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/java:0.205-11` (or `0.205-11-bullseye`, `0.205-11-buster` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/java:0.205.0-11` (or `0.205.0-11-bullseye`, `0.205.0-11-buster` to pin to an OS version)
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/microsoft/vscode-dev-containers/issues/532) versions of images (e.g. `0-11`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 

--- a/src/jekyll/README.md
+++ b/src/jekyll/README.md
@@ -35,7 +35,7 @@ You can decide how often you want updates by referencing a [semantic version](ht
 
 - `mcr.microsoft.com/devcontainers/jekyll:0` (or `0-bullseye`, `0-buster` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/jekyll:0.1` (or `0.1-bullseye`, `0.1-buster` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/jekyll:0.1.0` (or `0.1.0-bullseye`, `0.1.0-buster` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/jekyll:0.1.6` (or `0.1.6-bullseye`, `0.1.6-buster` to pin to an OS version)
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/microsoft/vscode-dev-containers/issues/532) versions of images (e.g. `0-bullseye`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 

--- a/src/miniconda/README.md
+++ b/src/miniconda/README.md
@@ -27,8 +27,8 @@ You can directly reference pre-built versions of `Dockerfile` by using the `imag
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/devcontainers/miniconda:0-3`
-- `mcr.microsoft.com/devcontainers/miniconda:0.201-3`
-- `mcr.microsoft.com/devcontainers/miniconda:0.201.4-3`
+- `mcr.microsoft.com/devcontainers/miniconda:0.202-3`
+- `mcr.microsoft.com/devcontainers/miniconda:0.202.3-3`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/miniconda/tags/list).
 

--- a/src/php/README.md
+++ b/src/php/README.md
@@ -32,7 +32,7 @@ You can decide how often you want updates by referencing a [semantic version](ht
 
 - `mcr.microsoft.com/devcontainers/python:0-7` (or `0-7-bullseye`, `0-7-buster`)
 - `mcr.microsoft.com/devcontainers/python:0.203-7` (or `0.203-7-bullseye`, `0.203-7-buster`)
-- `mcr.microsoft.com/devcontainers/python:0.203.0-7` (or `0.203.0-7-bullseye`, `0.203.0-7-buster`)
+- `mcr.microsoft.com/devcontainers/python:0.203.3-7` (or `0.203.3-7-bullseye`, `0.203.3-7-buster`)
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/microsoft/vscode-dev-containers/issues/532) versions of images (e.g. `0-7`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 

--- a/src/python/README.md
+++ b/src/python/README.md
@@ -33,8 +33,8 @@ You can directly reference pre-built versions of `Dockerfile` by using the `imag
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/devcontainers/python:0-3.9` (or `0-3.9-bullseye`, `0-3.9-buster`)
-- `mcr.microsoft.com/devcontainers/python:0.202-3.9` (or `0.202-3.9-bullseye`, `0.202-3.9-buster`)
-- `mcr.microsoft.com/devcontainers/python:0.202.0-3.9` (or `0.202.0-3.9-bullseye`, `0.202.0-3.9-buster`)
+- `mcr.microsoft.com/devcontainers/python:0.203-3.9` (or `0.203-3.9-bullseye`, `0.203-3.9-buster`)
+- `mcr.microsoft.com/devcontainers/python:0.202.5-3.9` (or `0.202.5-3.9-bullseye`, `0.202.5-3.9-buster`)
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/microsoft/vscode-dev-containers/issues/532) versions of images (e.g. `0-14`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 

--- a/src/ruby/README.md
+++ b/src/ruby/README.md
@@ -31,8 +31,8 @@ You can directly reference pre-built versions of `Dockerfile` by using the `imag
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/devcontainers/ruby:0-3` (or `0-3-bullseye`, `0-3-buster` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/ruby:0.203-3` (or `0.202-3-bullseye`, `0.202-3-buster` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/ruby:0.203.0-3` (or `0.202.0-3-bullseye`, `0.202.0-3-buster` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/ruby:0.203-3` (or `0.203-3-bullseye`, `0.203-3-buster` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/ruby:0.203.3-3` (or `0.203.3-3-bullseye`, `0.202.3-3-buster` to pin to an OS version)
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/microsoft/vscode-dev-containers/issues/532) versions of images (e.g. `0-2.7`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 

--- a/src/rust/README.md
+++ b/src/rust/README.md
@@ -27,8 +27,8 @@ You can directly reference pre-built versions of `Dockerfile` by using the `imag
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/devcontainers/rust:0-1` (or `0-1-bullseye`, `0-1-buster` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/rust:0.201-1` (or `0.201-1-bullseye`, `0.201-1-buster` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/rust:0.201.0-1` (or `0.201.0-1-bullseye`, `0.201.0-1-buster` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/rust:0.202-1` (or `0.202-1-bullseye`, `0.202-1-buster` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/rust:0.202.0-1` (or `0.202.0-1-bullseye`, `0.202.0-1-buster` to pin to an OS version)
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/microsoft/vscode-dev-containers/issues/532) versions of images (e.g. `0-1`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 


### PR DESCRIPTION
Fixes: 

- MCR namespace bug was a recent regression from https://github.com/devcontainers/images/pull/57
- As README was copied over from `vscode-dev-containers` repo, the examples on how to reference semvers had stale tags. Hence, updated tags to match the ones which exists in https://mcr.microsoft.com/v2/devcontainers/${image}/tags/list