### PR TITLE
Prep Release continued: Bump image versions

### DIFF
--- a/src/base-debian/manifest.json
+++ b/src/base-debian/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.203.1",
+	"version": "0.203.2",
 	"variants": [
 		"buster",
 		"bullseye"

--- a/src/base-debian/test-project/test.sh
+++ b/src/base-debian/test-project/test.sh
@@ -15,5 +15,9 @@ fi
 
 check "git version satisfies requirement" echo $git_version_satisfied | grep "true"
 
+cd /tmp && git clone https://github.com/devcontainers/feature-starter.git
+cd feature-starter
+check "perl" bash -c "git -c grep.patternType=perl grep -q 'a.+b'"
+
 # Report result
 reportResults

--- a/src/cpp/manifest.json
+++ b/src/cpp/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.206.1",
+	"version": "0.206.2",
 	"variants": [
 		"bullseye",
 		"buster",

--- a/src/go/manifest.json
+++ b/src/go/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.207.10",
+  "version": "0.207.11",
   "variants": [
     "1.19-bullseye",
     "1.19-buster",

--- a/src/java-8/manifest.json
+++ b/src/java-8/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "1.0.9",
+	"version": "1.0.10",
 	"variants": [
 		"bullseye",
 		"buster"

--- a/src/java/manifest.json
+++ b/src/java/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.205.15",
+	"version": "0.205.16",
 	"variants": [
 		"17-bullseye",
 		"17-buster",

--- a/src/jekyll/manifest.json
+++ b/src/jekyll/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.1.14",
+	"version": "0.1.15",
 	"variants": [
 		"2.7-bullseye",
 		"2.7-buster"

--- a/src/miniconda/manifest.json
+++ b/src/miniconda/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.202.12",
+	"version": "0.202.13",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/src/php/manifest.json
+++ b/src/php/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.203.14",
+	"version": "0.203.15",
 	"variants": [
 		"8.2-apache-bullseye",
 		"8.1-apache-bullseye",

--- a/src/python/manifest.json
+++ b/src/python/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.204.1",
+	"version": "0.204.2",
 	"variants": [
 		"3.11-bullseye",
 		"3.10-bullseye",

--- a/src/ruby/manifest.json
+++ b/src/ruby/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.203.13",
+	"version": "0.203.14",
 	"variants": [
 		"3.1-bullseye",
 		"3.0-bullseye",

--- a/src/rust/manifest.json
+++ b/src/rust/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.203.1",
+	"version": "0.203.2",
 	"variants": [
 		"buster",
 		"bullseye"


### PR DESCRIPTION
Includes https://github.com/devcontainers/features/pull/331 changes

> Git: Build from source with USE_LIBPCRE 