### PR TITLE
Support PHP 8.0

### DIFF
--- a/src/php/README.md
+++ b/src/php/README.md
@@ -9,7 +9,7 @@
 | *Categories* | Languages |
 | *Image type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/php |
-| *Available image variants* | 8 / 8-bullseye, 8.2 / 8.2-bullseye, 8.1 / 8.1-bullseye, 8-buster, 8.2-buster, 8.1-buster ([full list](https://mcr.microsoft.com/v2/devcontainers/php/tags/list)) |
+| *Available image variants* | 8 / 8-bullseye, 8.2 / 8.2-bullseye, 8.1 / 8.1-bullseye, 8.0 / 8.0-bullseye, 8-buster, 8.2-buster, 8.1-buster, 8.0-buster ([full list](https://mcr.microsoft.com/v2/devcontainers/php/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bullseye` variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -25,6 +25,7 @@ You can directly reference pre-built versions of `Dockerfile` by using the `imag
 - `mcr.microsoft.com/devcontainers/php:8` (or `8-bullseye`, `8-buster` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/php:8.2` (or `8.2-bullseye`, `8.2-buster` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/php:8.1` (or `8.1-bullseye`, `8.1-buster` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/php:8.0` (or `8.0-bullseye`, `8.0-buster` to pin to an OS version)
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 

--- a/src/php/manifest.json
+++ b/src/php/manifest.json
@@ -3,8 +3,10 @@
 	"variants": [
 		"8.2-apache-bullseye",
 		"8.1-apache-bullseye",
+		"8.0-apache-bullseye",
 		"8.2-apache-buster",
-		"8.1-apache-buster"
+		"8.1-apache-buster",
+		"8.0-apache-buster"
 	],
 	"build": {
 		"latest": "8.2-apache-bullseye",
@@ -18,10 +20,17 @@
 				"linux/amd64",
 				"linux/arm64"
 			],
+			"8.0-apache-bullseye": [
+				"linux/amd64",
+				"linux/arm64"
+			],
 			"8.2-apache-buster": [
 				"linux/amd64"
 			],
 			"8.1-apache-buster": [
+				"linux/amd64"
+			],
+			"8.0-apache-buster": [
 				"linux/amd64"
 			]
 		},
@@ -40,6 +49,10 @@
 				"php:${VERSION}-8.1",
 				"php:${VERSION}-8.1-bullseye"
 			],
+			"8.0-apache-bullseye": [
+				"php:${VERSION}-8.0",
+				"php:${VERSION}-8.0-bullseye"
+			],
 			"8.2-apache-buster": [
 				"php:${VERSION}-8-buster",
 				"php:${VERSION}-8.2-buster",
@@ -47,6 +60,9 @@
 			],
 			"8.1-apache-buster": [
 				"php:${VERSION}-8.1-buster"
+			],
+			"8.0-apache-buster": [
+				"php:${VERSION}-8.0-buster"
 			]
 		}
 	},


### PR DESCRIPTION
It was mistakenly deprecated in https://github.com/devcontainers/images/pull/344

We should support PHP 8.0 even thought it's in "Security Fixes Only" phase until it is marked as "End of Life" by https://www.php.net/supported-versions.php

![image](https://user-images.githubusercontent.com/24955913/220774252-86d3bbde-76cb-476f-a1c8-cc844fe50aab.png)

