### PR TITLE
Prep release: v0.3.8

### DIFF
--- a/src/base-debian/README.md
+++ b/src/base-debian/README.md
@@ -30,9 +30,9 @@ Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/devcontainers/base:0-buster`
-- `mcr.microsoft.com/devcontainers/base:0.202-buster`
-- `mcr.microsoft.com/devcontainers/base:0.202.6-buster`
+- `mcr.microsoft.com/devcontainers/base:1-bookworm`
+- `mcr.microsoft.com/devcontainers/base:1.0-bookworm`
+- `mcr.microsoft.com/devcontainers/base:1.0.0-bookworm`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/base/tags/list).
 

--- a/src/base-debian/manifest.json
+++ b/src/base-debian/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.203.10",
+	"version": "1.0.0",
 	"variants": [
 		"bookworm",
 		"buster",


### PR DESCRIPTION
Changelog: 

- [Debian: Support debian 12 (bookworm)](https://github.com/devcontainers/images/commit/e90321f71d69348675c1b463b2e350b50ff6e960)
    - `mcr.microsoft.com/devcontainers/base:debian` now points to `bookworm` instead of `bullseye`
    - Indicated that a with a major version bump for this image (eg. `0-debian` to `1-debian`)
    - Folks who wish to continue using `bullseye` variant, can do so with `base:bullseye` instead of `base:debian`
- [Jekyll: Pins "sass-embedded" to unblock build failures](https://github.com/devcontainers/images/commit/754379c179d0f615eb7e744ab7d7419f90411631)