### PR TITLE
Pin Python versions in Universal image

### DIFF
--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -23,8 +23,8 @@
         },
         "./local-features/nvs": "latest",
         "ghcr.io/devcontainers/features/python:1": {
-            "version": "3.10",
-            "additionalVersions": "3.9",
+            "version": "3.10.4",
+            "additionalVersions": "3.9.7",
             "installJupyterlab": "true",
             "configureJupyterlabAllowOrigin": "*"
         },

--- a/src/universal/manifest.json
+++ b/src/universal/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.0.17",
+	"version": "2.0.18",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",


### PR DESCRIPTION
Pins the Python versions in the Universal image at 3.10.4 and 3.9.7 to ensure compatibility with Oryx.

https://github.com/microsoft/Oryx/blob/main/doc/supportedPlatformVersions.md#python

<img width="813" alt="Python 3.10.4" src="https://user-images.githubusercontent.com/19893438/193367367-71692fc2-b440-4c11-bc7e-e796637fb4f5.png">