### PR TITLE
[anaconda] Reorg Dockerfile instructions to resolve issue with group permissions and `PIP` 

### DIFF
--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -3,12 +3,6 @@ FROM continuumio/anaconda3 as upstream
 # Verify OS version is expected one
 RUN . /etc/os-release && if [ "${VERSION_CODENAME}" != "bullseye" ]; then exit 1; fi
 
-# Update, change owner
-RUN groupadd -r conda --gid 900 \
-    && chown -R :conda /opt/conda \
-    && chmod -R g+w /opt/conda \
-    && find /opt -type d | xargs -n 1 chmod g+s
-
 # Reset and copy updated files with updated privs to keep image size down
 FROM mcr.microsoft.com/devcontainers/base:0-bullseye
 COPY --from=upstream /opt /opt/
@@ -47,8 +41,6 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh \
     && echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc \
     && echo "conda activate base" >> ~/.bashrc \
-    && groupadd -r conda --gid 900 \
-    && usermod -aG conda ${USERNAME} \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts/add-notice.sh
 
 # Temporary: Upgrade python packages due to mentioned CVEs
@@ -58,26 +50,21 @@ RUN python3 -m pip install \
     --upgrade joblib \
     # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24065
     cookiecutter \
-    # https://github.com/advisories/GHSA-39hc-v87j-747x
-    cryptography \
     # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-34749
     mistune \
     # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-34141
     numpy \
-    # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23491
-    certifi \
-    # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40897
-    setuptools \
-    # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40899
-    future \
-    # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40898
-    wheel \
-    # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32862
-    nbconvert \
     # https://github.com/devcontainers/images/issues/486
     pyOpenssl \
     # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-25577
     werkzeug
+
+# Update, change owner
+RUN groupadd -r conda --gid 900 \
+    && chown -R :conda /opt/conda \
+    && chmod -R g+w /opt/conda \
+    && find /opt -type d | xargs -n 1 chmod g+s \
+    && usermod -aG conda ${USERNAME}
 
 # Copy environment.yml (if found) to a temp location so we can update the environment. Also
 # copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.

--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -57,7 +57,9 @@ RUN python3 -m pip install \
     # https://github.com/devcontainers/images/issues/486
     pyOpenssl \
     # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-25577
-    werkzeug
+    werkzeug \
+    # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32862
+    nbconvert
 
 # Update, change owner
 RUN groupadd -r conda --gid 900 \

--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -61,13 +61,6 @@ RUN python3 -m pip install \
     # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32862
     nbconvert
 
-# Update, change owner
-RUN groupadd -r conda --gid 900 \
-    && chown -R :conda /opt/conda \
-    && chmod -R g+w /opt/conda \
-    && find /opt -type d | xargs -n 1 chmod g+s \
-    && usermod -aG conda ${USERNAME}
-
 # Copy environment.yml (if found) to a temp location so we can update the environment. Also
 # copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.
 # COPY environment.yml* .devcontainer/noop.txt /tmp/conda-tmp/
@@ -78,3 +71,13 @@ RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then umask 0002 && /opt/conda/bi
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 #     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# Create conda group, update conda directory permissions, 
+# add user to conda group
+# Note: We need to execute these commands after pip install / conda update 
+# since pip doesn't preserve directory permissions
+RUN groupadd -r conda --gid 900 \
+    && chown -R :conda /opt/conda \
+    && chmod -R g+w /opt/conda \
+    && find /opt -type d | xargs -n 1 chmod g+s \
+    && usermod -aG conda ${USERNAME}

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -63,5 +63,8 @@ check "conda-install" bash -c "conda install -c conda-forge --yes pytorch"
 werkzeug_version=$(python -c "import werkzeug; print(werkzeug.__version__)")
 check-version-ge "werkzeug-requirement" "${werkzeug_version}" "2.2.3"
 
+certifi_version=$(python -c "import certifi; print(certifi.__version__)")
+check-version-ge "certifi-requirement" "${certifi_version}" "2022.12.07"
+
 # Report result
 reportResults


### PR DESCRIPTION
**Devcontainer name**:

- anaconda

**Description**:

This PR addresses the `[Errno 13] Permission denied` error that recently appeared during `anaconda` devcontainer smoke testing. The error relates to the fact that when PIP installs updates for Python packages, it's not preserving group permissions which results in flipping the group write permission bite:

_Without running `pip install`_:

```console
vscode ➜ ~ $ tree -ugp -L 1 /opt/conda/lib/python3.10/site-packages/
/opt/conda/lib/python3.10/site-packages/
...
├── [drwxrwsr-x root     conda   ]  cookiecutter
├── [drwxrwsr-x root     conda   ]  cookiecutter-1.7.3.dist-info
├── [drwxrwsr-x root     conda   ]  cryptography
├── [drwxrwsr-x root     conda   ]  cryptography-39.0.1.dist-info
```

_With running `pip install`_:

```console
vscode ➜ ~ $ tree -ugp -L 1 /opt/conda/lib/python3.10/site-packages/
/opt/conda/lib/python3.10/site-packages/
...
├── [drwxr-sr-x root     conda   ]  cookiecutter
├── [drwxr-sr-x root     conda   ]  cookiecutter-2.1.1.dist-info
├── [drwxr-sr-x root     conda   ]  cryptography
├── [drwxr-sr-x root     conda   ]  cryptography-40.0.2.dist-info
```

**Fix**:

We need to reorg several instructions in `Dockerfile` to ensure the `site-packages` directory has the correct permissions for all packages.

**Changelog**:

- Updated Dockerfile instructions and they order to address issues with PIP and group permission;
- Removed temp security patches that are no longer actual;
- Added missing tests for Python packages version check;