### PR TITLE
Javascript-node & universal: Update 'got' due to CVE-2022-33987

### DIFF
--- a/src/javascript-node/.devcontainer/library-scripts/add-patch.sh
+++ b/src/javascript-node/.devcontainer/library-scripts/add-patch.sh
@@ -6,6 +6,7 @@ IMAGE_VARIANT=$1
 # Upgrade 'decode-uri-component' due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-38900
 # Upgrade 'ansi-regex ' due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3807
 # Upgrade 'minimatch' due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3517
+# Upgrade 'got' due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-33987
 if [[ "${IMAGE_VARIANT}" =~ "14" ]] ; then
     cd /usr/local/lib/node_modules/npm
     npm update --save

--- a/src/universal/.devcontainer/local-features/setup-user/install.sh
+++ b/src/universal/.devcontainer/local-features/setup-user/install.sh
@@ -42,9 +42,11 @@ rm -rf /tmp/jsoup-jsoup-1.15.3
 # decode-uri-component: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-38900
 # ansi-regex: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3807
 # minimatch: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3517
+# got: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-33987
 NPM_PACKAGES_LIST="decode-uri-component
     ansi-regex
-    minimatch"
+    minimatch
+    got"
 
 cd /usr/local/share/nvm/versions/node/v14*/lib/node_modules/npm
 npm install ${NPM_PACKAGES_LIST}

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -186,6 +186,9 @@ check-version-ge "ansi-regex" "${ansiVersion}" "6.0.0"
 minimatchVersion=$(npm ls --depth 1 --json | jq -r '.dependencies.minimatch.version')
 check-version-ge "minimatch" "${minimatchVersion}" "3.0.5"
 
+gotVersion=$(npm ls --depth 1 --json | jq -r '.dependencies.got.version')
+check-version-ge "got" "${gotVersion}" "12.1.0"
+
 ls -la /home/codespace
 
 # Report result


### PR DESCRIPTION
More details - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-33987