### PR TITLE
Ubuntu 18.04 (bionic) - End of Standard Support

### DIFF
--- a/src/base-ubuntu/.devcontainer/Dockerfile
+++ b/src/base-ubuntu/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Ubuntu version (use jammy or bionic on local arm64/Apple Silicon): jammy, focal, bionic
+# [Choice] Ubuntu version (use jammy on local arm64/Apple Silicon): jammy, focal
 ARG VARIANT="jammy"
 FROM buildpack-deps:${VARIANT}-curl
 

--- a/src/base-ubuntu/README.md
+++ b/src/base-ubuntu/README.md
@@ -9,8 +9,8 @@
 | *Categories* | Core, Other |
 | *Image type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/base:ubuntu |
-| *Available image variants* | ubuntu-22.04 / jammy, ubuntu-20.04 / focal, ubuntu-18.04 / bionic ([full list](https://mcr.microsoft.com/v2/devcontainers/base/tags/list)) |
-| *Published image architecture(s)* | x86-64, aarch64/arm64 for `ubuntu-22.04` (`jammy`) and `ubuntu-18.04` (`bionic`) variants  |
+| *Available image variants* | ubuntu-22.04 / jammy, ubuntu-20.04 / focal ([full list](https://mcr.microsoft.com/v2/devcontainers/base/tags/list)) |
+| *Published image architecture(s)* | x86-64, aarch64/arm64 for `ubuntu-22.04` (`jammy`) variant  |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Ubuntu |
 | *Languages, platforms* | Any |
@@ -24,15 +24,14 @@ You can directly reference pre-built versions of `Dockerfile` by using the `imag
 - `mcr.microsoft.com/devcontainers/base:ubuntu` (latest LTS release)
 - `mcr.microsoft.com/devcontainers/base:ubuntu-22.04` (or `jammy`)
 - `mcr.microsoft.com/devcontainers/base:ubuntu-20.04` (or `focal`)
-- `mcr.microsoft.com/devcontainers/base:ubuntu-18.04` (or `bionic`)
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/devcontainers/base:1-focal`
-- `mcr.microsoft.com/devcontainers/base:1.0-focal`
-- `mcr.microsoft.com/devcontainers/base:1.0.0-focal`
+- `mcr.microsoft.com/devcontainers/base:1-jammy`
+- `mcr.microsoft.com/devcontainers/base:1.0-jammy`
+- `mcr.microsoft.com/devcontainers/base:1.0.0-jammy`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/base/tags/list).
 

--- a/src/base-ubuntu/manifest.json
+++ b/src/base-ubuntu/manifest.json
@@ -2,8 +2,7 @@
 	"version": "1.0.12",
 	"variants": [
 		"jammy",
-		"focal",
-		"bionic"
+		"focal"
 	],
 	"build": {
 		"latest": false,
@@ -15,10 +14,6 @@
 			],
 			"focal": [
 				"linux/amd64"
-			],
-			"bionic": [
-				"linux/amd64",
-				"linux/arm64"
 			]
 		},
 		"tags": [
@@ -33,10 +28,6 @@
 			"focal": [
 				"base:${VERSION}-ubuntu-20.04",
 				"base:${VERSION}-ubuntu20.04"
-			],
-			"bionic": [
-				"base:${VERSION}-ubuntu-18.04",
-				"base:${VERSION}-ubuntu18.04"
 			]
 		}
 	},


### PR DESCRIPTION
Ref: https://github.com/devcontainers/images/issues/567

Referring to https://ubuntu.com/blog/18-04-end-of-standard-support, as Ubuntu 18.04 has reached EOSS, we are deprecating support for this image. 