### PR TITLE
Rust: "rust:${VERSION}-1" should point to "bullseye"

### DIFF
--- a/src/rust/manifest.json
+++ b/src/rust/manifest.json
@@ -21,10 +21,10 @@
 		],
 		"variantTags": {
 			"buster": [
-				"rust:${VERSION}-1",
 				"rust:${VERSION}-1-buster"
 			],
 			"bullseye": [
+				"rust:${VERSION}-1",
 				"rust:${VERSION}-1-bullseye"
 			]
 		}


### PR DESCRIPTION
Addresses https://github.com/devcontainers/images/issues/474