### PR TITLE
EOL - `alpine-3.13`

### DIFF
--- a/src/base-alpine/README.md
+++ b/src/base-alpine/README.md
@@ -9,7 +9,7 @@
 | *Categories* | Core, Other |
 | *Image type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/base:alpine |
-| *Available image variants* | alpine-3.16, alpine-3.15, alpine-3.14, alpine-3.13 ([full list](https://mcr.microsoft.com/v2/devcontainers/base/tags/list)) |
+| *Available image variants* | alpine-3.16, alpine-3.15, alpine-3.14 ([full list](https://mcr.microsoft.com/v2/devcontainers/base/tags/list)) |
 | *Published image architecture(s)* | x86-64, aarch64/arm64 |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Alpine Linux |
@@ -22,7 +22,6 @@ See **[history](history)** for information on the contents of published images.
 You can also directly reference pre-built versions of `.devcontainer/Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
 
 - `mcr.microsoft.com/devcontainers/base:alpine` (latest)
-- `mcr.microsoft.com/devcontainers/base:alpine-3.13`
 - `mcr.microsoft.com/devcontainers/base:alpine-3.14`
 - `mcr.microsoft.com/devcontainers/base:alpine-3.15`
 - `mcr.microsoft.com/devcontainers/base:alpine-3.16`

--- a/src/base-alpine/manifest.json
+++ b/src/base-alpine/manifest.json
@@ -1,10 +1,9 @@
 {
-	"version": "0.204.13",
+	"version": "0.205.0",
 	"variants": [
 		"3.16",
 		"3.15",
-		"3.14",
-		"3.13"
+		"3.14"
 	],
 	"build": {
 		"latest": false,
@@ -18,7 +17,13 @@
 			"base:${VERSION}-alpine${VARIANT}"
 		],
 		"variantTags": {
+			"3.16": [
+				"base:${VERSION}-alpine"
+			],
 			"3.15": [
+				"base:${VERSION}-alpine"
+			],
+			"3.14": [
 				"base:${VERSION}-alpine"
 			]
 		}

--- a/src/base-alpine/manifest.json
+++ b/src/base-alpine/manifest.json
@@ -17,13 +17,7 @@
 			"base:${VERSION}-alpine${VARIANT}"
 		],
 		"variantTags": {
-			"3.16": [
-				"base:${VERSION}-alpine"
-			],
 			"3.15": [
-				"base:${VERSION}-alpine"
-			],
-			"3.14": [
 				"base:${VERSION}-alpine"
 			]
 		}


### PR DESCRIPTION
Updates `base-alpine`

According to https://endoflife.date/alpine, `alpine 3.13` is no longer supported.