### PR TITLE
Remove files.watcherExclude from Universal image

### DIFF
--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -123,10 +123,7 @@
                 "python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
                 "python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
                 "python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
-                "lldb.executable": "/usr/bin/lldb",
-                "files.watcherExclude": {
-                    "**/target/**": true
-                }
+                "lldb.executable": "/usr/bin/lldb"
             },
             // Add the IDs of extensions you want installed when the container is created.
             "extensions": [

--- a/src/universal/manifest.json
+++ b/src/universal/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.0.17",
+	"version": "2.0.18",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/src/universal/manifest.json
+++ b/src/universal/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.0.20",
+	"version": "2.0.18",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",


### PR DESCRIPTION
Removes the `files.watcherExclude` VS Code settings from the Universal image.