### PR TITLE
[universal] Update Python 3.10 due to CVE-2022-40897

### DIFF
--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
         },
         "./local-features/nvs": "latest",
         "ghcr.io/devcontainers/features/python:1": {
-            "version": "3.10.11",
+            "version": "3.10.8",
             "additionalVersions": "3.9.16",
             "installJupyterlab": "true",
             "configureJupyterlabAllowOrigin": "*"
@@ -71,7 +71,8 @@
         },
         "./local-features/jekyll": "latest",
         "ghcr.io/devcontainers/features/oryx:1": "latest",
-        "./local-features/setup-user": "latest"
+        "./local-features/setup-user": "latest",
+        "./local-features/patch-python": "latest"
     },
     "overrideFeatureInstallOrder": [
         "ghcr.io/devcontainers/features/common-utils",
@@ -81,6 +82,7 @@
         "ghcr.io/devcontainers/features/node",
         "./local-features/nvs",
         "ghcr.io/devcontainers/features/python",
+        "./local-features/patch-python",
         "./local-features/machine-learning-packages",
         "ghcr.io/devcontainers/features/php",
         "ghcr.io/devcontainers/features/conda",

--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
         },
         "./local-features/nvs": "latest",
         "ghcr.io/devcontainers/features/python:1": {
-            "version": "3.10.4",
+            "version": "3.10.11",
             "additionalVersions": "3.9.16",
             "installJupyterlab": "true",
             "configureJupyterlabAllowOrigin": "*"

--- a/src/universal/.devcontainer/local-features/patch-python/devcontainer-feature.json
+++ b/src/universal/.devcontainer/local-features/patch-python/devcontainer-feature.json
@@ -1,0 +1,8 @@
+{
+    "id": "patch-python",
+    "name": "Patch Python Packages",
+    "install": {
+        "app": "",
+        "file": "install.sh"
+    }
+}

--- a/src/universal/.devcontainer/local-features/patch-python/install.sh
+++ b/src/universal/.devcontainer/local-features/patch-python/install.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+USERNAME=${USERNAME:-"codespace"}
+
+set -eux
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Ensure that login shells get the correct path if the user updated the PATH using ENV.
+rm -f /etc/profile.d/00-restore-env.sh
+echo "export PATH=${PATH//$(sh -lc 'echo $PATH')/\$PATH}" > /etc/profile.d/00-restore-env.sh
+chmod +x /etc/profile.d/00-restore-env.sh
+
+export DEBIAN_FRONTEND=noninteractive
+
+sudo_if() {
+    COMMAND="$*"
+    if [ "$(id -u)" -eq 0 ] && [ "$USERNAME" != "root" ]; then
+        su - "$USERNAME" -c "$COMMAND"
+    else
+        "$COMMAND"
+    fi
+}
+
+update_package() {
+    PYTHON_PATH=$1
+    PACKAGE=$2
+
+    sudo_if "$PYTHON_PATH -m pip uninstall --yes $PACKAGE"
+    sudo_if "$PYTHON_PATH -m pip install --user --upgrade --no-cache-dir $PACKAGE"
+}
+
+# Temporary: Upgrade python packages due to security vulnerabilities
+# They are installed by the base image (python) which does not have the patch.
+
+# https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40897
+update_package /usr/local/python/3.9.*/bin/python setuptools
+update_package /usr/local/python/3.10.*/bin/python setuptools
+
+# https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-32681
+update_package /usr/local/python/3.10.*/bin/python requests

--- a/src/universal/.devcontainer/local-features/setup-user/install.sh
+++ b/src/universal/.devcontainer/local-features/setup-user/install.sh
@@ -43,8 +43,6 @@ sudo_if() {
 
 # Temporary: Upgrade python packages due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40897
 # They are installed by the base image (python) which does not have the patch.
-sudo_if /usr/local/python/current/bin/python -m pip uninstall --yes setuptools
-sudo_if /usr/local/python/current/bin/python -m pip install --user --upgrade --no-cache-dir setuptools
 sudo_if /usr/local/python/3.9.*/bin/python -m pip uninstall --yes setuptools
 sudo_if /usr/local/python/3.9.*/bin/python -m pip install --user --upgrade --no-cache-dir setuptools
 

--- a/src/universal/.devcontainer/local-features/setup-user/install.sh
+++ b/src/universal/.devcontainer/local-features/setup-user/install.sh
@@ -41,13 +41,6 @@ sudo_if() {
     fi
 }
 
-# Temporary: Upgrade python packages due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40897
-# They are installed by the base image (python) which does not have the patch.
-sudo_if /usr/local/python/current/bin/python -m pip uninstall --yes setuptools
-sudo_if /usr/local/python/current/bin/python -m pip install --user --upgrade --no-cache-dir setuptools
-sudo_if /usr/local/python/3.9.*/bin/python -m pip uninstall --yes setuptools
-sudo_if /usr/local/python/3.9.*/bin/python -m pip install --user --upgrade --no-cache-dir setuptools
-
 # Enables the oryx tool to generate manifest-dir which is needed for running the postcreate tool
 DEBIAN_FLAVOR="focal-scm"
 mkdir -p /opt/oryx && echo "vso-focal" > /opt/oryx/.imagetype

--- a/src/universal/.devcontainer/local-features/setup-user/install.sh
+++ b/src/universal/.devcontainer/local-features/setup-user/install.sh
@@ -43,6 +43,8 @@ sudo_if() {
 
 # Temporary: Upgrade python packages due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40897
 # They are installed by the base image (python) which does not have the patch.
+sudo_if /usr/local/python/current/bin/python -m pip uninstall --yes setuptools
+sudo_if /usr/local/python/current/bin/python -m pip install --user --upgrade --no-cache-dir setuptools
 sudo_if /usr/local/python/3.9.*/bin/python -m pip uninstall --yes setuptools
 sudo_if /usr/local/python/3.9.*/bin/python -m pip install --user --upgrade --no-cache-dir setuptools
 


### PR DESCRIPTION
**Dev container name**: 

- universal

**Description**:

This PR addresses the CVE-2022-40897 vulnerability. The vulnerability related to the `setuptools` package comes with Python v3.10.4 distribution. The `setuptools` v58.1.0 package comes from the `site-packages` folder. The fix for [Python distribution](https://github.com/devcontainers/images/blob/7b95b63b206a22530757f2ea38bf9324d4b70e0a/src/universal/.devcontainer/local-features/setup-user/install.sh#L46-L47) was provided earlier. However, the `site-packages` folder still contains an older version of `setuptools`, so we need to update the Python distribution to address security checks alerts.

*Changelog*:

- Bumped Python version `3.10.4` -> `3.10.11`;
- Removed temp fix for `setuptools`;

**Checklist**:

- [x] Checked that applied changes work as expected