### PR TITLE
Bump universal .NET versions to 6 and 7

### DIFF
--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -10,9 +10,9 @@
             "gid": "1000"
         },
         "ghcr.io/devcontainers/features/dotnet:1": {
-            "version": "6",
+            "version": "7",
             "installUsingApt": "false",
-            "additionalVersions": "3"
+            "additionalVersions": "6"
         },
         "ghcr.io/devcontainers/features/hugo:1": {
             "version": "latest"

--- a/src/universal/manifest.json
+++ b/src/universal/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.1.0",
+	"version": "2.0.24",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/src/universal/manifest.json
+++ b/src/universal/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.0.24",
+	"version": "2.1.0",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",


### PR DESCRIPTION
Related to #200

This is likely at least partly dependent on https://github.com/devcontainers/features/pull/269, but given `installUsingApt` is set to false, it may work without this modification. For consistency, it might be best to wait, however.