### PR TITLE
Universal- adds configureJupyterlabAllowOrigin option to python Feature

### DIFF
--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -25,7 +25,8 @@
         "ghcr.io/devcontainers/features/python:1": {
             "version": "3.10",
             "additionalVersions": "3.9",
-            "installJupyterlab": "true"
+            "installJupyterlab": "true",
+            "configureJupyterlabAllowOrigin": "*"
         },
         "./local-features/machine-learning-packages": "latest",
         "ghcr.io/devcontainers/features/php:1": {

--- a/src/universal/manifest.json
+++ b/src/universal/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.0.14",
+	"version": "2.0.15",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -47,6 +47,7 @@ check "requests" python -c "import requests; print(requests.__version__)"
 
 # Check JupyterLab
 check "jupyter-lab" jupyter-lab --version
+check "jupyter-lab config" grep ".*.allow_origin = '*'" /home/codespace/.jupyter/jupyter_server_config.py
 
 # Check Java tools
 check "java" java -version


### PR DESCRIPTION
- Fixes: Regression from migrating the image - [details](https://github.com/microsoft/vscode-dev-containers/blob/main/containers/codespaces-linux/.devcontainer/base.Dockerfile#L87)
- Includes the Python Feature fix where Jupyter recently changed the name of the file used to configure JupyterLab - https://github.com/devcontainers/features/pull/174