### PR TITLE
vscdc - update build command

### DIFF
--- a/build/src/push.js
+++ b/build/src/push.js
@@ -132,8 +132,7 @@ async function pushImage(definitionId, repo, release, updateLatest,
                 // ubuntu:focal image supports multiarch but Universal does not. Hence, the build fails similar to https://github.com/docker/buildx/issues/235
                 if (definitionId !== "universal") {
                     platformParams = "--platform " + (pushImages ? architectures.reduce((prev, current) => prev + ',' + current, '').substring(1) : localArchitecture)
-                }
-                else {
+                } else {
                     skipPersistingCustomizationsFormFeatures = true;
                 }
 
@@ -153,7 +152,7 @@ async function pushImage(definitionId, repo, release, updateLatest,
                     '--no-cache', 'true',
                     platformParams,
                     pushImages ? '--push' : '',
-                    '--skip-persisting-customizations-from-features', skipPersistingCustomizationsFormFeatures
+                    '--skip-persisting-customizations-from-features', skipPersistingCustomizationsFormFeatures,
                 ], spawnOpts);
 
                 if (!pushImages) {

--- a/build/src/push.js
+++ b/build/src/push.js
@@ -126,14 +126,14 @@ async function pushImage(definitionId, repo, release, updateLatest,
 
             if (replaceImage || !await isDefinitionVersionAlreadyPublished(definitionId, release, registry, registryPath, variant)) {
 
-                let skipPersistingCustomizationsFormFeatures = false;
+                let skipPersistingCustomizationsFromFeatures = false;
                 let platformParams = "";
                 // Universal image does not need to be multi-arch
                 // ubuntu:focal image supports multiarch but Universal does not. Hence, the build fails similar to https://github.com/docker/buildx/issues/235
                 if (definitionId !== "universal") {
                     platformParams = "--platform " + (pushImages ? architectures.reduce((prev, current) => prev + ',' + current, '').substring(1) : localArchitecture)
                 } else {
-                    skipPersistingCustomizationsFormFeatures = true;
+                    skipPersistingCustomizationsFromFeatures = true;
                 }
 
                 const context = devContainerJson.build ? devContainerJson.build.context || '.' : devContainerJson.context || '.';
@@ -152,7 +152,7 @@ async function pushImage(definitionId, repo, release, updateLatest,
                     '--no-cache', 'true',
                     platformParams,
                     pushImages ? '--push' : '',
-                    '--skip-persisting-customizations-from-features', skipPersistingCustomizationsFormFeatures,
+                    '--skip-persisting-customizations-from-features', skipPersistingCustomizationsFromFeatures,
                 ], spawnOpts);
 
                 if (!pushImages) {

--- a/build/src/push.js
+++ b/build/src/push.js
@@ -126,11 +126,15 @@ async function pushImage(definitionId, repo, release, updateLatest,
 
             if (replaceImage || !await isDefinitionVersionAlreadyPublished(definitionId, release, registry, registryPath, variant)) {
 
+                let skipPersistingCustomizationsFormFeatures = false;
                 let platformParams = "";
                 // Universal image does not need to be multi-arch
                 // ubuntu:focal image supports multiarch but Universal does not. Hence, the build fails similar to https://github.com/docker/buildx/issues/235
-                if (definitionId != "universal") {
+                if (definitionId !== "universal") {
                     platformParams = "--platform " + (pushImages ? architectures.reduce((prev, current) => prev + ',' + current, '').substring(1) : localArchitecture)
+                }
+                else {
+                    skipPersistingCustomizationsFormFeatures = true;
                 }
 
                 const context = devContainerJson.build ? devContainerJson.build.context || '.' : devContainerJson.context || '.';
@@ -149,6 +153,7 @@ async function pushImage(definitionId, repo, release, updateLatest,
                     '--no-cache', 'true',
                     platformParams,
                     pushImages ? '--push' : '',
+                    '--skip-persisting-customizations-from-features', skipPersistingCustomizationsFormFeatures
                 ], spawnOpts);
 
                 if (!pushImages) {


### PR DESCRIPTION
For `universal` image, adds a '--skip-persisting-customizations-from-features' flag

Universal
![image](https://user-images.githubusercontent.com/24955913/199544415-c2e06dab-ca34-4343-83d1-09903a125bfb.png)


Cpp
![image](https://user-images.githubusercontent.com/24955913/199544352-e188199c-05f6-4bbd-8b78-9792679e1cb9.png)