### PR TITLE
php: install more extensions, fixes #196

### DIFF
--- a/src/php/.devcontainer/Dockerfile
+++ b/src/php/.devcontainer/Dockerfile
@@ -1,19 +1,17 @@
 # [Choice] PHP version (use -bullseye variants on local arm64/Apple Silicon): 8-apache-bullseye, 8.1-apache-bullseye, 8.0-apache-bullseye, 7-apache-bullseye, 7.4-apache-bullseye, 8-apache-buster, 8.1-apache-buster, 8.0-apache-buster, 7-apache-buster, 7.4-apache-buster
-ARG VARIANT=7-apache-bullseye
+ARG VARIANT=8-apache-bullseye
 FROM php:${VARIANT}
 
-# Install xdebug
-RUN yes | pecl install xdebug \
-    && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini \
-    && echo "xdebug.mode = debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
-    && echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/xdebug.ini \
-    && echo "xdebug.client_port = 9000" >> /usr/local/etc/php/conf.d/xdebug.ini \
-    && rm -rf /tmp/pear
+COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
+COPY --from=composer/composer:latest-bin /composer /usr/bin/composer
 
-# Install composer
-RUN curl -sSL https://getcomposer.org/installer | php \
-    && chmod +x composer.phar \
-    && mv composer.phar /usr/local/bin/composer
+# Install some php extensions
+RUN IPE_GD_WITHOUTAVIF=1 install-php-extensions bz2 bcmath gd intl mysqli pdo_mysql pdo_pgsql sockets gmp soap zip pcntl redis xsl calendar xdebug
+
+# Configure xdebug
+RUN echo "xdebug.mode = debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.client_port = 9000" >> /usr/local/etc/php/conf.d/xdebug.ini
 
 # [Optional] Uncomment this section to install additional packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
- Changed the default variant to PHP 8 (7 is EOL)
- Installed some "default" extensions, with [install-php-extensions](https://github.com/mlocati/docker-php-extension-installer)
- Copy composer from official docker image