### PR TITLE
Go 1.18 - EOL

### DIFF
--- a/src/go/.devcontainer/Dockerfile
+++ b/src/go/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Go version (use -bullseye variants on local arm64/Apple Silicon): 1, 1.20, 1.19, 1.18, 1-bullseye, 1.20-bullseye, 1.19-bullseye, 1.18-bullseye, 1-buster, 1.20-buster, 1.19-buster, 1.18-buster
+# [Choice] Go version (use -bullseye variants on local arm64/Apple Silicon): 1, 1.20, 1.19, 1-bullseye, 1.20-bullseye, 1.19-bullseye, 1-buster, 1.20-buster, 1.19-buster
 ARG VARIANT=1.20-bullseye
 FROM golang:${VARIANT}
 

--- a/src/go/README.md
+++ b/src/go/README.md
@@ -10,7 +10,7 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/go |
-| *Available image variants* | 1 / 1-bullseye, 1.20 / 1.20-bullseye, 1.19 / 1.19-bullseye, 1.18 / 1.18-bullseye, 1-buster, 1.20-buster, 1.19-buster, 1.18-buster  ([full list](https://mcr.microsoft.com/v2/devcontainers/go/tags/list)) |
+| *Available image variants* | 1 / 1-bullseye, 1.20 / 1.20-bullseye, 1.19 / 1.19-bullseye, 1-buster, 1.20-buster, 1.19-buster ([full list](https://mcr.microsoft.com/v2/devcontainers/go/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bullseye` variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -26,7 +26,6 @@ You can directly reference pre-built versions of `Dockerfile` by using the `imag
 - `mcr.microsoft.com/devcontainers/go:1` (or `1-bullseye`, `1-buster` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/go:1.20` (or `1.20-bullseye`, `1.20-buster` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/go:1.19` (or `1.19-bullseye`, `1.19-buster` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/go:1.18` (or `1.18-bullseye`, `1.18-buster` to pin to an OS version)
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 

--- a/src/go/manifest.json
+++ b/src/go/manifest.json
@@ -4,9 +4,7 @@
     "1.20-bullseye",
     "1.20-buster",
     "1.19-bullseye",
-    "1.19-buster",
-    "1.18-bullseye",
-    "1.18-buster"
+    "1.19-buster"
   ],
   "build": {
     "latest": "1.20-bullseye",
@@ -23,17 +21,10 @@
         "linux/amd64",
         "linux/arm64"
       ],
-      "1.18-bullseye": [
-        "linux/amd64",
-        "linux/arm64"
-      ],
       "1.20-buster": [
         "linux/amd64"
       ],
       "1.19-buster": [
-        "linux/amd64"
-      ],
-      "1.18-buster": [
         "linux/amd64"
       ]
     },
@@ -50,9 +41,6 @@
       ],
       "1.19-bullseye": [
         "go:${VERSION}-1.19"
-      ],
-      "1.18-bullseye": [
-        "go:${VERSION}-1.18"
       ]
     }
   },


### PR DESCRIPTION
More details in https://github.com/devcontainers/images/issues/444