### PR TITLE
Update 'git' to '2.39.1' due to CVE-2022-41903 & CVE-2022-23521

### DIFF
--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -26,7 +26,6 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get install -y --no-install-recommends \
         bzip2 \
         ca-certificates \
-        git \
         libglib2.0-0 \
         libsm6 \
         libxcomposite1 \

--- a/src/anaconda/test-project/test-utils.sh
+++ b/src/anaconda/test-project/test-utils.sh
@@ -108,7 +108,6 @@ checkExtension() {
 checkCommon()
 {
     PACKAGE_LIST="apt-utils \
-        git \
         openssh-client \
         less \
         iproute2 \

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -17,8 +17,17 @@ check "pydocstyle" pydocstyle --version
 check "pycodestyle" pycodestyle --version
 check "nvm" bash -c ". /usr/local/share/nvm/nvm.sh && nvm --version"
 
+check "git" git --version
+check "git-location" sh -c "which git | grep /usr/local/bin/git"
+
 git_version=$(git --version)
-check-version-ge "git-requirement" "${git_version}" "git version 2.38.1"
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
+
+check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
+check "gitconfig-file-location" sh -c "ls /etc/gitconfig"
+check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcontainers'"
+
+check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
 joblib_version=$(python -c "import joblib; print(joblib.__version__)")
 check-version-ge "joblib-requirement" "${joblib_version}" "1.2.0"

--- a/src/base-alpine/.devcontainer/devcontainer.json
+++ b/src/base-alpine/.devcontainer/devcontainer.json
@@ -11,7 +11,8 @@
 			"userUid": "1000",
 			"userGid": "1000",
 			"upgradePackages": "true"
-		}
+		},
+		"./local-features/git": {}
 	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/src/base-alpine/.devcontainer/local-features/git/devcontainer-feature.json
+++ b/src/base-alpine/.devcontainer/local-features/git/devcontainer-feature.json
@@ -1,8 +1,4 @@
 {
 	"id": "git",
-	"name": "Git from source",
-	"install": {
-        "app": "",
-        "file": "install.sh"
-    }
+	"name": "Git from source"
 }

--- a/src/base-alpine/.devcontainer/local-features/git/devcontainer-feature.json
+++ b/src/base-alpine/.devcontainer/local-features/git/devcontainer-feature.json
@@ -1,0 +1,8 @@
+{
+	"id": "git",
+	"name": "Git from source",
+	"install": {
+        "app": "",
+        "file": "install.sh"
+    }
+}

--- a/src/base-alpine/.devcontainer/local-features/git/install.sh
+++ b/src/base-alpine/.devcontainer/local-features/git/install.sh
@@ -1,0 +1,42 @@
+#!/bin/ash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+set -e
+
+apk update
+apk add --no-cache \
+    --upgrade \
+    curl \
+    grep \
+    make \
+    zlib-dev \
+    --no-cache \
+    openssl-dev \
+    curl-dev \
+    expat-dev \
+    asciidoc \
+    xmlto \
+    perl-error \
+    perl-dev \
+    tcl \
+    tk \
+    gcc \
+    g++ \
+    python3-dev \
+    pcre2-dev
+
+GIT_VERSION_LIST="$(curl -sSL -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/git/git/tags" | grep -oP '"name":\s*"v\K[0-9]+\.[0-9]+\.[0-9]+"' | tr -d '"' | sort -rV )"
+GIT_VERSION="$(echo "${GIT_VERSION_LIST}" | head -n 1)"
+
+echo "Installing git v${GIT_VERSION}"
+curl -sL https://github.com/git/git/archive/v${GIT_VERSION}.tar.gz | tar -xzC /tmp 2>&1
+
+cd /tmp/git-${GIT_VERSION}
+
+make -s prefix=/usr/local sysconfdir=/etc all NO_REGEX=YesPlease NO_GETTEXT=YesPlease \
+    && make -s prefix=/usr/local sysconfdir=/etc NO_REGEX=YesPlease NO_GETTEXT=YesPlease install 2>&1
+
+rm -rf /tmp/git-${GIT_VERSION}

--- a/src/base-alpine/test-project/test-utils-alpine.sh
+++ b/src/base-alpine/test-project/test-utils-alpine.sh
@@ -27,6 +27,23 @@ check() {
     fi
 }
 
