### PR TITLE
Universal: adding missing env

### DIFF
--- a/src/universal/.devcontainer/local-features/setup-user/devcontainer-feature.json
+++ b/src/universal/.devcontainer/local-features/setup-user/devcontainer-feature.json
@@ -2,7 +2,7 @@
     "id": "setup-user",
     "name": "Setup Secure Path",
     "containerEnv": {
-        "PATH": "/home/codespace/.dotnet:/home/codespace/.nodejs/current/bin:/home/codespace/.php/current/bin:/home/codespace/.python/current/bin:/home/codespace/.java/current/bin:/home/codespace/.ruby/current/bin:${PATH}"
+        "PATH": "/home/codespace/.dotnet:/home/codespace/.nodejs/current/bin:/home/codespace/.php/current/bin:/home/codespace/.python/current/bin:/home/codespace/.java/current/bin:/home/codespace/.ruby/current/bin:/home/codespace/.local/bin:${PATH}"
     },
     "install": {
         "app": "",

--- a/src/universal/.devcontainer/local-features/setup-user/install.sh
+++ b/src/universal/.devcontainer/local-features/setup-user/install.sh
@@ -64,6 +64,6 @@ chown -R codespace:oryx ${OPT_DIR}
 chmod -R g+r+w "${OPT_DIR}"
 find "${OPT_DIR}" -type d | xargs -n 1 chmod g+s
 
-echo "Defaults secure_path=\"${DOTNET_PATH}:${NODE_PATH}/bin:${PHP_PATH}/bin:${PYTHON_PATH}/bin:${JAVA_PATH}/bin:${RUBY_PATH}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:/usr/local/share:${PATH}\"" >> /etc/sudoers.d/$USERNAME
+echo "Defaults secure_path=\"${DOTNET_PATH}:${NODE_PATH}/bin:${PHP_PATH}/bin:${PYTHON_PATH}/bin:${JAVA_PATH}/bin:${RUBY_PATH}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:/usr/local/share:/home/codespace/.local/bin:${PATH}\"" >> /etc/sudoers.d/$USERNAME
 
 echo "Done!"

--- a/src/universal/manifest.json
+++ b/src/universal/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.0.11",
+	"version": "2.0.12",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",


### PR DESCRIPTION
Adding missing `/home/codespace/.local/bin` to `$PATH`
Old reference - https://github.com/microsoft/vscode-dev-containers/blob/main/containers/codespaces-linux/.devcontainer/base.Dockerfile#L37

<img width="1089" alt="image" src="https://user-images.githubusercontent.com/24955913/189241944-867b753d-f8cd-44ab-9cb8-cbd3ccb8727d.png">
