### PR TITLE
Add git extension for JupyterLab to Universal image

### DIFF
--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -29,6 +29,7 @@
             "configureJupyterlabAllowOrigin": "*"
         },
         "./local-features/machine-learning-packages": "latest",
+        "./local-features/jupyterlab-extensions": {},
         "ghcr.io/devcontainers/features/php:1": {
             "version": "8.1.4",
             "additionalVersions": "8.0.16",
@@ -81,6 +82,7 @@
         "./local-features/nvs",
         "ghcr.io/devcontainers/features/python",
         "./local-features/machine-learning-packages",
+        "./local-features/jupyterlab-extensions",
         "ghcr.io/devcontainers/features/php",
         "ghcr.io/devcontainers/features/conda",
         "ghcr.io/devcontainers/features/ruby",

--- a/src/universal/.devcontainer/local-features/jupyterlab-extensions/devcontainer-feature.json
+++ b/src/universal/.devcontainer/local-features/jupyterlab-extensions/devcontainer-feature.json
@@ -1,0 +1,8 @@
+{
+    "id": "jupyterlab-extensions",
+    "name": "Extensions for JupyterLab",
+    "install": {
+        "app": "",
+        "file": "install.sh"
+    }
+}

--- a/src/universal/.devcontainer/local-features/jupyterlab-extensions/install.sh
+++ b/src/universal/.devcontainer/local-features/jupyterlab-extensions/install.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+USERNAME=${USERNAME:-"codespace"}
+
+set -eux
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Ensure that login shells get the correct path if the user updated the PATH using ENV.
+rm -f /etc/profile.d/00-restore-env.sh
+echo "export PATH=${PATH//$(sh -lc 'echo $PATH')/\$PATH}" > /etc/profile.d/00-restore-env.sh
+chmod +x /etc/profile.d/00-restore-env.sh
+
+sudo_if() {
+    COMMAND="$*"
+    if [ "$(id -u)" -eq 0 ] && [ "$USERNAME" != "root" ]; then
+        su - "$USERNAME" -c "$COMMAND"
+    else
+        "$COMMAND"
+    fi
+}
+
+export DEBIAN_FRONTEND=noninteractive
+
+install_python_package() {
+    PACKAGE=${1:-""}
+
+    sudo_if /usr/local/python/current/bin/python -m pip uninstall --yes $PACKAGE
+    echo "Installing $PACKAGE..."
+    sudo_if /usr/local/python/current/bin/python -m pip install --user --upgrade --no-cache-dir $PACKAGE
+}
+
+if [[ "$(python --version)" != "" ]] && [[ "$(pip --version)" != "" ]]; then
+    install_python_package "jupyterlab-git"
+else
+    "(*) Error: Need to install python and pip."
+fi
+
+echo "Done!"

--- a/src/universal/manifest.json
+++ b/src/universal/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.0.24",
+	"version": "2.0.25",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -51,6 +51,7 @@ check "seaborn" python -c "import seaborn; print(seaborn.__version__)"
 check "scikit-learn" python -c "import sklearn; print(sklearn.__version__)"
 check "torch" python -c "import torch; print(torch.__version__)"
 check "requests" python -c "import requests; print(requests.__version__)"
+check "jupyterlab-git" python -m pip list | grep jupyterlab-git
 
 # Check JupyterLab
 check "jupyter-lab" jupyter-lab --version


### PR DESCRIPTION
Adds the `jupyterlab-git` package to the Universal image. This extension makes it much easier to interact with git repos from JupyterLab. This is a light extension (6 MB, measured by `du -hx /usr/local/python`). 

<img width="1282" alt="Demo of jupyterlab-git" src="https://user-images.githubusercontent.com/19893438/201726162-df96d1ff-2f42-4f90-a26d-71eb969f8379.png">