### PR TITLE
[Miniconda] Address CVE-2022-40897 and CVE-2022-40898 vulnerabilities

### DIFF
--- a/src/miniconda/.devcontainer/Dockerfile
+++ b/src/miniconda/.devcontainer/Dockerfile
@@ -50,7 +50,7 @@ RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then umask 0002 && /opt/conda/bi
 USER vscode
 
 # Temporary: Upgrade python packages due to mentioned CVEs
-# They are installed by the base image (continuumio/anaconda3) which does not have the patch.
+# They are installed by the base image (continuumio/miniconda3) which does not have the patch.
 RUN python3 -m conda update -y \
     # https://github.com/advisories/GHSA-39hc-v87j-747x
     cryptography \

--- a/src/miniconda/.devcontainer/Dockerfile
+++ b/src/miniconda/.devcontainer/Dockerfile
@@ -49,9 +49,15 @@ RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then umask 0002 && /opt/conda/bi
 
 USER vscode
 
-# Temporary: Upgrade 'cryptography' due to https://github.com/advisories/GHSA-39hc-v87j-747x
-# 'cryptography' is installed by the base image (continuumio/miniconda3) which does not have the patch.
-RUN python3 -m conda update -y cryptography
+# Temporary: Upgrade python packages due to mentioned CVEs
+# They are installed by the base image (continuumio/anaconda3) which does not have the patch.
+RUN python3 -m conda update -y \
+    # https://github.com/advisories/GHSA-39hc-v87j-747x
+    cryptography \
+    # https://github.com/advisories/GHSA-r9hx-vwmv-q579
+    setuptools \
+    # https://github.com/advisories/GHSA-qwmp-2cf2-g9g6
+    wheel
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/src/miniconda/manifest.json
+++ b/src/miniconda/manifest.json
@@ -39,7 +39,9 @@
 		"pip": [
 			"certifi",
 			"cryptography",
-			"pyOpenssl"
+			"pyOpenssl",
+			"setuptools",
+			"wheel"
 		],
 		"other": {
 			"git": {},

--- a/src/miniconda/test-project/test.sh
+++ b/src/miniconda/test-project/test.sh
@@ -23,5 +23,11 @@ check-version-ge "cryptography-requirement" "${cryptography_version}" "38.0.3"
 
 check "conda-update-conda" bash -c "conda update -y conda"
 
+setuptools_version=$(python -c "import setuptools; print(setuptools.__version__)")
+check-version-ge "setuptools-requirement" "${setuptools_version}" "65.5.1"
+
+wheel_version=$(python -c "import wheel; print(wheel.__version__)")
+check-version-ge "wheel-requirement" "${wheel_version}" " 0.38.1"
+
 # Report result
 reportResults


### PR DESCRIPTION
**Dev container name**: 

- Miniconda

**Description**:

This PR addresses the following vulnerabilities:

- CVE-2022-40897 - related to the `setuptools` package;
- CVE-2022-40898 - related to the `wheel` package.


These vulnerabilities come from the `continuumio/miniconda3` image used upstream for the Miniconda dev container.

*Changelog*:

- Updated Dockerfile to install updated versions of `wheel` and `setuptools` packages;

- Added tests to verify `setuptools` and `wheel` minimum versions:
  - `setuptools` - _minimum package version set to `65.5.1` which fixes CVE-2022-40897_;
  - `wheel` - _minimum package version set to `0.38.1`, which fixes CVE-2022-40898_;

- Updated manifest to include info about `setuptools` and `wheel` packages;


**Checklist**:

- [x] Checked that applied changes work as expected