### PR TITLE
[anaconda] Temporally lock upstream version to resolve issues with smoke testing

### DIFF
--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/anaconda3 as upstream
+FROM continuumio/anaconda3:2022.10 as upstream
 
 # Verify OS version is expected one
 RUN . /etc/os-release && if [ "${VERSION_CODENAME}" != "bullseye" ]; then exit 1; fi


### PR DESCRIPTION
**Devcontainer name**:

- anaconda

**Description**:

The following workflow started to fail constantly: 
- [Smoke test "anaconda" build](https://github.com/devcontainers/images/actions/workflows/smoke-anaconda.yaml)

The following tests are broken:

```console
Failed tests: conda-update-conda conda-install conda-install
```

The issue seems to be related to a recent update of the `continuumio/anaconda3` image that we use as [upstream](https://github.com/devcontainers/images/blob/8fb5d266a7f674557472d8643d9a1b096dd05a74/src/anaconda/.devcontainer/Dockerfile#LL1C33-L1C33) for `anaconda` devcontainer.

The recent [version](https://github.com/ContinuumIO/docker-images/releases) of the `continuumio/anaconda3` image contains two major changes:

- Conda version bumped: `22.9.0` -> `23.3.1`; 
- Default Python version changed `python3.9` -> `python3.10`

_Errors_:

```console
[Errno 13] Permission denied: '/opt/conda/lib/python3.10/site-packages/cookiecutter/__init__.py' -> '/opt/conda/lib/python3.10/site-packages/cookiecutter/__init__.py.c~'
()
[Errno 13] Permission denied: '/opt/conda/lib/python3.10/site-packages/certifi/__init__.py' -> '/opt/conda/lib/python3.10/site-packages/certifi/__init__.py.c~'
()
[Errno 13] Permission denied: '/opt/conda/lib/python3.10/site-packages/certifi/__init__.py' -> '/opt/conda/lib/python3.10/site-packages/certifi/__init__.py.c~'
()
```

_Fix_:

As a temporal fix, we can lock the upstream version.

_Changelog_:

- Lock the upstream version to resolve issues with smoke testing

