### PR TITLE
Added codespaces jupyterlab extension to list of machine learning packages to install in universal image

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -11263,3 +11263,43 @@ THE SOFTWARE.
 
 
 ---------------------------------------------------------
+
+---------------------------------------------------------
+
+
+codespaces_jupyterlab
+https://github.com/github/codespaces-jupyterlab
+
+
+BSD 3-Clause License
+
+Copyright (c) 2022, GitHub
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+---------------------------------------------------------

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1216,6 +1216,15 @@
         },
         {
             "Component": {
+                "Type": "Pip",
+                "Pip": {
+                    "Name": "codespaces_jupyterlab",
+                    "Version": "0.2.1"
+                }
+            }
+        },
+        {
+            "Component": {
                 "Type": "RubyGems",
                 "RubyGems": {
                     "Name": "rake",

--- a/src/universal/.devcontainer/local-features/machine-learning-packages/install.sh
+++ b/src/universal/.devcontainer/local-features/machine-learning-packages/install.sh
@@ -47,6 +47,7 @@ if [[ "$(python --version)" != "" ]] && [[ "$(pip --version)" != "" ]]; then
     install_python_package "torch"
     install_python_package "requests"
     install_python_package "plotly"
+    install_python_package "codespaces_jupyterlab"
 else
     "(*) Error: Need to install python and pip."
 fi

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -45,6 +45,8 @@ check "matplotlib" python -c "import matplotlib; print(matplotlib.__version__)"
 check "seaborn" python -c "import seaborn; print(seaborn.__version__)"
 check "scikit-learn" python -c "import sklearn; print(sklearn.__version__)"
 check "torch" python -c "import torch; print(torch.__version__)"
+check "codespaces_jupyterlab" python -c "import codespaces_jupyterlab; print(codespaces_jupyterlab.__version__)"
+
 check "requests" python -c "import requests; print(requests.__version__)"
 check "jupyterlab-git" bash -c "python3 -m pip list | grep jupyterlab-git"
 


### PR DESCRIPTION
The purpose of this change is to add the [codespaces jupyterlab extension](https://github.com/github/codespaces-jupyterlab) package to the universal image. Since the image is enabled by default for codespaces, this package will already be preinstalled for codespaces users, and save time for users opening a codespace in a jupyterlab editor.