### PR TITLE
universal - Add CMD and containerUser

### DIFF
--- a/src/universal/.devcontainer/Dockerfile
+++ b/src/universal/.devcontainer/Dockerfile
@@ -99,6 +99,7 @@ VOLUME [ "/var/lib/docker" ]
 
 # Fire Docker/Moby script if needed
 ENTRYPOINT [ "/usr/local/share/docker-init.sh", "/usr/local/share/ssh-init.sh"]
+CMD [ "sleep", "infinity" ]
 
 # [Optional] Install debugger for development of Codespaces - Not in resulting image by default
 ARG DeveloperBuild

--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -95,6 +95,7 @@
         "./local-features/setup-user"
     ],
     "remoteUser": "codespace",
+    "containerUser": "codespace",
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
     // "forwardPorts": [],
     // "oryx build" will automatically install your dependencies and attempt to build your project


### PR DESCRIPTION
- Copies over missing CMD from [here](https://github.com/microsoft/vscode-dev-containers/blob/main/containers/codespaces-linux/.devcontainer/base.Dockerfile#L126)

- The new image has config.user: "root", however the old one has `codespace` (set [here](https://github.com/microsoft/vscode-dev-containers/blob/main/containers/codespaces-linux/.devcontainer/base.Dockerfile#L136)). Fixing that.
