### PR TITLE
Add prerelease for C# extension and minor spacing

### DIFF
--- a/src/dotnet/.devcontainer/devcontainer.json
+++ b/src/dotnet/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
         "ghcr.io/devcontainers/features/node:1": {
             "version": "none"
         },
-		"ghcr.io/devcontainers/features/git:1": {
+	"ghcr.io/devcontainers/features/git:1": {
             "version": "latest",
             "ppa": "false"
         }
@@ -25,7 +25,7 @@
 		"vscode": {
 			// Add the IDs of extensions you want installed when the container is created.
 			"extensions": [
-				"ms-dotnettools.csharp"
+				"ms-dotnettools.csharp@prerelease"
 			]
 		}
 	},


### PR DESCRIPTION
Part of https://github.com/devcontainers/templates/issues/164

To use the C# Dev Kit today, users need the pre-release version of the C# extension. I also fixed a small spacing inconsistency in the devcontainer.json.

@timheuer would love to know if you had any other thoughts/feedback on this image. Thanks!