+check-version-ge() {
+    LABEL=$1
+    CURRENT_VERSION=$2
+    REQUIRED_VERSION=$3
+    shift
+    echo -e "\n🧪 Testing $LABEL: '$CURRENT_VERSION' is >= '$REQUIRED_VERSION'"
+    local GREATER_VERSION=$((echo ${CURRENT_VERSION}; echo ${REQUIRED_VERSION}) | sort -V | tail -1)
+    if [ "${CURRENT_VERSION}" == "${GREATER_VERSION}" ]; then
+        echo "✅  Passed!"
+        return 0
+    else
+        echoStderr "❌ $LABEL check failed."
+        FAILED+=("$LABEL")
+        return 1
+    fi
+}
+
 checkMultiple() {
     PASSED=0
     LABEL="$1"
@@ -90,8 +107,7 @@ checkExtension() {
 
 checkCommon()
 {
-    PACKAGE_LIST="git \
-        openssh-client \
+    PACKAGE_LIST="openssh-client \
         gnupg \
         procps \
         lsof \

--- a/src/base-alpine/test-project/test.sh
+++ b/src/base-alpine/test-project/test.sh
@@ -6,5 +6,17 @@ source test-utils-alpine.sh vscode
 # Run common tests
 checkCommon
 
+check "git" git --version
+check "git-location" sh -c "which git | grep /usr/local/bin/git"
+
+git_version=$(git --version)
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
+
+check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
+check "gitconfig-file-location" sh -c "ls /etc/gitconfig"
+check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcontainers'"
+
+check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
+
 # Report result
 reportResults

--- a/src/base-debian/test-project/test-utils.sh
+++ b/src/base-debian/test-project/test-utils.sh
@@ -22,6 +22,23 @@ check() {
     fi
 }
 
+check-version-ge() {
+    LABEL=$1
+    CURRENT_VERSION=$2
+    REQUIRED_VERSION=$3
+    shift
+    echo -e "\n🧪 Testing $LABEL: '$CURRENT_VERSION' is >= '$REQUIRED_VERSION'"
+    local GREATER_VERSION=$((echo ${CURRENT_VERSION}; echo ${REQUIRED_VERSION}) | sort -V | tail -1)
+    if [ "${CURRENT_VERSION}" == "${GREATER_VERSION}" ]; then
+        echo "✅  Passed!"
+        return 0
+    else
+        echoStderr "❌ $LABEL check failed."
+        FAILED+=("$LABEL")
+        return 1
+    fi
+}
+
 checkMultiple() {
     PASSED=0
     LABEL="$1"

--- a/src/base-debian/test-project/test.sh
+++ b/src/base-debian/test-project/test.sh
@@ -7,13 +7,16 @@ source test-utils.sh vscode
 checkCommon
 
 check "git" git --version
+check "git-location" sh -c "which git | grep /usr/local/bin/git"
 
-git_version_satisfied=false
-if (echo a version 2.38.1; git --version) | sort -Vk3 | tail -1 | grep -q git; then
-    git_version_satisfied=true
-fi
+git_version=$(git --version)
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
 
-check "git version satisfies requirement" echo $git_version_satisfied | grep "true"
+check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
+check "gitconfig-file-location" sh -c "ls /etc/gitconfig"
+check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcontainers'"
+
+check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
 cd /tmp && git clone https://github.com/devcontainers/feature-starter.git
 cd feature-starter

--- a/src/base-ubuntu/.devcontainer/devcontainer.json
+++ b/src/base-ubuntu/.devcontainer/devcontainer.json
@@ -10,6 +10,10 @@
             "userUid": "1000",
             "userGid": "1000",
             "upgradePackages": "true"
+        },
+        "ghcr.io/devcontainers/features/git:1": {
+            "version": "latest",
+            "ppa": "false"
         }
     },
     // Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/src/base-ubuntu/test-project/test-utils.sh
+++ b/src/base-ubuntu/test-project/test-utils.sh
@@ -27,6 +27,23 @@ check() {
     fi
 }
 
+check-version-ge() {
+    LABEL=$1
+    CURRENT_VERSION=$2
+    REQUIRED_VERSION=$3
+    shift
+    echo -e "\n🧪 Testing $LABEL: '$CURRENT_VERSION' is >= '$REQUIRED_VERSION'"
+    local GREATER_VERSION=$((echo ${CURRENT_VERSION}; echo ${REQUIRED_VERSION}) | sort -V | tail -1)
+    if [ "${CURRENT_VERSION}" == "${GREATER_VERSION}" ]; then
+        echo "✅  Passed!"
+        return 0
+    else
+        echoStderr "❌ $LABEL check failed."
+        FAILED+=("$LABEL")
+        return 1
+    fi
+}
+
 checkMultiple() {
     PASSED=0
     LABEL="$1"

--- a/src/base-ubuntu/test-project/test.sh
+++ b/src/base-ubuntu/test-project/test.sh
@@ -9,5 +9,17 @@ checkCommon
 check "Oh My Zsh! theme" test -e $HOME/.oh-my-zsh/custom/themes/devcontainers.zsh-theme
 check "zsh theme symlink" test -e $HOME/.oh-my-zsh/custom/themes/codespaces.zsh-theme
 
+check "git" git --version
+check "git-location" sh -c "which git | grep /usr/local/bin/git"
+
+git_version=$(git --version)
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
+
+check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
+check "gitconfig-file-location" sh -c "ls /etc/gitconfig"
+check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcontainers'"
+
+check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
+
 # Report result
 reportResults

--- a/src/cpp/.devcontainer/base-scripts/install-vcpkg.sh
+++ b/src/cpp/.devcontainer/base-scripts/install-vcpkg.sh
@@ -51,7 +51,7 @@ check_packages() {
 export DEBIAN_FRONTEND=noninteractive
 
 # Install additional packages needed by vcpkg: https://github.com/microsoft/vcpkg/blob/master/README.md#installing-linux-developer-tools
-check_packages build-essential tar curl zip unzip pkg-config bash-completion ninja-build git
+check_packages build-essential tar curl zip unzip pkg-config bash-completion ninja-build
 
 # Setup group and add user
 umask 0002

--- a/src/cpp/.devcontainer/devcontainer.json
+++ b/src/cpp/.devcontainer/devcontainer.json
@@ -3,6 +3,14 @@
 		"dockerfile": "./Dockerfile",
 		"context": "."
 	},
+
+	"features": {
+		"ghcr.io/devcontainers/features/git:1": {
+            "version": "latest",
+            "ppa": "false"
+        }
+    },
+
 	"capAdd": ["SYS_PTRACE"],
 	"securityOpt": ["seccomp=unconfined"],
 	// Configure tool-specific properties.

--- a/src/cpp/test-project/test-utils.sh
+++ b/src/cpp/test-project/test-utils.sh
@@ -27,6 +27,23 @@ check() {
     fi
 }
 
+check-version-ge() {
+    LABEL=$1
+    CURRENT_VERSION=$2
+    REQUIRED_VERSION=$3
+    shift
+    echo -e "\n🧪 Testing $LABEL: '$CURRENT_VERSION' is >= '$REQUIRED_VERSION'"
+    local GREATER_VERSION=$((echo ${CURRENT_VERSION}; echo ${REQUIRED_VERSION}) | sort -V | tail -1)
+    if [ "${CURRENT_VERSION}" == "${GREATER_VERSION}" ]; then
+        echo "✅  Passed!"
+        return 0
+    else
+        echoStderr "❌ $LABEL check failed."
+        FAILED+=("$LABEL")
+        return 1
+    fi
+}
+
 checkMultiple() {
     PASSED=0
     LABEL="$1"

--- a/src/cpp/test-project/test.sh
+++ b/src/cpp/test-project/test.sh
@@ -27,13 +27,16 @@ cd ..
 rm -rf build
 
 check "git" git --version
+check "git-location" sh -c "which git | grep /usr/local/bin/git"
 
-git_version_satisfied=false
-if (echo a version 2.38.1; git --version) | sort -Vk3 | tail -1 | grep -q git; then
-    git_version_satisfied=true
-fi
+git_version=$(git --version)
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
 
-check "git version satisfies requirement" echo $git_version_satisfied | grep "true"
+check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
+check "gitconfig-file-location" sh -c "ls /etc/gitconfig"
+check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcontainers'"
+
+check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
 ## Report result
 reportResults

--- a/src/dotnet/test-project/test-utils.sh
+++ b/src/dotnet/test-project/test-utils.sh
@@ -27,6 +27,23 @@ check() {
     fi
 }
 
+check-version-ge() {
+    LABEL=$1
+    CURRENT_VERSION=$2
+    REQUIRED_VERSION=$3
+    shift
+    echo -e "\n🧪 Testing $LABEL: '$CURRENT_VERSION' is >= '$REQUIRED_VERSION'"
+    local GREATER_VERSION=$((echo ${CURRENT_VERSION}; echo ${REQUIRED_VERSION}) | sort -V | tail -1)
+    if [ "${CURRENT_VERSION}" == "${GREATER_VERSION}" ]; then
+        echo "✅  Passed!"
+        return 0
+    else
+        echoStderr "❌ $LABEL check failed."
+        FAILED+=("$LABEL")
+        return 1
+    fi
+}
+
 checkMultiple() {
     PASSED=0
     LABEL="$1"

--- a/src/dotnet/test-project/test.sh
+++ b/src/dotnet/test-project/test.sh
@@ -14,17 +14,18 @@ sudo rm -rf obj bin
 check "nvm" bash -c ". /usr/local/share/nvm/nvm.sh && nvm install 10"
 check "nvm-node" bash -c ". /usr/local/share/nvm/nvm.sh && node --version"
 check "yarn" bash -c ". /usr/local/share/nvm/nvm.sh && yarn --version"
+
 check "git" git --version
+check "git-location" sh -c "which git | grep /usr/local/bin/git"
 
-check "Oh My Zsh! theme" test -e $HOME/.oh-my-zsh/custom/themes/devcontainers.zsh-theme
-check "zsh theme symlink" test -e $HOME/.oh-my-zsh/custom/themes/codespaces.zsh-theme
+git_version=$(git --version)
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
 
-git_version_satisfied=false
-if (echo a version 2.38.1; git --version) | sort -Vk3 | tail -1 | grep -q git; then
-    git_version_satisfied=true
-fi
+check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
+check "gitconfig-file-location" sh -c "ls /etc/gitconfig"
+check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcontainers'"
 
-check "git version satisfies requirement" echo $git_version_satisfied | grep "true"
+check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
 # Report result
 reportResults

--- a/src/go/test-project/test-utils.sh
+++ b/src/go/test-project/test-utils.sh
@@ -27,6 +27,23 @@ check() {
     fi
 }
 
+check-version-ge() {
+    LABEL=$1
+    CURRENT_VERSION=$2
+    REQUIRED_VERSION=$3
+    shift
+    echo -e "\n🧪 Testing $LABEL: '$CURRENT_VERSION' is >= '$REQUIRED_VERSION'"
+    local GREATER_VERSION=$((echo ${CURRENT_VERSION}; echo ${REQUIRED_VERSION}) | sort -V | tail -1)
+    if [ "${CURRENT_VERSION}" == "${GREATER_VERSION}" ]; then
+        echo "✅  Passed!"
+        return 0
+    else
+        echoStderr "❌ $LABEL check failed."
+        FAILED+=("$LABEL")
+        return 1
+    fi
+}
+
 checkMultiple() {
     PASSED=0
     LABEL="$1"

--- a/src/go/test-project/test.sh
+++ b/src/go/test-project/test.sh
@@ -11,14 +11,18 @@ check "go" go version
 check "nvm" bash -c ". /usr/local/share/nvm/nvm.sh && nvm install 10"
 check "nvm-node" bash -c ". /usr/local/share/nvm/nvm.sh && node --version"
 check "yarn" bash -c ". /usr/local/share/nvm/nvm.sh && yarn --version"
+
 check "git" git --version
+check "git-location" sh -c "which git | grep /usr/local/bin/git"
 
-git_version_satisfied=false
-if (echo a version 2.38.1; git --version) | sort -Vk3 | tail -1 | grep -q git; then
-    git_version_satisfied=true
-fi
+git_version=$(git --version)
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
 
-check "git version satisfies requirement" echo $git_version_satisfied | grep "true"
+check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
+check "gitconfig-file-location" sh -c "ls /etc/gitconfig"
+check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcontainers'"
+
+check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
 check "Oh My Zsh! theme" test -e $HOME/.oh-my-zsh/custom/themes/devcontainers.zsh-theme
 check "zsh theme symlink" test -e $HOME/.oh-my-zsh/custom/themes/codespaces.zsh-theme

--- a/src/java-8/test-project/test-utils.sh
+++ b/src/java-8/test-project/test-utils.sh
@@ -27,6 +27,23 @@ check() {
     fi
 }
 
+check-version-ge() {
+    LABEL=$1
+    CURRENT_VERSION=$2
+    REQUIRED_VERSION=$3
+    shift
+    echo -e "\n🧪 Testing $LABEL: '$CURRENT_VERSION' is >= '$REQUIRED_VERSION'"
+    local GREATER_VERSION=$((echo ${CURRENT_VERSION}; echo ${REQUIRED_VERSION}) | sort -V | tail -1)
+    if [ "${CURRENT_VERSION}" == "${GREATER_VERSION}" ]; then
+        echo "✅  Passed!"
+        return 0
+    else
+        echoStderr "❌ $LABEL check failed."
+        FAILED+=("$LABEL")
+        return 1
+    fi
+}
+
 checkMultiple() {
     PASSED=0
     LABEL="$1"

--- a/src/java-8/test-project/test.sh
+++ b/src/java-8/test-project/test.sh
@@ -20,13 +20,16 @@ check "build-and-test-jar" ./mvnw -q package
 check "test-project" java -jar target/my-app-1.0-SNAPSHOT.jar
 
 check "git" git --version
+check "git-location" sh -c "which git | grep /usr/local/bin/git"
 
-git_version_satisfied=false
-if (echo a version 2.38.1; git --version) | sort -Vk3 | tail -1 | grep -q git; then
-    git_version_satisfied=true
-fi
+git_version=$(git --version)
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
 
-check "git version satisfies requirement" echo $git_version_satisfied | grep "true"
+check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
+check "gitconfig-file-location" sh -c "ls /etc/gitconfig"
+check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcontainers'"
+
+check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
 # Clean up
 rm -f mvnw

--- a/src/java/test-project/test-utils.sh
+++ b/src/java/test-project/test-utils.sh
@@ -27,6 +27,23 @@ check() {
     fi
 }
 
+check-version-ge() {
+    LABEL=$1
+    CURRENT_VERSION=$2
+    REQUIRED_VERSION=$3
+    shift
+    echo -e "\n🧪 Testing $LABEL: '$CURRENT_VERSION' is >= '$REQUIRED_VERSION'"
+    local GREATER_VERSION=$((echo ${CURRENT_VERSION}; echo ${REQUIRED_VERSION}) | sort -V | tail -1)
+    if [ "${CURRENT_VERSION}" == "${GREATER_VERSION}" ]; then
+        echo "✅  Passed!"
+        return 0
+    else
+        echoStderr "❌ $LABEL check failed."
+        FAILED+=("$LABEL")
+        return 1
+    fi
+}
+
 checkMultiple() {
     PASSED=0
     LABEL="$1"

--- a/src/java/test-project/test.sh
+++ b/src/java/test-project/test.sh
@@ -22,13 +22,16 @@ check "nvm-node" bash -c ". /usr/local/share/nvm/nvm.sh && node --version"
 check "yarn" bash -c ". /usr/local/share/nvm/nvm.sh && yarn --version"
 
 check "git" git --version
+check "git-location" sh -c "which git | grep /usr/local/bin/git"
 
-git_version_satisfied=false
-if (echo a version 2.38.1; git --version) | sort -Vk3 | tail -1 | grep -q git; then
-    git_version_satisfied=true
-fi
+git_version=$(git --version)
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
 
-check "git version satisfies requirement" echo $git_version_satisfied | grep "true"
+check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
+check "gitconfig-file-location" sh -c "ls /etc/gitconfig"
+check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcontainers'"
+
+check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
 # Clean up
 rm -f mvnw

--- a/src/javascript-node/test-project/test.sh
+++ b/src/javascript-node/test-project/test.sh
@@ -19,8 +19,17 @@ check "nvm" bash -c ". /usr/local/share/nvm/nvm.sh && nvm install 8"
 check "nvm-node" bash -c ". /usr/local/share/nvm/nvm.sh && node --version"
 sudo rm -rf node_modules
 
+check "git" git --version
+check "git-location" sh -c "which git | grep /usr/local/bin/git"
+
 git_version=$(git --version)
-check-version-ge "git-requirement" "${git_version}" "git version 2.38.1"
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
+
+check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
+check "gitconfig-file-location" sh -c "ls /etc/gitconfig"
+check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcontainers'"
+
+check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
 check "Oh My Zsh! theme" test -e $HOME/.oh-my-zsh/custom/themes/devcontainers.zsh-theme
 check "zsh theme symlink" test -e $HOME/.oh-my-zsh/custom/themes/codespaces.zsh-theme

--- a/src/jekyll/test-project/test-utils.sh
+++ b/src/jekyll/test-project/test-utils.sh
@@ -27,6 +27,23 @@ check() {
     fi
 }
 
+check-version-ge() {
+    LABEL=$1
+    CURRENT_VERSION=$2
+    REQUIRED_VERSION=$3
+    shift
+    echo -e "\n🧪 Testing $LABEL: '$CURRENT_VERSION' is >= '$REQUIRED_VERSION'"
+    local GREATER_VERSION=$((echo ${CURRENT_VERSION}; echo ${REQUIRED_VERSION}) | sort -V | tail -1)
+    if [ "${CURRENT_VERSION}" == "${GREATER_VERSION}" ]; then
+        echo "✅  Passed!"
+        return 0
+    else
+        echoStderr "❌ $LABEL check failed."
+        FAILED+=("$LABEL")
+        return 1
+    fi
+}
+
 checkMultiple() {
     PASSED=0
     LABEL="$1"

--- a/src/jekyll/test-project/test.sh
+++ b/src/jekyll/test-project/test.sh
@@ -16,13 +16,16 @@ check "nvm" bash -c ". /usr/local/share/nvm/nvm.sh && nvm install 10"
 check "nvm-node" bash -c ". /usr/local/share/nvm/nvm.sh && node --version"
 
 check "git" git --version
+check "git-location" sh -c "which git | grep /usr/local/bin/git"
 
-git_version_satisfied=false
-if (echo a version 2.38.1; git --version) | sort -Vk3 | tail -1 | grep -q git; then
-    git_version_satisfied=true
-fi
+git_version=$(git --version)
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
 
-check "git version satisfies requirement" echo $git_version_satisfied | grep "true"
+check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
+check "gitconfig-file-location" sh -c "ls /etc/gitconfig"
+check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcontainers'"
+
+check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
 # Report result
 reportResults

--- a/src/miniconda/.devcontainer/Dockerfile
+++ b/src/miniconda/.devcontainer/Dockerfile
@@ -22,7 +22,6 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get install -y --no-install-recommends \
         bzip2 \
         ca-certificates \
-        git \
         libglib2.0-0 \
         libsm6 \
         libxext6 \

--- a/src/miniconda/test-project/test.sh
+++ b/src/miniconda/test-project/test.sh
@@ -7,9 +7,16 @@ source test-utils.sh vscode
 checkCommon
 
 check "git" git --version
+check "git-location" sh -c "which git | grep /usr/local/bin/git"
 
 git_version=$(git --version)
-check-version-ge "git-requirement" "${git_version}" "git version 2.38.1"
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
+
+check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
+check "gitconfig-file-location" sh -c "ls /etc/gitconfig"
+check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcontainers'"
+
+check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
 cryptography_version=$(python -c "import cryptography; print(cryptography.__version__)")
 check-version-ge "cryptography-requirement" "${cryptography_version}" "38.0.3"

--- a/src/php/test-project/test-utils.sh
+++ b/src/php/test-project/test-utils.sh
@@ -22,6 +22,23 @@ check() {
     fi
 }
 
+check-version-ge() {
+    LABEL=$1
+    CURRENT_VERSION=$2
+    REQUIRED_VERSION=$3
+    shift
+    echo -e "\n🧪 Testing $LABEL: '$CURRENT_VERSION' is >= '$REQUIRED_VERSION'"
+    local GREATER_VERSION=$((echo ${CURRENT_VERSION}; echo ${REQUIRED_VERSION}) | sort -V | tail -1)
+    if [ "${CURRENT_VERSION}" == "${GREATER_VERSION}" ]; then
+        echo "✅  Passed!"
+        return 0
+    else
+        echoStderr "❌ $LABEL check failed."
+        FAILED+=("$LABEL")
+        return 1
+    fi
+}
+
 checkMultiple() {
     PASSED=0
     LABEL="$1"

--- a/src/php/test-project/test.sh
+++ b/src/php/test-project/test.sh
@@ -18,13 +18,16 @@ check "Oh My Zsh! theme" test -e $HOME/.oh-my-zsh/custom/themes/devcontainers.zs
 check "zsh theme symlink" test -e $HOME/.oh-my-zsh/custom/themes/codespaces.zsh-theme
 
 check "git" git --version
+check "git-location" sh -c "which git | grep /usr/local/bin/git"
 
-git_version_satisfied=false
-if (echo a version 2.38.1; git --version) | sort -Vk3 | tail -1 | grep -q git; then
-    git_version_satisfied=true
-fi
+git_version=$(git --version)
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
 
-check "git version satisfies requirement" echo $git_version_satisfied | grep "true"
+check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
+check "gitconfig-file-location" sh -c "ls /etc/gitconfig"
+check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcontainers'"
+
+check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
 # Report result
 reportResults

--- a/src/python/test-project/test-utils.sh
+++ b/src/python/test-project/test-utils.sh
@@ -27,6 +27,23 @@ check() {
     fi
 }
 
+check-version-ge() {
+    LABEL=$1
+    CURRENT_VERSION=$2
+    REQUIRED_VERSION=$3
+    shift
+    echo -e "\n🧪 Testing $LABEL: '$CURRENT_VERSION' is >= '$REQUIRED_VERSION'"
+    local GREATER_VERSION=$((echo ${CURRENT_VERSION}; echo ${REQUIRED_VERSION}) | sort -V | tail -1)
+    if [ "${CURRENT_VERSION}" == "${GREATER_VERSION}" ]; then
+        echo "✅  Passed!"
+        return 0
+    else
+        echoStderr "❌ $LABEL check failed."
+        FAILED+=("$LABEL")
+        return 1
+    fi
+}
+
 checkMultiple() {
     PASSED=0
     LABEL="$1"

--- a/src/python/test-project/test.sh
+++ b/src/python/test-project/test.sh
@@ -28,13 +28,16 @@ check "Oh My Zsh! theme" test -e $HOME/.oh-my-zsh/custom/themes/devcontainers.zs
 check "zsh theme symlink" test -e $HOME/.oh-my-zsh/custom/themes/codespaces.zsh-theme
 
 check "git" git --version
+check "git-location" sh -c "which git | grep /usr/local/bin/git"
 
-git_version_satisfied=false
-if (echo a version 2.38.1; git --version) | sort -Vk3 | tail -1 | grep -q git; then
-    git_version_satisfied=true
-fi
+git_version=$(git --version)
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
 
-check "git version satisfies requirement" echo $git_version_satisfied | grep "true"
+check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
+check "gitconfig-file-location" sh -c "ls /etc/gitconfig"
+check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcontainers'"
+
+check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
 # Report result
 reportResults

--- a/src/ruby/test-project/test-utils.sh
+++ b/src/ruby/test-project/test-utils.sh
@@ -27,6 +27,23 @@ check() {
     fi
 }
 
+check-version-ge() {
+    LABEL=$1
+    CURRENT_VERSION=$2
+    REQUIRED_VERSION=$3
+    shift
+    echo -e "\n🧪 Testing $LABEL: '$CURRENT_VERSION' is >= '$REQUIRED_VERSION'"
+    local GREATER_VERSION=$((echo ${CURRENT_VERSION}; echo ${REQUIRED_VERSION}) | sort -V | tail -1)
+    if [ "${CURRENT_VERSION}" == "${GREATER_VERSION}" ]; then
+        echo "✅  Passed!"
+        return 0
+    else
+        echoStderr "❌ $LABEL check failed."
+        FAILED+=("$LABEL")
+        return 1
+    fi
+}
+
 checkMultiple() {
     PASSED=0
     LABEL="$1"

--- a/src/ruby/test-project/test.sh
+++ b/src/ruby/test-project/test.sh
@@ -19,13 +19,16 @@ check "Oh My Zsh! theme" test -e $HOME/.oh-my-zsh/custom/themes/devcontainers.zs
 check "zsh theme symlink" test -e $HOME/.oh-my-zsh/custom/themes/codespaces.zsh-theme
 
 check "git" git --version
+check "git-location" sh -c "which git | grep /usr/local/bin/git"
 
-git_version_satisfied=false
-if (echo a version 2.38.1; git --version) | sort -Vk3 | tail -1 | grep -q git; then
-    git_version_satisfied=true
-fi
+git_version=$(git --version)
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
 
-check "git version satisfies requirement" echo $git_version_satisfied | grep "true"
+check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
+check "gitconfig-file-location" sh -c "ls /etc/gitconfig"
+check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcontainers'"
+
+check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
 # Report result
 reportResults

--- a/src/rust/test-project/test-utils.sh
+++ b/src/rust/test-project/test-utils.sh
@@ -27,6 +27,23 @@ check() {
     fi
 }
 
+check-version-ge() {
+    LABEL=$1
+    CURRENT_VERSION=$2
+    REQUIRED_VERSION=$3
+    shift
+    echo -e "\n🧪 Testing $LABEL: '$CURRENT_VERSION' is >= '$REQUIRED_VERSION'"
+    local GREATER_VERSION=$((echo ${CURRENT_VERSION}; echo ${REQUIRED_VERSION}) | sort -V | tail -1)
+    if [ "${CURRENT_VERSION}" == "${GREATER_VERSION}" ]; then
+        echo "✅  Passed!"
+        return 0
+    else
+        echoStderr "❌ $LABEL check failed."
+        FAILED+=("$LABEL")
+        return 1
+    fi
+}
+
 checkMultiple() {
     PASSED=0
     LABEL="$1"

--- a/src/rust/test-project/test.sh
+++ b/src/rust/test-project/test.sh
@@ -14,13 +14,16 @@ check "Oh My Zsh! theme" test -e $HOME/.oh-my-zsh/custom/themes/devcontainers.zs
 check "zsh theme symlink" test -e $HOME/.oh-my-zsh/custom/themes/codespaces.zsh-theme
 
 check "git" git --version
+check "git-location" sh -c "which git | grep /usr/local/bin/git"
 
-git_version_satisfied=false
-if (echo a version 2.38.1; git --version) | sort -Vk3 | tail -1 | grep -q git; then
-    git_version_satisfied=true
-fi
+git_version=$(git --version)
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
 
-check "git version satisfies requirement" echo $git_version_satisfied | grep "true"
+check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
+check "gitconfig-file-location" sh -c "ls /etc/gitconfig"
+check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcontainers'"
+
+check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
 # Report result
 reportResults

--- a/src/typescript-node/test-project/test-utils.sh
+++ b/src/typescript-node/test-project/test-utils.sh
@@ -27,6 +27,23 @@ check() {
     fi
 }
 
+check-version-ge() {
+    LABEL=$1
+    CURRENT_VERSION=$2
+    REQUIRED_VERSION=$3
+    shift
+    echo -e "\n🧪 Testing $LABEL: '$CURRENT_VERSION' is >= '$REQUIRED_VERSION'"
+    local GREATER_VERSION=$((echo ${CURRENT_VERSION}; echo ${REQUIRED_VERSION}) | sort -V | tail -1)
+    if [ "${CURRENT_VERSION}" == "${GREATER_VERSION}" ]; then
+        echo "✅  Passed!"
+        return 0
+    else
+        echoStderr "❌ $LABEL check failed."
+        FAILED+=("$LABEL")
+        return 1
+    fi
+}
+
 checkMultiple() {
     PASSED=0
     LABEL="$1"

--- a/src/typescript-node/test-project/test.sh
+++ b/src/typescript-node/test-project/test.sh
@@ -20,13 +20,16 @@ check "nvm-node" bash -c ". /usr/local/share/nvm/nvm.sh && node --version"
 sudo rm -rf node_modules out
 
 check "git" git --version
+check "git-location" sh -c "which git | grep /usr/local/bin/git"
 
-git_version_satisfied=false
-if (echo a version 2.38.1; git --version) | sort -Vk3 | tail -1 | grep -q git; then
-    git_version_satisfied=true
-fi
+git_version=$(git --version)
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
 
-check "git version satisfies requirement" echo $git_version_satisfied | grep "true"
+check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
+check "gitconfig-file-location" sh -c "ls /etc/gitconfig"
+check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcontainers'"
+
+check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
 # Report result
 reportResults

--- a/src/universal/.devcontainer/Dockerfile
+++ b/src/universal/.devcontainer/Dockerfile
@@ -16,7 +16,6 @@ RUN LANG="C.UTF-8" \
     && apt-get update \
     && apt-get upgrade -y \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        git \
         make \
         unzip \
         # The tools in this package are used when installing packages for Python

--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -62,6 +62,10 @@
         "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
             "version": "latest"
         },
+        "ghcr.io/devcontainers/features/git:1": {
+            "version": "latest",
+            "ppa": "false"
+        },
         "ghcr.io/devcontainers/features/go:1": {
             "version": "latest"
         },
@@ -86,6 +90,7 @@
         "ghcr.io/devcontainers/features/github-cli",
         "ghcr.io/devcontainers/features/docker-in-docker",
         "ghcr.io/devcontainers/features/kubectl-helm-minikube",
+        "ghcr.io/devcontainers/features/git",
         "ghcr.io/devcontainers/features/go",
         "./local-features/jekyll",
         "ghcr.io/devcontainers/features/oryx",

--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -75,6 +75,7 @@
     },
     "overrideFeatureInstallOrder": [
         "ghcr.io/devcontainers/features/common-utils",
+        "ghcr.io/devcontainers/features/git",
         "ghcr.io/devcontainers/features/dotnet",
         "ghcr.io/devcontainers/features/hugo",
         "ghcr.io/devcontainers/features/node",
@@ -90,7 +91,6 @@
         "ghcr.io/devcontainers/features/github-cli",
         "ghcr.io/devcontainers/features/docker-in-docker",
         "ghcr.io/devcontainers/features/kubectl-helm-minikube",
-        "ghcr.io/devcontainers/features/git",
         "ghcr.io/devcontainers/features/go",
         "./local-features/jekyll",
         "ghcr.io/devcontainers/features/oryx",

--- a/src/universal/.devcontainer/local-features/nvs/install.sh
+++ b/src/universal/.devcontainer/local-features/nvs/install.sh
@@ -50,9 +50,6 @@ updaterc() {
 
 export DEBIAN_FRONTEND=noninteractive
 
-# Install dependencies
-check_packages git
-
 if ! cat /etc/group | grep -e "^nvs:" > /dev/null 2>&1; then
     groupadd -r nvs
 fi

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -7,8 +7,16 @@ source test-utils.sh codespace
 checkCommon
 
 check "git" git --version
-check "gitconfig" bash -c "sudo git config --system user.name devcontainer"
-check "gitconfig-location" bash -c "sudo ls /etc | grep gitconfig"
+check "git-location" sh -c "which git | grep /usr/local/bin/git"
+
+git_version=$(git --version)
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
+
+check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
+check "gitconfig-file-location" sh -c "ls /etc/gitconfig"
+check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcontainers'"
+
+check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
 # Check .NET
 check "dotnet" dotnet --list-sdks


### PR DESCRIPTION
Ref: https://github.blog/2023-01-17-git-security-vulnerabilities-announced-2/