### PR TITLE
Jekyll: Pins "sass-embedded" to unblock build failures

### DIFF
--- a/src/jekyll/.devcontainer/Dockerfile
+++ b/src/jekyll/.devcontainer/Dockerfile
@@ -14,6 +14,9 @@ ENV LANG=en_US.UTF-8 \
 
 # Install bundler, latest jekyll, and github-pages for older jekyll
 RUN gem update --system
+
+# https://github.com/ntkme/sass-embedded-host-ruby/issues/130
+RUN gem install sass-embedded -v 1.62.1
 RUN gem install bundler jekyll github-pages
 
 RUN chown -R "vscode:rvm" "/usr/local/rvm/" \


### PR DESCRIPTION
Fixes jekyll build failures: https://github.com/devcontainers/images/actions/runs/5247340000
Ref: https://github.com/devcontainers/images/issues/602