### PR TITLE
universal: update version

### DIFF
--- a/src/universal/manifest.json
+++ b/src/universal/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.0.19",
+	"version": "2.0.18",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",


### PR DESCRIPTION
Looks like the version for `universal` image was bumped twice. Fixing that - `v2.0.18` does not exist.