### PR TITLE
Drop git feature from C++ since its in upstream

### DIFF
--- a/src/cpp/.devcontainer/devcontainer.json
+++ b/src/cpp/.devcontainer/devcontainer.json
@@ -3,17 +3,8 @@
 		"dockerfile": "./Dockerfile",
 		"context": "."
 	},
-	"features": {
-        "ghcr.io/devcontainers/features/git:1": {
-            "version": "latest",
-            "ppa": "false"
-        }
-    },
-	"runArgs": [
-		"--cap-add=SYS_PTRACE",
-		"--security-opt",
-		"seccomp=unconfined"
-	],
+	"capAdd": ["SYS_PTRACE"],
+	"securityOpt": ["seccomp=unconfined"],
 	// Configure tool-specific properties.
 	"customizations": {
 		// Configure properties specific to VS Code.


### PR DESCRIPTION
The base image will already have an updated git in it, so this just slows down the build and adds size to the image with no benifit.

The "runArgs" also will not end up on the image, so switch to new capAdd, securityOpt properties.  Other places like "go" use a feature that adds this, but C++ does not.