### PR TITLE
Universal: Patch for  'testng' plugin due to CVE-2022-4065

### DIFF
--- a/src/universal/.devcontainer/local-features/setup-user/install.sh
+++ b/src/universal/.devcontainer/local-features/setup-user/install.sh
@@ -38,6 +38,12 @@ curl -sSL https://github.com/jhy/jsoup/archive/refs/tags/jsoup-1.15.3.tar.gz | t
 jar cf ${GRADLE_PATH}/jsoup-1.15.3.jar /tmp/jsoup-jsoup-1.15.3
 rm -rf /tmp/jsoup-jsoup-1.15.3
 
+# Temporary: Due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-4065
+rm -f ${GRADLE_PATH}/testng-*
+curl -sSL https://github.com/cbeust/testng/archive/refs/tags/7.7.0.tar.gz | tar -xzC /tmp 2>&1
+jar cf ${GRADLE_PATH}/testng-7.7.0.jar /tmp/testng-7.7.0
+rm -rf /tmp/testng-7.7.0
+
 # Temporary: Due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-29425
 MAVEN_PATH=$(cd /usr/local/sdkman/candidates/maven/3*/lib/ && pwd)
 rm -f ${MAVEN_PATH}/commons-io-*

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -174,6 +174,7 @@ check "java-version-on-path-is-12.0.2" java --version | grep 12.0.2
 GRADLE_PATH=$(cd /usr/local/sdkman/candidates/gradle/7*/lib/plugins && pwd)
 check "aws-java-sdk-s3-plugin" bash -c "ls ${GRADLE_PATH} | grep aws-java-sdk-s3-1.12.363.jar"
 check "jsoup-plugin" bash -c "ls ${GRADLE_PATH} | grep jsoup-1.15.3.jar"
+check "testng-plugin" bash -c "ls ${GRADLE_PATH} | grep testng-7.7.0.jar"
 
 MAVEN_PATH=$(cd /usr/local/sdkman/candidates/maven/3*/lib/ && pwd)
 check "commons-io-lib" bash -c "ls ${MAVEN_PATH} | grep commons-io-2.11.jar"


### PR DESCRIPTION
More details - https://github.com/advisories/GHSA-rc2q-x9mf-w3vf