### PR TITLE
[miniconda] Remove the `USER` instruction to fix issue with `miniconda` template

### DIFF
--- a/src/miniconda/.devcontainer/Dockerfile
+++ b/src/miniconda/.devcontainer/Dockerfile
@@ -47,8 +47,6 @@ COPY environment.yml* noop.txt /tmp/conda-tmp/
 RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then umask 0002 && /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment.yml; fi \
     && rm -rf /tmp/conda-tmp
 
-USER vscode
-
 # Temporary: Upgrade python packages due to mentioned CVEs
 # They are installed by the base image (continuumio/miniconda3) which does not have the patch.
 RUN python3 -m conda update -y \

--- a/src/miniconda/test-project/test.sh
+++ b/src/miniconda/test-project/test.sh
@@ -22,6 +22,8 @@ cryptography_version=$(python -c "import cryptography; print(cryptography.__vers
 check-version-ge "cryptography-requirement" "${cryptography_version}" "38.0.3"
 
 check "conda-update-conda" bash -c "conda update -y conda"
+check "conda-install" bash -c "conda install -c conda-forge --yes tensorflow"
+check "conda-install" bash -c "conda install -c conda-forge --yes pytorch"
 
 setuptools_version=$(python -c "import setuptools; print(setuptools.__version__)")
 check-version-ge "setuptools-requirement" "${setuptools_version}" "65.5.1"


### PR DESCRIPTION
**Dev container name**: 

- miniconda

**Description**:
This PR removes the `USER` instruction from the devcontainer Dockerfile. According to [Docker documentation](https://docs.docker.com/engine/reference/builder/#user), when we set the user in the Dockerfile. The specified user is used for `RUN` instructions and, at runtime, runs the relevant `ENTRYPOINT` and `CMD` commands. This caused the issue with the [miniconda template](https://github.com/devcontainers/templates/tree/main/src/miniconda).  

We copy several files to the container in the related template and remove them afterward:

```Dockerfile
# Copy environment.yml (if found) to a temp location so we update the environment. Also
# copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.
COPY environment.yml* .devcontainer/noop.txt /tmp/conda-tmp/
RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then umask 0002 && /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment.yml; fi \
    && rm -rf /tmp/conda-tmp
```

When Docker attempts to remove the `conda-tmp` folder, the following error appears:

```console
> [dev_container_auto_added_stage_label 3/3] RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then umask 0002 && /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment.yml; fi     && rm -rf /tmp/conda-tmp:
#0 0.343 rm: cannot remove '/tmp/conda-tmp/noop.txt': Permission denied
------
[2023-05-09T15:58:53.496Z] Dockerfile-with-features:8
[2023-05-09T15:58:53.508Z] 
--------------------
   7 |     COPY environment.yml* .devcontainer/noop.txt /tmp/conda-tmp/
   8 | >>> RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then umask 0002 && /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment.yml; fi \
   9 | >>>     && rm -rf /tmp/conda-tmp
  10 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c if [ -f \"/tmp/conda-tmp/environment.yml\" ]; then umask 0002 && /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment.yml; fi     && rm -rf /tmp/conda-tmp" did not complete successfully: exit code: 1
```

The issue is related to the fact that the `RUN` instruction runs via the `vscode` user (Due to the `USER` instruction) while only the `root` user has the write permissions for the `/tmp/conda-tmp` folder.

```console
vscode ➜ ~ $ tree -up  /tmp/
/tmp/
├── [drwxr-xr-x root    ]  conda-tmp
│   └── [-rwxr-xr-x root    ]  noop.txt
```

_Changelog_:

- Removed the `USER` instruction form `Dockerfile` to ensure that all subsequent commands run via the `root` user.

**Attached related issue**:

- devcontainers/templates/issues/154

**Checklist**:

- [x] Checked that applied changes work as expected