### PR TITLE
Update dev Action: Set fail-fast: false

### DIFF
--- a/.github/workflows/push-dev.yml
+++ b/.github/workflows/push-dev.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         page: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57]
         page-total: [57]
-      fail-fast: true
+      fail-fast: false
     runs-on: devcontainer-image-builder-ubuntu
     steps:
     - name: Free more space


### PR DESCRIPTION
Now we have 57 jobs running in parallel for pushing dev and prod tags.
For dev, it will be convenient to turn off `fail-fast` 

Sample - https://github.com/devcontainers/images/actions/runs/3464287236
One such job failure (generally due to timeouts) would lead for other jobs to get cancelled.