### PR TITLE
Update config

### DIFF
--- a/build/config.json
+++ b/build/config.json
@@ -152,7 +152,7 @@
 			"downloadUrl": "https://github.com/rvm/rvm"
 		},
 		"kubectl": {
-			"versionCommand": "kubectl version --client | grep -oP 'GitVersion\\s*:\\s*\\\"v\\K[0-9]+\\.[0-9]+\\.[0-9]+'",
+			"versionCommand": "kubectl version --output=json --client | jq '.clientVersion .gitVersion'",
 			"path": "/usr/local/bin",
 			"downloadUrl": "https://github.com/kubernetes/kubectl"
 		},

--- a/build/config.json
+++ b/build/config.json
@@ -152,7 +152,7 @@
 			"downloadUrl": "https://github.com/rvm/rvm"
 		},
 		"kubectl": {
-			"versionCommand": "kubectl version --output=json --client | jq '.clientVersion .gitVersion'",
+			"versionCommand": "kubectl version --client --output=json | jq '.clientVersion .gitVersion'",
 			"path": "/usr/local/bin",
 			"downloadUrl": "https://github.com/kubernetes/kubectl"
 		},


### PR DESCRIPTION
Update command to find `kubectl` version. Previous one is deprecated.

Fixes such warnings ⬇️  ( https://github.com/devcontainers/images/blob/main/src/universal/history/2.0.8.md )
![image](https://user-images.githubusercontent.com/24955913/199552389-6c5d3932-73a7-447a-8aa2-3fde5e3da40d.png)

![image](https://user-images.githubusercontent.com/24955913/199551974-1b1284cf-8d6d-4768-b317-fdc29ade0b8f.png)