### PR TITLE
Universal: Fixes NVM in a Node project

### DIFF
--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -10,9 +10,9 @@
             "gid": "1000"
         },
         "ghcr.io/devcontainers/features/dotnet:1": {
-            "version": "7",
+            "version": "6",
             "installUsingApt": "false",
-            "additionalVersions": "6"
+            "additionalVersions": "3"
         },
         "ghcr.io/devcontainers/features/hugo:1": {
             "version": "latest"

--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -10,9 +10,9 @@
             "gid": "1000"
         },
         "ghcr.io/devcontainers/features/dotnet:1": {
-            "version": "6",
+            "version": "7",
             "installUsingApt": "false",
-            "additionalVersions": "3"
+            "additionalVersions": "6"
         },
         "ghcr.io/devcontainers/features/hugo:1": {
             "version": "latest"

--- a/src/universal/.devcontainer/local-features/setup-user/devcontainer-feature.json
+++ b/src/universal/.devcontainer/local-features/setup-user/devcontainer-feature.json
@@ -4,7 +4,7 @@
     "containerEnv": {
         "RUBY_HOME": "/usr/local/rvm/rubies/default",
         "JAVA_ROOT": "/home/codespace/.java",
-        "NODE_ROOT": "/home/codespace/.nodejs",
+        "NODE_ROOT": "/home/codespace/nvm",
         "PHP_ROOT": "/home/codespace/.php",
         "PYTHON_ROOT": "/home/codespace/.python",
         "RUBY_ROOT": "/home/codespace/.ruby",
@@ -20,7 +20,7 @@
         "RAILS_DEVELOPMENT_HOSTS": ".githubpreview.dev,.app.github.dev",
         "GOROOT": "/usr/local/go",
         "JUPYTERLAB_PATH": "/home/codespace/.local/bin",
-        "PATH": "/home/codespace/.dotnet:/home/codespace/.nodejs/current/bin:/home/codespace/.php/current/bin:/home/codespace/.python/current/bin:/home/codespace/.java/current/bin:/home/codespace/.ruby/current/bin:/home/codespace/.local/bin:${PATH}"
+        "PATH": "/home/codespace/.dotnet:/home/codespace/nvm/current/bin:/home/codespace/.php/current/bin:/home/codespace/.python/current/bin:/home/codespace/.java/current/bin:/home/codespace/.ruby/current/bin:/home/codespace/.local/bin:${PATH}"
     },
     "install": {
         "app": "",

--- a/src/universal/.devcontainer/local-features/setup-user/install.sh
+++ b/src/universal/.devcontainer/local-features/setup-user/install.sh
@@ -30,9 +30,8 @@ ln -snf /usr/local/oryx/* /opt/oryx
 
 # For the universal image, oryx build tool installs the detected platforms in /home/codespace/*. Hence, linking current platforms to the /home/codespace/ path and adding it to the PATH.
 # This ensures that whatever platfornm versions oryx detects and installs are set as root.
-NODE_PATH="/home/codespace/.nodejs/current"
-mkdir -p /home/codespace/.nodejs
-ln -snf /usr/local/share/nvm/current $NODE_PATH
+NODE_PATH="/home/codespace/nvm/current"
+ln -snf /usr/local/share/nvm /home/codespace
 
 PHP_PATH="/home/codespace/.php/current"
 mkdir -p /home/codespace/.php

--- a/src/universal/test-project/sample/node/package.json
+++ b/src/universal/test-project/sample/node/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "test-package",
+    "version": "1.0.0"
+}

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -157,6 +157,12 @@ check "oryx-install-java-12.0.2" oryx prep --skip-detection --platforms-and-vers
 check "java-12.0.2-installed-by-oryx" ls /opt/java/ | grep 12.0.2
 check "java-version-on-path-is-12.0.2" java --version | grep 12.0.2
 
+# Ensures nvm works in a Node Project
+check "default-node-version" bash -c "node --version | grep 16."
+oryx build ./sample/node
+nvm install 8.0.0
+check "nvm-works-in-node-project" bash -c "node --version | grep v8.0.0"
+
 ls -la /home/codespace
 
 # Report result

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -159,9 +159,11 @@ check "java-version-on-path-is-12.0.2" java --version | grep 12.0.2
 
 # Ensures nvm works in a Node Project
 check "default-node-version" bash -c "node --version | grep 16."
+check "default-node-location" bash -c "which node | grep /home/codespace/nvm/current/bin"
 oryx build ./sample/node
 nvm install 8.0.0
 check "nvm-works-in-node-project" bash -c "node --version | grep v8.0.0"
+check "default-node-location-remained-same" bash -c "which node | grep /home/codespace/nvm/current/bin"
 
 ls -la /home/codespace
 

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -160,8 +160,8 @@ check "java-version-on-path-is-12.0.2" java --version | grep 12.0.2
 # Ensures nvm works in a Node Project
 check "default-node-version" bash -c "node --version | grep 16."
 check "default-node-location" bash -c "which node | grep /home/codespace/nvm/current/bin"
-oryx build ./sample/node
-nvm install 8.0.0
+check "oryx-build-node-projectr" bash -c "oryx build ./sample/node"
+check "nvm-install-node" bash -c ". /usr/local/share/nvm/nvm.sh && nvm install 8.0.0"
 check "nvm-works-in-node-project" bash -c "node --version | grep v8.0.0"
 check "default-node-location-remained-same" bash -c "which node | grep /home/codespace/nvm/current/bin"
 


### PR DESCRIPTION
Addresses - https://github.com/devcontainers/images/issues/187

For `universal` image, node is first found at `/home/codespace/.nodejs/current` which is sym linked to `usr/local/share/nvm/current`

However, for Node projects, oryx installs another version of node and installs it in `/opt/nodejs` (from source) & links to `/home/codespace/.nodejs/current`. Hence, if the user then tries to set a default node version with nvm, it doesn't work.

This PR makes nvm to work even after oryx installs another version. However, the node version installed by oryx is not set as default. Created another PR on oryx repo to fix this --> https://github.com/microsoft/Oryx/pull/1692