### PR TITLE
Git update due to CVE-2023-22490 and CVE-2023-23946

### DIFF
--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -21,7 +21,7 @@ check "git" git --version
 check "git-location" sh -c "which git | grep /usr/local/bin/git"
 
 git_version=$(git --version)
-check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.2"
 
 check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
 check "gitconfig-file-location" sh -c "ls /etc/gitconfig"

--- a/src/base-alpine/test-project/test.sh
+++ b/src/base-alpine/test-project/test.sh
@@ -10,7 +10,7 @@ check "git" git --version
 check "git-location" sh -c "which git | grep /usr/local/bin/git"
 
 git_version=$(git --version)
-check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.2"
 
 check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
 check "gitconfig-file-location" sh -c "ls /etc/gitconfig"

--- a/src/base-debian/test-project/test.sh
+++ b/src/base-debian/test-project/test.sh
@@ -10,7 +10,7 @@ check "git" git --version
 check "git-location" sh -c "which git | grep /usr/local/bin/git"
 
 git_version=$(git --version)
-check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.2"
 
 check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
 check "gitconfig-file-location" sh -c "ls /etc/gitconfig"

--- a/src/base-ubuntu/.devcontainer/devcontainer.json
+++ b/src/base-ubuntu/.devcontainer/devcontainer.json
@@ -10,6 +10,10 @@
             "userUid": "1000",
             "userGid": "1000",
             "upgradePackages": "true"
+        },
+        "ghcr.io/devcontainers/features/git:1": {
+            "version": "latest",
+            "ppa": "false"
         }
     },
     // Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/src/base-ubuntu/test-project/test-utils.sh
