### PR TITLE
Add remoteUser to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,6 @@
 {
     "image": "mcr.microsoft.com/vscode/devcontainers/javascript-node:0-18",
+    "remoteUser": "node",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "image": "mcr.microsoft.com/vscode/devcontainers/javascript-node:0-18",
+    "image": "mcr.microsoft.com/devcontainers/javascript-node:0-18",
     "remoteUser": "node",
     "customizations": {
         "vscode": {


### PR DESCRIPTION
Adds `"remoteUser": "node"` to this repo's `devcontainer.json` to fix permissions issues.

Same idea as https://github.com/devcontainers/features/pull/181, but for this repo.