### PR TITLE
[anaconda] Update `tornado` package due to CVE-2023-28370

### DIFF
--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -59,7 +59,9 @@ RUN python3 -m pip install \
     # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32862
     nbconvert \
     # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-32681
-    requests
+    requests \
+    # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-28370
+    tornado
 
 # Copy environment.yml (if found) to a temp location so we can update the environment. Also
 # copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.

--- a/src/anaconda/manifest.json
+++ b/src/anaconda/manifest.json
@@ -37,7 +37,8 @@
 			"py",
 			"pyOpenssl",
 			"werkzeug",
-			"requests"
+			"requests",
+			"tornado"
 		],
 		"other": {
 			"git": {},

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -42,6 +42,10 @@ checkPythonPackageVersion "werkzeug" "2.2.3"
 checkPythonPackageVersion "certifi" "2022.12.07"
 checkPythonPackageVersion "requests" "2.31.0"
 
+# The `tornado` package doesn't have the `__version__` attribute so we can use the `version` attribute.
+tornado_version=$(python -c "import tornado; print(tornado.version)")
+check-version-ge "tornado-requirement" "${tornado_version}" "6.3.2"
+
 check "conda-update-conda" bash -c "conda update -y conda"
 check "conda-install" bash -c "conda install -c conda-forge --yes tensorflow"
 check "conda-install" bash -c "conda install -c conda-forge --yes pytorch"


### PR DESCRIPTION
**Dev container name**: 

- anaconda

**Description**:

This PR addresses the CVE-2023-28370 vulnerability. The vulnerability comes from the `continuumio/anaconda3` image and is related to the `tornado` package.

*Changelog*:

- Updated Dockerfile to install the latest `tornado` package version;
- Added test to verify `tornado` minimum version (_Minimum package version set to `6.3.2` which fixes CVE-2023-28370_);
- Updated manifest to include info about the `tornado` package;

**Checklist**:

- [x] Checked that applied changes work as expected