+++ b/src/base-ubuntu/test-project/test-utils.sh
@@ -108,7 +108,6 @@ checkExtension() {
 checkCommon()
 {
     PACKAGE_LIST="apt-utils \
-        git \
         openssh-client \
         less \
         iproute2 \

--- a/src/base-ubuntu/test-project/test.sh
+++ b/src/base-ubuntu/test-project/test.sh
@@ -12,7 +12,7 @@ check "zsh theme symlink" test -e $HOME/.oh-my-zsh/custom/themes/codespaces.zsh-
 check "git" git --version
 
 git_version=$(git --version)
-check-version-ge "git-requirement" "${git_version}" "git version 2.34.1"
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.2"
 
 check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
 check "gitconfig-file-location" sh -c "ls /etc/gitconfig"

--- a/src/cpp/test-project/test.sh
+++ b/src/cpp/test-project/test.sh
@@ -30,7 +30,7 @@ check "git" git --version
 check "git-location" sh -c "which git | grep /usr/local/bin/git"
 
 git_version=$(git --version)
-check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.2"
 
 check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
 check "gitconfig-file-location" sh -c "ls /etc/gitconfig"

--- a/src/dotnet/test-project/test.sh
+++ b/src/dotnet/test-project/test.sh
@@ -19,7 +19,7 @@ check "git" git --version
 check "git-location" sh -c "which git | grep /usr/local/bin/git"
 
 git_version=$(git --version)
-check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.2"
 
 check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
 check "gitconfig-file-location" sh -c "ls /etc/gitconfig"

--- a/src/go/test-project/test.sh
+++ b/src/go/test-project/test.sh
@@ -16,7 +16,7 @@ check "git" git --version
 check "git-location" sh -c "which git | grep /usr/local/bin/git"
 
 git_version=$(git --version)
-check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.2"
 
 check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
 check "gitconfig-file-location" sh -c "ls /etc/gitconfig"

--- a/src/java-8/test-project/test.sh
+++ b/src/java-8/test-project/test.sh
@@ -23,7 +23,7 @@ check "git" git --version
 check "git-location" sh -c "which git | grep /usr/local/bin/git"
 
 git_version=$(git --version)
-check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.2"
 
 check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
 check "gitconfig-file-location" sh -c "ls /etc/gitconfig"

--- a/src/java/test-project/test.sh
+++ b/src/java/test-project/test.sh
@@ -25,7 +25,7 @@ check "git" git --version
 check "git-location" sh -c "which git | grep /usr/local/bin/git"
 
 git_version=$(git --version)
-check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.2"
 
 check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
 check "gitconfig-file-location" sh -c "ls /etc/gitconfig"

--- a/src/javascript-node/test-project/test.sh
+++ b/src/javascript-node/test-project/test.sh
@@ -23,7 +23,7 @@ check "git" git --version
 check "git-location" sh -c "which git | grep /usr/local/bin/git"
 
 git_version=$(git --version)
-check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.2"
 
 check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
 check "gitconfig-file-location" sh -c "ls /etc/gitconfig"

--- a/src/jekyll/test-project/test.sh
+++ b/src/jekyll/test-project/test.sh
@@ -19,7 +19,7 @@ check "git" git --version
 check "git-location" sh -c "which git | grep /usr/local/bin/git"
 
 git_version=$(git --version)
-check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.2"
 
 check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
 check "gitconfig-file-location" sh -c "ls /etc/gitconfig"

--- a/src/miniconda/test-project/test.sh
+++ b/src/miniconda/test-project/test.sh
@@ -10,7 +10,7 @@ check "git" git --version
 check "git-location" sh -c "which git | grep /usr/local/bin/git"
 
 git_version=$(git --version)
-check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.2"
 
 check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
 check "gitconfig-file-location" sh -c "ls /etc/gitconfig"

--- a/src/php/test-project/test.sh
+++ b/src/php/test-project/test.sh
@@ -21,7 +21,7 @@ check "git" git --version
 check "git-location" sh -c "which git | grep /usr/local/bin/git"
 
 git_version=$(git --version)
-check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.2"
 
 check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
 check "gitconfig-file-location" sh -c "ls /etc/gitconfig"

--- a/src/python/test-project/test.sh
+++ b/src/python/test-project/test.sh
@@ -31,7 +31,7 @@ check "git" git --version
 check "git-location" sh -c "which git | grep /usr/local/bin/git"
 
 git_version=$(git --version)
-check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.2"
 
 check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
 check "gitconfig-file-location" sh -c "ls /etc/gitconfig"

--- a/src/ruby/test-project/test.sh
+++ b/src/ruby/test-project/test.sh
@@ -22,7 +22,7 @@ check "git" git --version
 check "git-location" sh -c "which git | grep /usr/local/bin/git"
 
 git_version=$(git --version)
-check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.2"
 
 check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
 check "gitconfig-file-location" sh -c "ls /etc/gitconfig"

--- a/src/rust/test-project/test.sh
+++ b/src/rust/test-project/test.sh
@@ -17,7 +17,7 @@ check "git" git --version
 check "git-location" sh -c "which git | grep /usr/local/bin/git"
 
 git_version=$(git --version)
-check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.2"
 
 check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
 check "gitconfig-file-location" sh -c "ls /etc/gitconfig"

--- a/src/typescript-node/test-project/test.sh
+++ b/src/typescript-node/test-project/test.sh
@@ -23,7 +23,7 @@ check "git" git --version
 check "git-location" sh -c "which git | grep /usr/local/bin/git"
 
 git_version=$(git --version)
-check-version-ge "git-requirement" "${git_version}" "git version 2.39.1"
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.2"
 
 check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
 check "gitconfig-file-location" sh -c "ls /etc/gitconfig"

--- a/src/universal/.devcontainer/Dockerfile
+++ b/src/universal/.devcontainer/Dockerfile
@@ -16,7 +16,6 @@ RUN LANG="C.UTF-8" \
     && apt-get update \
     && apt-get upgrade -y \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        git \
         make \
         unzip \
         # The tools in this package are used when installing packages for Python

--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -50,6 +50,10 @@
         "ghcr.io/devcontainers/features/sshd:1": {
             "version": "latest"
         },
+        "ghcr.io/devcontainers/features/git:1": {
+            "version": "latest",
+            "ppa": "false"
+        },
         "ghcr.io/devcontainers/features/git-lfs:1": {
             "version": "latest"
         },
@@ -71,6 +75,7 @@
     },
     "overrideFeatureInstallOrder": [
         "ghcr.io/devcontainers/features/common-utils",
+        "ghcr.io/devcontainers/features/git",
         "ghcr.io/devcontainers/features/dotnet",
         "ghcr.io/devcontainers/features/hugo",
         "ghcr.io/devcontainers/features/node",

--- a/src/universal/test-project/test-utils.sh
+++ b/src/universal/test-project/test-utils.sh
@@ -108,7 +108,6 @@ checkExtension() {
 checkCommon()
 {
     PACKAGE_LIST="apt-utils \
-        git \
         openssh-client \
         less \
         iproute2 \

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -9,7 +9,7 @@ checkCommon
 check "git" git --version
 
 git_version=$(git --version)
-check-version-ge "git-requirement" "${git_version}" "git version 2.25.1"
+check-version-ge "git-requirement" "${git_version}" "git version 2.39.2"
 
 check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
 check "gitconfig-file-location" sh -c "ls /etc/gitconfig"


### PR DESCRIPTION
Updates `git` to `2.39.2` due to CVE-2023-22490 and CVE-2023-23946
More info https://github.blog/2023-02-14-git-security-vulnerabilities-announced-3/