### PR TITLE
fix version history - Fails to generate info for  `rust` image

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -376,7 +376,6 @@ For example:
 
 ```json
 "cargo": {
-    "rls": null,
     "rustfmt": null,
     "rust-analysis": "rustc --version",
     "rust-src": "rustc --version",

--- a/src/rust/manifest.json
+++ b/src/rust/manifest.json
@@ -42,7 +42,6 @@
 			"Oh My Zsh!": "/home/vscode/.oh-my-zsh"
 		},
 		"cargo": {
-			"rls": null,
 			"rustfmt": null,
 			"rust-analysis": "rustc --version",
 			"rust-src": "rustc --version",

--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -10,9 +10,9 @@
             "gid": "1000"
         },
         "ghcr.io/devcontainers/features/dotnet:1": {
-            "version": "7",
+            "version": "6",
             "installUsingApt": "false",
-            "additionalVersions": "6"
+            "additionalVersions": "3"
         },
         "ghcr.io/devcontainers/features/hugo:1": {
             "version": "latest"

--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -10,9 +10,9 @@
             "gid": "1000"
         },
         "ghcr.io/devcontainers/features/dotnet:1": {
-            "version": "6",
+            "version": "7",
             "installUsingApt": "false",
-            "additionalVersions": "3"
+            "additionalVersions": "6"
         },
         "ghcr.io/devcontainers/features/hugo:1": {
             "version": "latest"


### PR DESCRIPTION
Fixes - https://github.com/devcontainers/images/actions/runs/3464602488/jobs/5789759137#step:5:11948

`rls` is deprecated (Details [here](https://github.com/rust-lang/rls#%EF%B8%8F-rls-is-no-longer-supported)) & hence the `rls --version` command is failing to run. 

Fixing that! 