### PR TITLE
Add test for kernel directory in Universal image

### DIFF
--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -48,6 +48,7 @@ check "requests" python -c "import requests; print(requests.__version__)"
 # Check JupyterLab
 check "jupyter-lab" jupyter-lab --version
 check "jupyter-lab config" grep ".*.allow_origin = '*'" /home/codespace/.jupyter/jupyter_server_config.py
+check "jupyter-lab kernel" test -d "/home/codespace/.python/current/bin"
 
 # Check Java tools
 check "java" java -version


### PR DESCRIPTION
#139 added a couple of VS Code settings that assume that `/home/codespace/.python/current/bin` exists.

This PR adds a test to ensure that the directory exists. If we remove or change `/home/codespace/.python` in the future, we need to check the following VS Code settings:
- `python.defaultInterpreterPath`
- `jupyter.kernels.filter`