### PR TITLE
Universal: Build git from source

### DIFF
--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -62,7 +62,8 @@
             "version": "latest"
         },
         "ghcr.io/devcontainers/features/git:1": {
-            "version": "latest"
+            "version": "latest",
+            "ppa": "false"
         },
         "ghcr.io/devcontainers/features/go:1": {
             "version": "latest"

--- a/src/universal/test-project/test-utils.sh
+++ b/src/universal/test-project/test-utils.sh
@@ -113,6 +113,7 @@ checkCommon()
         libstdc++6 \
         zlib1g \
         locales \
+        gettext \
         sudo"
 
     # Actual tests


### PR DESCRIPTION
Fixes `gettext` not found error and builds `git` from source ( similar to the old image). 