### PR TITLE
Javascript-node: Update 'got' due to CVE-2022-33987

### DIFF
--- a/src/javascript-node/.devcontainer/library-scripts/add-patch.sh
+++ b/src/javascript-node/.devcontainer/library-scripts/add-patch.sh
@@ -27,4 +27,7 @@ if [[ "${IMAGE_VARIANT}" =~ "14" ]] ; then
 
     cd /usr/local/lib/node_modules/npm/node_modules/yargs
     npm install ansi-regex --save
+
+    cd /usr/local/lib/node_modules/npm/node_modules/latest-version
+    npm install got --save
 fi


### PR DESCRIPTION
More details - https://github.com/advisories/GHSA-pfrx-2q88-qq97