### PR TITLE
Universal: Remove git installation from source

### DIFF
--- a/src/universal/.devcontainer/Dockerfile
+++ b/src/universal/.devcontainer/Dockerfile
@@ -54,6 +54,7 @@ RUN LANG="C.UTF-8" \
         tk-dev \
         uuid-dev \
         curl \
+        gettext \
     && rm -rf /var/lib/apt/lists/* \
     # This is the folder containing 'links' to benv and build script generator
     && apt-get update \

--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -10,9 +10,9 @@
             "gid": "1000"
         },
         "ghcr.io/devcontainers/features/dotnet:1": {
-            "version": "7",
+            "version": "6",
             "installUsingApt": "false",
-            "additionalVersions": "6"
+            "additionalVersions": "3"
         },
         "ghcr.io/devcontainers/features/hugo:1": {
             "version": "latest"

--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -62,10 +62,6 @@
         "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
             "version": "latest"
         },
-        "ghcr.io/devcontainers/features/git:1": {
-            "version": "latest",
-            "ppa": "false"
-        },
         "ghcr.io/devcontainers/features/go:1": {
             "version": "latest"
         },
@@ -90,7 +86,6 @@
         "ghcr.io/devcontainers/features/github-cli",
         "ghcr.io/devcontainers/features/docker-in-docker",
         "ghcr.io/devcontainers/features/kubectl-helm-minikube",
-        "ghcr.io/devcontainers/features/git",
         "ghcr.io/devcontainers/features/go",
         "./local-features/jekyll",
         "ghcr.io/devcontainers/features/oryx",

--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -10,9 +10,9 @@
             "gid": "1000"
         },
         "ghcr.io/devcontainers/features/dotnet:1": {
-            "version": "6",
+            "version": "7",
             "installUsingApt": "false",
-            "additionalVersions": "3"
+            "additionalVersions": "6"
         },
         "ghcr.io/devcontainers/features/hugo:1": {
             "version": "latest"

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -7,7 +7,8 @@ source test-utils.sh codespace
 checkCommon
 
 check "git" git --version
-check "gitconfig-location" bash -c "git config --system user.name devcontainer && ls /etc | grep gitconfig"
+check "gitconfig" bash -c "sudo git config --system user.name devcontainer"
+check "gitconfig-location" bash -c "sudo ls /etc | grep gitconfig"
 
 # Check .NET
 check "dotnet" dotnet --list-sdks

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -8,13 +8,6 @@ checkCommon
 
 check "git" git --version
 
-git_version_satisfied=false
-if (echo a version 2.38.1; git --version) | sort -Vk3 | tail -1 | grep -q git; then
-    git_version_satisfied=true
-fi
-
-check "git version satisfies requirement" echo $git_version_satisfied | grep "true"
-
 # Check .NET
 check "dotnet" dotnet --list-sdks
 count=$(ls /usr/local/dotnet | wc -l)

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -7,6 +7,7 @@ source test-utils.sh codespace
 checkCommon
 
 check "git" git --version
+check "gitconfig-location" bash -c "git config --system user.name devcontainer && ls /etc | grep gitconfig"
 
 # Check .NET
 check "dotnet" dotnet --list-sdks


### PR DESCRIPTION
Git is already installed from `apt`. Remove, re-installation from git source.

ℹ️  The upstream git has security patch applied! 