### PR TITLE
fix bug - update image history

### DIFF
--- a/build/src/utils/config.js
+++ b/build/src/utils/config.js
@@ -392,7 +392,8 @@ function getSortedDefinitionBuildList(page, pageTotal, definitionsToSkip) {
     if (allPages.length > pageTotal) {
         // If too many pages, add extra pages to last one
         console.log(`(!) Not enough pages to for target page size. Adding excess definitions to last page.`);
-        for (let i = pageTotal; i < allPages.length; i++) {
+        let i = pageTotal;
+        while (i < allPages.length) {
             allPages[pageTotal - 1] = allPages[pageTotal - 1].concat(allPages[i]);
             allPages.splice(i, 1);
         }


### PR DESCRIPTION
Due to incorrect pagination, history files were not created for `"javascript-node"` and `"typescript-node"`. Fixing that! 

![image](https://user-images.githubusercontent.com/24955913/187492608-65f1a0b0-b273-456c-ac6f-dbf6b3b9db09.png)

Expected -

![image](https://user-images.githubusercontent.com/24955913/187495146-37cc699a-e768-482e-a038-4d86b9063e4d.png)



