### PR TITLE
Typescript & Javascript node: Update qs due to CVE-2022-24999

### DIFF
--- a/src/javascript-node/.devcontainer/library-scripts/add-patch.sh
+++ b/src/javascript-node/.devcontainer/library-scripts/add-patch.sh
@@ -7,11 +7,13 @@ IMAGE_VARIANT=$1
 # Upgrade 'ansi-regex ' due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3807
 # Upgrade 'minimatch' due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3517
 # Upgrade 'got' due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-33987
+# Upgrade 'qs' due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24999
 if [[ "${IMAGE_VARIANT}" =~ "14" ]] ; then
     NPM_LIST="ansi-regex \
         decode-uri-component \
         got \
-        minimatch"
+        minimatch \
+        qs"
 
     cd /usr/local/lib/node_modules/npm
     npm install ${NPM_LIST} --save


### PR DESCRIPTION
Ref: https://github.com/advisories/GHSA-hrpp-h998-j3pp