### PR TITLE
[base-alpine] Update `sudo` package due to CVE-2023-27320

### DIFF
--- a/src/base-alpine/.devcontainer/Dockerfile
+++ b/src/base-alpine/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # [Choice] Alpine version: 3.17, 3.16, 3.15, 3.14
-ARG VARIANT=3.14
+ARG VARIANT=3.17
 FROM alpine:${VARIANT}
 
 ARG VARIANT

--- a/src/base-alpine/.devcontainer/Dockerfile
+++ b/src/base-alpine/.devcontainer/Dockerfile
@@ -1,8 +1,12 @@
 # [Choice] Alpine version: 3.17, 3.16, 3.15, 3.14
-ARG VARIANT=3.17
+ARG VARIANT=3.14
 FROM alpine:${VARIANT}
 
+ARG VARIANT
+
 # Temporary: Upgrade packages due to mentioned CVEs
-RUN apk update \
-    # https://security.alpinelinux.org/vuln/CVE-2023-27320
-    && apk add sudo>=1.9.12-r1 --repository https://dl-cdn.alpinelinux.org/alpine/latest-stable/community
+RUN if [[ "$VARIANT" == "3.14" || "$VARIANT" == "3.15" ]]; then \
+        apk update \
+        # https://security.alpinelinux.org/vuln/CVE-2023-27320
+        && apk add sudo>=1.9.12-r1 --repository https://dl-cdn.alpinelinux.org/alpine/latest-stable/community ; \
+    fi

--- a/src/base-alpine/.devcontainer/Dockerfile
+++ b/src/base-alpine/.devcontainer/Dockerfile
@@ -2,6 +2,7 @@
 ARG VARIANT=3.17
 FROM alpine:${VARIANT}
 
-# ** [Optional] Uncomment this section to install additional packages. **
-# RUN apk update \
-#     && apk add --no-cache <your-package-list-here>
+# Temporary: Upgrade packages due to mentioned CVEs
+RUN apk update \
+    # https://security.alpinelinux.org/vuln/CVE-2023-27320
+    && apk add sudo>=1.9.12-r1 --repository https://dl-cdn.alpinelinux.org/alpine/latest-stable/community

--- a/src/base-alpine/test-project/test.sh
+++ b/src/base-alpine/test-project/test.sh
@@ -18,8 +18,8 @@ check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcont
 
 check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
-sudo_version=$(sudo --version | head -1)
-check-version-ge "sudo-requirement" "${sudo_version}" "Sudo version 1.9.12p2"
+sudo_version=$(apk info sudo | head -1 | grep -Po  "sudo-\K(.*)(?=\s)")
+check-version-ge "sudo-requirement" "${sudo_version}" "1.9.12_p2-r1"
 
 # Report result
 reportResults

--- a/src/base-alpine/test-project/test.sh
+++ b/src/base-alpine/test-project/test.sh
@@ -18,5 +18,8 @@ check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcont
 
 check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
+sudo_version=$(sudo --version | head -1)
+check-version-ge "sudo-requirement" "${sudo_version}" "Sudo version 1.9.12p2"
+
 # Report result
 reportResults


### PR DESCRIPTION
**Dev container name**: 

- base-alpine

**Description**:

This PR addresses the CVE-2023-27320 vulnerability. The `sudo` package vulnerability comes from the `features/common-utils` image used in the base-alpine container. 

We need to update sudo to the `1.9.12-r1` version to resolve the security issue. However, this version is unavailable for `Alpine 3.14` and `Alpine 3.15`. The latest version that could be consumed by `Alpine 3.14` and `Alpine 3.15` is `1.9.12_p2-r0` because the `1.9.12-r1` version was not committed into related branches of the Alpine software repository. Here are related links to the application repository branches:
- 3.14 https://pkgs.alpinelinux.org/packages?name=sudo&branch=v3.14&repo=&arch=&maintainer=
- 3.15 https://pkgs.alpinelinux.org/packages?name=sudo&branch=v3.15&repo=&arch=&maintainer=

As a fix, we can consume the required version of the `sudo` package by explicitly forcing Alpine use the [alpine/latest-stable/community](https://dl-cdn.alpinelinux.org/alpine/latest-stable/community) repository. OS itself should resolve the build to install for the target architecture.

*Changelog*:

- Updated Dockerfile to install the latest version of the `sudo` package; 
- Added test to verify `sudo` minimum version (_Minimum package version set to `1.9.12_p2-r1` which fixes CVE-2023-27320_);

*Additional links*:

- Alpine Security Tracker: https://security.alpinelinux.org/vuln/CVE-2023-27320


**Checklist**:

- [x] Checked that applied changes work as expected