### PR TITLE
[Anaconda] Update `werkzeug` package due to CVE-2023-25577

### DIFF
--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -75,7 +75,9 @@ RUN python3 -m pip install \
     # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32862
     nbconvert \
     # https://github.com/devcontainers/images/issues/486
-    pyOpenssl
+    pyOpenssl \
+    # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-25577
+    werkzeug
 
 # Copy environment.yml (if found) to a temp location so we can update the environment. Also
 # copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.

--- a/src/anaconda/manifest.json
+++ b/src/anaconda/manifest.json
@@ -35,7 +35,8 @@
 			"wheel",
 			"nbconvert",
 			"py",
-			"pyOpenssl"
+			"pyOpenssl",
+			"werkzeug"
 		],
 		"other": {
 			"git": {},

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -60,5 +60,8 @@ check "conda-update-conda" bash -c "conda update -y conda"
 check "conda-install" bash -c "conda install -c conda-forge --yes tensorflow"
 check "conda-install" bash -c "conda install -c conda-forge --yes pytorch"
 
+werkzeug_version=$(python -c "import werkzeug; print(werkzeug.__version__)")
+check-version-ge "werkzeug-requirement" "${werkzeug_version}" "2.2.3"
+
 # Report result
 reportResults


### PR DESCRIPTION
**Dev container name**: 
- Anaconda

**Description**:
This PR addresses the CVE-2023-25577 vulnerability. The vulnerability related to the `werkzeug` package comes from the `continuumio/anaconda3` image, which is used upstream for the Anaconda dev container.

*Changelog*:
- Updated Dockerfile to install the latest `werkzeug` package version;
- Added test to verify werkzeug minimum version (_Minimum package version set to `2.2.3` which fixes CVE-2023-25577_);
- Updated manifest to include info about the `werkzeug` package.

**Checklist**:

- [x] Checked that applied changes work as expected