### PR TITLE
Universal Javascript & Typescript node: Update 'ansi-regex' 

### DIFF
--- a/src/javascript-node/.devcontainer/library-scripts/add-patch.sh
+++ b/src/javascript-node/.devcontainer/library-scripts/add-patch.sh
@@ -18,4 +18,7 @@ if [[ "${IMAGE_VARIANT}" =~ "14" ]] ; then
 
     cd /usr/local/lib/node_modules/npm/node_modules/string-width
     npm install ansi-regex --save
+
+    cd /usr/local/lib/node_modules/npm/node_modules/yargs
+    npm install ansi-regex --save
 fi

--- a/src/universal/.devcontainer/local-features/setup-user/install.sh
+++ b/src/universal/.devcontainer/local-features/setup-user/install.sh
@@ -83,6 +83,9 @@ npm install marked@4.2.5
 cd /usr/local/share/nvm/versions/node/v14*/lib/node_modules/npm/node_modules/string-width
 npm install ansi-regex --save
 
+cd /usr/local/share/nvm/versions/node/v14*/lib/node_modules/npm/node_modules/yargs
+npm install ansi-regex --save
+
 # Temporary due to minimist: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44906 & https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-7598
 cd /usr/local/share/nvm/versions/node/v14*/lib/node_modules/npm/node_modules/tacks
 npm update mkdirp

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -221,6 +221,10 @@ cd /usr/local/share/nvm/versions/node/v14*/lib/node_modules/npm/node_modules/tac
 minimistVersion=$(npm ls --depth 1 --json | jq -r '.dependencies.mkdirp.dependencies.minimist.version')
 check-version-ge "minimist" "${minimistVersion}" "1.2.6"
 
+cd /usr/local/share/nvm/versions/node/v14*/lib/node_modules/npm/node_modules/yargs
+ansiVersion=$(npm ls --depth 1 --json | jq -r '.dependencies."ansi-regex".version')
+check-version-ge "ansi-regex-3" "${ansiVersion}" "6.0.1"
+
 ls -la /home/codespace
 
 # Report result


### PR DESCRIPTION
CVE-2021-3807 - https://github.com/advisories/GHSA-93q8-gq69-wqmw