### PR TITLE
Universal: Update 'npm:minimist' due to CVE-2020-7598 & CVE-2021-44906

### DIFF
--- a/src/universal/.devcontainer/local-features/setup-user/install.sh
+++ b/src/universal/.devcontainer/local-features/setup-user/install.sh
@@ -59,7 +59,7 @@ cd /usr/local/share/nvm/versions/node/v14*/lib/node_modules/npm
 npm install ${NPM_PACKAGES_LIST}
 
 # Temporary due to minimist: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44906 & https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-7598
-cd /usr/local/share/nvm/versions/node/v14.21.2/lib/node_modules/npm/node_modules/tacks
+cd /usr/local/share/nvm/versions/node/v14*/lib/node_modules/npm/node_modules/tacks
 npm update mkdirp
 
 # Temporary: Due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-0536 & https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-0155

--- a/src/universal/.devcontainer/local-features/setup-user/install.sh
+++ b/src/universal/.devcontainer/local-features/setup-user/install.sh
@@ -58,6 +58,10 @@ NPM_PACKAGES_LIST="decode-uri-component
 cd /usr/local/share/nvm/versions/node/v14*/lib/node_modules/npm
 npm install ${NPM_PACKAGES_LIST}
 
+# Temporary due to minimist: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44906 & https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-7598
+cd /usr/local/share/nvm/versions/node/v14.21.2/lib/node_modules/npm/node_modules/tacks
+npm update mkdirp
+
 # Temporary: Due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-0536 & https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-0155
 rm -rf /usr/local/nvs/deps/node_modules/follow-redirects/*
 curl -sSL https://github.com/follow-redirects/follow-redirects/archive/refs/tags/v1.15.2.tar.gz | tar -xzC /tmp 2>&1

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -192,6 +192,11 @@ check-version-ge "minimatch" "${minimatchVersion}" "3.0.5"
 gotVersion=$(npm ls --depth 1 --json | jq -r '.dependencies.got.version')
 check-version-ge "got" "${gotVersion}" "12.1.0"
 
+cd /usr/local/share/nvm/versions/node/v14.21.2/lib/node_modules/npm/node_modules/tacks
+
+minimistVersion=$(npm ls --depth 1 --json | jq -r '.dependencies.mkdirp.dependencies.minimist.version')
+check-version-ge "minimist" "${minimistVersion}" "1.2.6"
+
 ls -la /home/codespace
 
 # Report result

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -196,7 +196,7 @@ check-version-ge "got" "${gotVersion}" "12.1.0"
 qsVersion=$(npm ls --depth 1 --json | jq -r '.dependencies.qs.version')
 check-version-ge "qs" "${qsVersion}" "6.10"
 
-cd /usr/local/share/nvm/versions/node/v14.21.2/lib/node_modules/npm/node_modules/tacks
+cd /usr/local/share/nvm/versions/node/v14*/lib/node_modules/npm/node_modules/tacks
 
 minimistVersion=$(npm ls --depth 1 --json | jq -r '.dependencies.mkdirp.dependencies.minimist.version')
 check-version-ge "minimist" "${minimistVersion}" "1.2.6"


### PR DESCRIPTION
More details - https://github.com/advisories/GHSA-vh95-rmgr-6w4m & https://github.com/advisories/GHSA-xvch-5gv4-984h