### PR TITLE
[anaconda & miniconda] Update `requests` package due to CVE-2023-32681 

### DIFF
--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -59,7 +59,9 @@ RUN python3 -m pip install \
     # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-25577
     werkzeug \
     # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32862
-    nbconvert
+    nbconvert \
+    # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-32681
+    requests
 
 # Copy environment.yml (if found) to a temp location so we can update the environment. Also
 # copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.

--- a/src/anaconda/manifest.json
+++ b/src/anaconda/manifest.json
@@ -36,7 +36,8 @@
 			"nbconvert",
 			"py",
 			"pyOpenssl",
-			"werkzeug"
+			"werkzeug",
+			"requests"
 		],
 		"other": {
 			"git": {},

--- a/src/anaconda/test-project/test-utils.sh
+++ b/src/anaconda/test-project/test-utils.sh
@@ -162,3 +162,12 @@ fixTestProjectFolderPrivs() {
         fi
     fi
 }
+
+checkPythonPackageVersion()
+{
+    PACKAGE=$1
+    REQUIRED_VERSION=$2
+
+    current_version=$(python -c "import ${PACKAGE}; print(${PACKAGE}.__version__)")
+    check-version-ge "${PACKAGE}-requirement" "${current_version}" "${REQUIRED_VERSION}"
+}

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -29,42 +29,22 @@ check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcont
 
 check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
-joblib_version=$(python -c "import joblib; print(joblib.__version__)")
-check-version-ge "joblib-requirement" "${joblib_version}" "1.2.0"
-
-cookiecutter_version=$(python -c "import cookiecutter; print(cookiecutter.__version__)")
-check-version-ge "cookiecutter-requirement" "${cookiecutter_version}" "2.1.1"
-
-cryptography_version=$(python -c "import cryptography; print(cryptography.__version__)")
-check-version-ge "cryptography-requirement" "${cryptography_version}" "38.0.3"
-
-mistune_version=$(python -c "import mistune; print(mistune.__version__)")
-check-version-ge "mistune-requirement" "${mistune_version}" "2.0.3"
-
-numpy_version=$(python -c "import numpy; print(numpy.__version__)")
-check-version-ge "numpy-requirement" "${numpy_version}" "1.22"
-
-setuptools_version=$(python -c "import setuptools; print(setuptools.__version__)")
-check-version-ge "setuptools-requirement" "${setuptools_version}" "65.5.1"
-
-future_version=$(python -c "import future; print(future.__version__)")
-check-version-ge "future-requirement" "${future_version}" "0.18.3"
-
-wheel_version=$(python -c "import wheel; print(wheel.__version__)")
-check-version-ge "wheel-requirement" "${wheel_version}" "0.38.1"
-
-nbconvert_version=$(python -c "import nbconvert; print(nbconvert.__version__)")
-check-version-ge "nbconvert-requirement" "${nbconvert_version}" "6.5.1"
-
 check "conda-update-conda" bash -c "conda update -y conda"
 check "conda-install" bash -c "conda install -c conda-forge --yes tensorflow"
 check "conda-install" bash -c "conda install -c conda-forge --yes pytorch"
 
-werkzeug_version=$(python -c "import werkzeug; print(werkzeug.__version__)")
-check-version-ge "werkzeug-requirement" "${werkzeug_version}" "2.2.3"
-
-certifi_version=$(python -c "import certifi; print(certifi.__version__)")
-check-version-ge "certifi-requirement" "${certifi_version}" "2022.12.07"
+checkPythonPackageVersion "joblib" "1.2.0"
+checkPythonPackageVersion "cookiecutter" "2.1.1"
+checkPythonPackageVersion "cryptography" "38.0.3"
+checkPythonPackageVersion "mistune" "2.0.3"
+checkPythonPackageVersion "numpy" "1.22"
+checkPythonPackageVersion "setuptools" "65.5.1"
+checkPythonPackageVersion "future" "0.18.3"
+checkPythonPackageVersion "wheel" "0.38.1"
+checkPythonPackageVersion "nbconvert" "6.5.1"
+checkPythonPackageVersion "werkzeug" "2.2.3"
+checkPythonPackageVersion "certifi" "2022.12.07"
+checkPythonPackageVersion "requests" "2.31.0"
 
 # Report result
 reportResults

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -29,10 +29,6 @@ check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcont
 
 check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
-check "conda-update-conda" bash -c "conda update -y conda"
-check "conda-install" bash -c "conda install -c conda-forge --yes tensorflow"
-check "conda-install" bash -c "conda install -c conda-forge --yes pytorch"
-
 checkPythonPackageVersion "joblib" "1.2.0"
 checkPythonPackageVersion "cookiecutter" "2.1.1"
 checkPythonPackageVersion "cryptography" "38.0.3"
@@ -45,6 +41,10 @@ checkPythonPackageVersion "nbconvert" "6.5.1"
 checkPythonPackageVersion "werkzeug" "2.2.3"
 checkPythonPackageVersion "certifi" "2022.12.07"
 checkPythonPackageVersion "requests" "2.31.0"
+
+check "conda-update-conda" bash -c "conda update -y conda"
+check "conda-install" bash -c "conda install -c conda-forge --yes tensorflow"
+check "conda-install" bash -c "conda install -c conda-forge --yes pytorch"
 
 # Report result
 reportResults

--- a/src/miniconda/.devcontainer/Dockerfile
+++ b/src/miniconda/.devcontainer/Dockerfile
@@ -39,9 +39,11 @@ COPY environment.yml* noop.txt /tmp/conda-tmp/
 RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then umask 0002 && /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment.yml; fi \
     && rm -rf /tmp/conda-tmp
 
-# [Optional] Uncomment this section to install updates/additional Python packages.
-# RUN python3 -m conda update -y \
-#     <your-package-list-here>
+# Temporary: Upgrade python packages due to mentioned CVEs
+# They are installed by the base image (continuumio/miniconda3) which does not have the patch.
+RUN python3 -m pip install --upgrade \
+    # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-32681
+    requests
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/src/miniconda/manifest.json
+++ b/src/miniconda/manifest.json
@@ -41,7 +41,8 @@
 			"cryptography",
 			"pyOpenssl",
 			"setuptools",
-			"wheel"
+			"wheel",
+			"requests"
 		],
 		"other": {
 			"git": {},

--- a/src/miniconda/test-project/test-utils.sh
+++ b/src/miniconda/test-project/test-utils.sh
@@ -163,3 +163,12 @@ fixTestProjectFolderPrivs() {
         fi
     fi
 }
+
+checkPythonPackageVersion()
+{
+    PACKAGE=$1
+    REQUIRED_VERSION=$2
+
+    current_version=$(python -c "import ${PACKAGE}; print(${PACKAGE}.__version__)")
+    check-version-ge "${PACKAGE}-requirement" "${current_version}" "${REQUIRED_VERSION}"
+}

--- a/src/miniconda/test-project/test.sh
+++ b/src/miniconda/test-project/test.sh
@@ -18,18 +18,14 @@ check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcont
 
 check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
-cryptography_version=$(python -c "import cryptography; print(cryptography.__version__)")
-check-version-ge "cryptography-requirement" "${cryptography_version}" "38.0.3"
-
 check "conda-update-conda" bash -c "conda update -y conda"
 check "conda-install" bash -c "conda install -c conda-forge --yes tensorflow"
 check "conda-install" bash -c "conda install -c conda-forge --yes pytorch"
 
-setuptools_version=$(python -c "import setuptools; print(setuptools.__version__)")
-check-version-ge "setuptools-requirement" "${setuptools_version}" "65.5.1"
-
-wheel_version=$(python -c "import wheel; print(wheel.__version__)")
-check-version-ge "wheel-requirement" "${wheel_version}" " 0.38.1"
+checkPythonPackageVersion "cryptography" "38.0.3"
+checkPythonPackageVersion "setuptools" "65.5.1"
+checkPythonPackageVersion "wheel" "0.38.1"
+checkPythonPackageVersion "requests" "2.31.0"
 
 # Report result
 reportResults

--- a/src/miniconda/test-project/test.sh
+++ b/src/miniconda/test-project/test.sh
@@ -18,14 +18,14 @@ check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcont
 
 check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
-check "conda-update-conda" bash -c "conda update -y conda"
-check "conda-install" bash -c "conda install -c conda-forge --yes tensorflow"
-check "conda-install" bash -c "conda install -c conda-forge --yes pytorch"
-
 checkPythonPackageVersion "cryptography" "38.0.3"
 checkPythonPackageVersion "setuptools" "65.5.1"
 checkPythonPackageVersion "wheel" "0.38.1"
 checkPythonPackageVersion "requests" "2.31.0"
+
+check "conda-update-conda" bash -c "conda update -y conda"
+check "conda-install" bash -c "conda install -c conda-forge --yes tensorflow"
+check "conda-install" bash -c "conda install -c conda-forge --yes pytorch"
 
 # Report result
 reportResults


### PR DESCRIPTION
**Dev container name**: 

- anaconda
- miniconda

**Description**:

This PR addresses the CVE-2023-32681 vulnerability. The vulnerability comes from the `continuumio/anaconda3` and `continuumio/miniconda3` images and is related to the `requests` package. These containers are used upstream for `anaconda` and `miniconda` dev containers.

*Changelog*:

- Updated Dockerfile to install the latest `requests` package version;
- Added test to verify `requests` minimum version (_Minimum package version set to `2.31.0` which fixes CVE-2023-32681_);
- Updated manifest to include info about the `requests` package;
- Refactored tests for Python packages;

**Checklist**:

- [x] Checked that applied changes work as expected