### PR TITLE
Ruby - Release 2.7.8

### DIFF
--- a/src/ruby/manifest.json
+++ b/src/ruby/manifest.json
@@ -4,9 +4,11 @@
 		"3.2-bullseye",
 		"3.1-bullseye",
 		"3.0-bullseye",
+		"2.7-bullseye",
 		"3.2-buster",
 		"3.1-buster",
-		"3.0-buster"
+		"3.0-buster",
+		"2.7-buster"
 	],
 	"build": {
 		"latest": "3.2-bullseye",
@@ -24,6 +26,10 @@
 				"linux/amd64",
 				"linux/arm64"
 			],
+			"2.7-bullseye": [
+				"linux/amd64",
+				"linux/arm64"
+			],
 			"3.2-buster": [
 				"linux/amd64"
 			],
@@ -31,6 +37,9 @@
 				"linux/amd64"
 			],
 			"3.0-buster": [
+				"linux/amd64"
+			],
+			"2.7-buster": [
 				"linux/amd64"
 			]
 		},
@@ -50,9 +59,17 @@
 			"3.0-bullseye": [
 				"ruby:${VERSION}-3.0"
 			],
+			"2.7-bullseye": [
+				"ruby:${VERSION}-2",
+				"ruby:${VERSION}-2.7",
+				"ruby:${VERSION}-2-bullseye"
+			],
 			"3.2-buster": [
 				"ruby:${VERSION}-3-buster",
 				"ruby:${VERSION}-buster"
+			],
+			"2.7-buster": [
+				"ruby:${VERSION}-2-buster"
 			]
 		}
 	},


### PR DESCRIPTION
Ref: https://github.com/devcontainers/images/issues/526

Follow up with EOL for ruby 2.7 after ruby 2.7.8 image is released.