### PR TITLE
Update VS Code setting for the Python extension

### DIFF
--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -114,13 +114,12 @@
                 "python.defaultInterpreterPath": "/home/codespace/.python/current/bin/python3",
                 "python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
                 "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
-                "python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
-                "python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
                 "python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+                "python.linting.flake8Enabled": false,
                 "python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
-                "python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
-                "python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+                "python.linting.mypyEnabled": false,
                 "python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
+                "python.linting.pylintEnabled": false,
                 "jupyter.kernels.filter": [
                     {
                         "path": "/opt/conda/bin/python",


### PR DESCRIPTION
Remove tool paths for things that are planned for removal from the Python extension (hopefully) this year. Also explicitly turn linting off by default as they are moving to their own extensions (which already exist), and to minimize noise (e.g. Pylint complaining about imports).

This brings things in line with https://github.com/devcontainers/features/tree/main/src/python .