### PR TITLE
Universal: Set moby:false as it is no longer supported for unbuntu:focal

### DIFF
--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -57,7 +57,8 @@
             "version": "latest"
         },
         "ghcr.io/devcontainers/features/docker-in-docker:2": {
-            "version": "latest"
+            "version": "latest",
+            "moby": false
         },
         "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
             "version": "latest"


### PR DESCRIPTION
Fixes build failure - https://github.com/devcontainers/images/actions/runs/4164214688/jobs/7211607878#step:5:36028