### PR TITLE
Filter unwanted Jupyter kernels in Universal image

### DIFF
--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -112,16 +112,16 @@
                 "go.useLanguageServer": true,
                 "go.gopath": "/go",
                 "python.defaultInterpreterPath": "/home/codespace/.python/current/bin/python3",
-                "python.linting.enabled": true,
-                "python.linting.pylintEnabled": true,
                 "python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
                 "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
                 "python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
                 "python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+                "python.linting.enabled": true,
                 "python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
                 "python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
                 "python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
                 "python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+                "python.linting.pylintEnabled": true,
                 "python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
                 "jupyter.kernels.filter": [
                     {

--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -123,6 +123,36 @@
                 "python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
                 "python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
                 "python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
+                "jupyter.kernels.filter": [
+                    {
+                        "path": "/opt/conda/bin/python",
+                        "type": "pythonEnvironment"
+                    },
+                    {
+                        "path": "/bin/python2",
+                        "type": "pythonEnvironment"
+                    },
+                    {
+                        "path": "/usr/bin/python2",
+                        "type": "pythonEnvironment"
+                    },
+                    {
+                        "path": "/usr/local/python/current/bin/python3",
+                        "type": "pythonEnvironment"
+                    },
+                    {
+                        "path": "/usr/local/python/current/bin/python",
+                        "type": "pythonEnvironment"
+                    },
+                    {
+                        "path": "/usr/bin/python3",
+                        "type": "pythonEnvironment"
+                    },
+                    {
+                        "path": "/bin/python3",
+                        "type": "pythonEnvironment"
+                    }
+                ],
                 "lldb.executable": "/usr/bin/lldb",
                 "files.watcherExclude": {
                     "**/target/**": true

--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -110,7 +110,7 @@
             "settings": {
                 "go.toolsManagement.checkForUpdates": "local",
                 "go.useLanguageServer": true,
-                "go.gopath": "/usr/local/go/bin/go",
+                "go.gopath": "/go",
                 "python.defaultInterpreterPath": "/home/codespace/.python/current/bin/python3",
                 "python.linting.enabled": true,
                 "python.linting.pylintEnabled": true,

--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -111,7 +111,7 @@
                 "go.toolsManagement.checkForUpdates": "local",
                 "go.useLanguageServer": true,
                 "go.gopath": "/usr/local/go/bin/go",
-                "python.defaultInterpreterPath": "/usr/local/python/current/bin/python",
+                "python.defaultInterpreterPath": "/home/codespace/.python/current/bin/python3",
                 "python.linting.enabled": true,
                 "python.linting.pylintEnabled": true,
                 "python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",

--- a/src/universal/manifest.json
+++ b/src/universal/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.0.17",
+	"version": "2.0.18",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/src/universal/manifest.json
+++ b/src/universal/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.0.18",
+	"version": "2.0.19",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",


### PR DESCRIPTION
Adds the `jupyter.kernels.filter` VS Code setting to the Universal image to filter unwanted Python kernels. This setting makes for a much cleaner VS Code experience when using the Jupyter extension.

This won't filter new Conda environments or Python installations that users add. It just hides the extra installations in the universal image that don't include our Jupyter and ML tooling.

Before:
<img width="1279" alt="Many Python installations in the kernel picker" src="https://user-images.githubusercontent.com/19893438/193113479-d0be1f46-268c-4ff7-a8b1-37e2177fb371.png">

Note that the `Suggested` kernel isn't our primary installation of Python and that there are several entries for our primary installation (because of our symlinks).

After:
<img width="1280" alt="Only our primary Python installation in the kernel picker" src="https://user-images.githubusercontent.com/19893438/193113522-698097c9-afd3-4ea5-9b4b-0e26327f1251.png">

The only kernel that appears in the picker is our primary installation of Python. Its path matches the output of `which python3`.