### PR TITLE
Retry az login to fix dev release failures

### DIFF
--- a/build/src/push.js
+++ b/build/src/push.js
@@ -57,6 +57,15 @@ async function push(repo, release, updateLatest, registry, registryPath, stubReg
             stagingFolder = await configUtils.getStagingFolder(release);
             await configUtils.loadConfig(stagingFolder);
 
+            const registryName = registry.replace(/\.azurecr\.io.*/, '');
+            const spawnOpts = { stdio: 'inherit', shell: true };
+            await asyncUtils.spawn('az', [
+                'acr',
+                'login',
+                '--name',
+                registryName
+            ], spawnOpts);
+
             console.log(`**** Pushing ${currentJob['id']}: ${currentJob['variant']} ${release} ****`);
             await pushImage(
                 currentJob['id'], currentJob['variant'] || null, repo, release, updateLatest, registry, registryPath, stubRegistry, stubRegistryPath, prepOnly, pushImages, replaceImages, secondaryRegistryPath);


### PR DESCRIPTION
Az login has a expiry of 3 hours, on of the job for dev release is taking longer than that. Hence, it fails to push the image.
This attempts to fix it! 

https://github.com/devcontainers/images/actions/runs/4044601960