### PR TITLE
[javascript-node & typescript-node] Address CVE-2022-33987 vulnerability

### DIFF
--- a/src/javascript-node/.devcontainer/library-scripts/add-patch.sh
+++ b/src/javascript-node/.devcontainer/library-scripts/add-patch.sh
@@ -30,4 +30,5 @@ if [[ "${IMAGE_VARIANT}" =~ "14" ]] ; then
 
     cd /usr/local/lib/node_modules/npm/node_modules/latest-version
     npm install got --save
+    npm install package-json@8 --save
 fi


### PR DESCRIPTION
**Dev container name**: 

- javascript-node

**Description**:

This PR addresses the CVE-2022-33987 vulnerability. This vulnerability comes from the `got v6.7.1` package, which is used as a dependency in the `package-json v4.0.1` [npm package](https://www.npmjs.com/package/package-json). We need to bump the `package-json` version to address the vulnerability.

*Changelog*:

- Updated `add-patch.sh` script to bump `package-json` npm package version: `v4.0.1 -> v8.1.0`  

**Checklist**:

- [x] Checked that applied changes work as expected
