### PR TITLE
Anaconda: Adds back 'anaconda' pkg

### DIFF
--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -43,6 +43,9 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && echo "conda activate base" >> ~/.bashrc \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts/add-notice.sh
 
+# Since anaconda distribution 2023.03-1, continuumio/anaconda3 image no more contains `anaconda` pkg.
+RUN conda install anaconda
+
 # Temporary: Upgrade python packages due to mentioned CVEs
 # They are installed by the base image (continuumio/anaconda3) which does not have the patch.
 RUN python3 -m pip install \
@@ -54,8 +57,6 @@ RUN python3 -m pip install \
     mistune \
     # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-34141
     numpy \
-    # https://github.com/devcontainers/images/issues/486
-    pyOpenssl \
     # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-25577
     werkzeug \
     # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32862

--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -44,7 +44,8 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts/add-notice.sh
 
 # Since anaconda distribution 2023.03-1, continuumio/anaconda3 image no more contains `anaconda` pkg.
-RUN conda install anaconda
+RUN conda update --yes conda \
+    && conda install -c conda-forge --yes anaconda
 
 # Temporary: Upgrade python packages due to mentioned CVEs
 # They are installed by the base image (continuumio/anaconda3) which does not have the patch.
@@ -60,9 +61,7 @@ RUN python3 -m pip install \
     # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-25577
     werkzeug \
     # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32862
-    nbconvert
-
-RUN conda update \
+    nbconvert \
     # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-32681
     requests
 

--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -44,10 +44,8 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts/add-notice.sh
 
 # Since anaconda distribution 2023.03-1, continuumio/anaconda3 image no more contains `anaconda` pkg.
-RUN conda update --yes conda \
-    && conda install -c conda-forge --yes anaconda \
-    # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-32681
-    && conda update --yes requests
+RUN conda update -n base -c defaults conda \
+    && conda install --yes anaconda
 
 # Temporary: Upgrade python packages due to mentioned CVEs
 # They are installed by the base image (continuumio/anaconda3) which does not have the patch.

--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -60,7 +60,9 @@ RUN python3 -m pip install \
     # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-25577
     werkzeug \
     # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32862
-    nbconvert \
+    nbconvert
+
+RUN conda update \
     # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-32681
     requests
 

--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -45,7 +45,9 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 
 # Since anaconda distribution 2023.03-1, continuumio/anaconda3 image no more contains `anaconda` pkg.
 RUN conda update --yes conda \
-    && conda install -c conda-forge --yes anaconda
+    && conda install -c conda-forge --yes anaconda \
+    # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-32681
+    && conda update --yes requests
 
 # Temporary: Upgrade python packages due to mentioned CVEs
 # They are installed by the base image (continuumio/anaconda3) which does not have the patch.

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -8,6 +8,7 @@ checkCommon
 
 # Image specific tests
 check "conda" conda --version
+check "anaconda" bash -c "conda list anaconda$ | grep -oP 'anaconda\\s+\\K[^\\s]+'"
 check "python" python --version
 check "pylint" pylint --version
 check "flake8" flake8 --version

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -43,7 +43,8 @@ checkPythonPackageVersion "werkzeug" "2.2.3"
 checkPythonPackageVersion "certifi" "2022.12.07"
 checkPythonPackageVersion "requests" "2.31.0"
 
-check "conda-update-conda" bash -c "conda update -y conda"
+# https://github.com/conda/conda/issues/8149
+check "conda-update-conda" bash -c "conda update --force conda"
 check "conda-install" bash -c "conda install -c conda-forge --yes tensorflow"
 check "conda-install" bash -c "conda install -c conda-forge --yes pytorch"
 


### PR DESCRIPTION
Fixes image history generation - https://github.com/devcontainers/images/actions/runs/5123831476/jobs/9219811428#step:5:263

Since the update to anaconda distribution `2023.03-1`, `continuumio/anaconda3` image no more contains the `anaconda` pkg. The dev container's anaconda image expects that to exist, hence install manually. 