### PR TITLE
Universal: Remove python2 installation

### DIFF
--- a/src/universal/.devcontainer/Dockerfile
+++ b/src/universal/.devcontainer/Dockerfile
@@ -60,13 +60,7 @@ RUN LANG="C.UTF-8" \
     && apt-get update \
     && apt-get upgrade -y \
     && add-apt-repository universe \
-    && apt-get install -y --no-install-recommends python2 \
-    && rm -rf /var/lib/apt/lists/* \
-    # 'get-pip.py' has been moved to ' https://bootstrap.pypa.io/pip/2.7/get-pip.py' from 'https://bootstrap.pypa.io/2.7/get-pip.py'
-    && curl  https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py \
-    && python2 get-pip.py \
-    && pip install pip --upgrade \
-    && pip3 install pip --upgrade
+    && rm -rf /var/lib/apt/lists/*
 
 # Verify expected build and debug tools are present
 RUN apt-get update \

--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -124,14 +124,6 @@
                         "type": "pythonEnvironment"
                     },
                     {
-                        "path": "/bin/python2",
-                        "type": "pythonEnvironment"
-                    },
-                    {
-                        "path": "/usr/bin/python2",
-                        "type": "pythonEnvironment"
-                    },
-                    {
                         "path": "/usr/local/python/current/bin/python3",
                         "type": "pythonEnvironment"
                     },


### PR DESCRIPTION
Python2 has reached EOL in Jan 2020. Removing its support. 
Also, helps resolve [CVE-2021-3572](https://github.com/advisories/GHSA-5xp3-jfq3-5q8x)