### PR TITLE
Revert "Universal: Patch "testng" gradle plugin due to CVE-2022-4065"

### DIFF
--- a/src/universal/.devcontainer/local-features/setup-user/install.sh
+++ b/src/universal/.devcontainer/local-features/setup-user/install.sh
@@ -20,13 +20,6 @@ chmod +x /etc/profile.d/00-restore-env.sh
 
 export DEBIAN_FRONTEND=noninteractive
 
-# Temporary: Due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-4065
-GRADLE_PATH=$(cd /usr/local/sdkman/candidates/gradle/8*/lib/plugins/ && pwd)
-rm -f ${GRADLE_PATH}/testng-*
-curl -sSL https://github.com/cbeust/testng/archive/refs/tags/7.7.0.tar.gz | tar -xzC /tmp 2>&1
-jar cf ${GRADLE_PATH}/testng-7.7.0.jar /tmp/testng-7.7.0
-rm -rf /tmp/testng-7.7.0
-
 # Temporary: Due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-29425
 MAVEN_PATH=$(cd /usr/local/sdkman/candidates/maven/3*/lib/ && pwd)
 rm -f ${MAVEN_PATH}/commons-io-*

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -181,9 +181,6 @@ check "java-12.0.2-installed-by-oryx" ls /opt/java/ | grep 12.0.2
 check "java-version-on-path-is-12.0.2" java --version | grep 12.0.2
 
 # Test patches
-GRADLE_PATH=$(cd /usr/local/sdkman/candidates/gradle/8*/lib/plugins && pwd)
-check "testng-plugin" bash -c "ls ${GRADLE_PATH} | grep testng-7.7.0.jar"
-
 MAVEN_PATH=$(cd /usr/local/sdkman/candidates/maven/3*/lib/ && pwd)
 check "commons-io-lib" bash -c "ls ${MAVEN_PATH} | grep commons-io-2.11.jar"
 


### PR DESCRIPTION
This reverts commit d4540cbb9da06beeca9360334c575ea9c240c67f.

Fixes - https://github.com/devcontainers/images/issues/483

From https://github.com/gradle/gradle/issues/24062, looks like it will take a while for the upstream issue to be fixed. However, I think it's worth to wait on the upstream fix rather than adding a patch which makes `gradle` unusable. 