### PR TITLE
Fix nvm install shell in comments

### DIFF
--- a/src/typescript-node/.devcontainer/Dockerfile
+++ b/src/typescript-node/.devcontainer/Dockerfile
@@ -13,7 +13,7 @@ RUN su node -c "umask 0002 && npm install -g ${NODE_MODULES}" \
 
 # [Optional] Uncomment if you want to install an additional version of node using nvm
 # ARG EXTRA_NODE_VERSION=10
-# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+# RUN su node -c "source /usr/local/share/nvm/install.sh && nvm install ${EXTRA_NODE_VERSION}"
 
 # [Optional] Uncomment if you want to install more global node packages
 # RUN su node -c "npm install -g <your-package-list -here>"


### PR DESCRIPTION
Not 100% sure, but there is no `nvm.sh` but `install.sh` in the nvm folder.