### PR TITLE
Add `preview.app.github.dev` to `RAILS_DEVELOPMENT_HOSTS`

### DIFF
--- a/src/universal/.devcontainer/local-features/setup-user/devcontainer-feature.json
+++ b/src/universal/.devcontainer/local-features/setup-user/devcontainer-feature.json
@@ -17,7 +17,7 @@
         "NPM_GLOBAL": "/home/codespace/.npm-global",
         "NVS_HOME": "/home/codespace/.nvs",
         "RVM_PATH": "/usr/local/rvm",
-        "RAILS_DEVELOPMENT_HOSTS": ".githubpreview.dev,.app.github.dev",
+        "RAILS_DEVELOPMENT_HOSTS": ".githubpreview.dev,.preview.app.github.dev,.app.github.dev",
         "GOROOT": "/usr/local/go",
         "JUPYTERLAB_PATH": "/home/codespace/.local/bin",
         "PATH": "/home/codespace/.dotnet:/home/codespace/nvm/current/bin:/home/codespace/.php/current/bin:/home/codespace/.python/current/bin:/home/codespace/java/current/bin:/home/codespace/.ruby/current/bin:/home/codespace/.local/bin:${PATH}"

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -119,7 +119,7 @@ check "fish" fish --version
 check "zsh" zsh --version
 
 # Check env variable
-check "RAILS_DEVELOPMENT_HOSTS is set correctly" echo $RAILS_DEVELOPMENT_HOSTS | grep ".githubpreview.dev,.app.github.dev"
+check "RAILS_DEVELOPMENT_HOSTS is set correctly" echo $RAILS_DEVELOPMENT_HOSTS | grep ".githubpreview.dev,.preview.app.github.dev,.app.github.dev"
 
 # Check that we can run a puppeteer node app.
 yarn


### PR DESCRIPTION
Caught by @ghiculescu over at https://github.com/microsoft/vscode-dev-containers/pull/1626#issuecomment-1345449615.

I had missed the `preview` prefix when I had updated it before. Leaving `app.github.dev` in place since that will be the final destination of port forwarding.