### PR TITLE
PHP: Reverts 8.0-apache-bookworm

### DIFF
--- a/src/php/.devcontainer/Dockerfile
+++ b/src/php/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] PHP version (use -bullseye variants on local arm64/Apple Silicon): 8-apache-bookworm, 8.2-apache-bookworm, 8.1-apache-bookworm, 8.0-apache-bookworm, 8-apache-bullseye, 8.2-apache-bullseye, 8.1-apache-bullseye, 8.0-apache-bullseye, 8-apache-buster, 8.2-apache-buster, 8.1-apache-buster, 8.0-apache-buster
+# [Choice] PHP version (use -bullseye variants on local arm64/Apple Silicon): 8-apache-bookworm, 8.2-apache-bookworm, 8.1-apache-bookworm, 8-apache-bullseye, 8.2-apache-bullseye, 8.1-apache-bullseye, 8.0-apache-bullseye, 8-apache-buster, 8.2-apache-buster, 8.1-apache-buster, 8.0-apache-buster
 ARG VARIANT=8.2-apache-bookworm
 FROM php:${VARIANT}
 

--- a/src/php/README.md
+++ b/src/php/README.md
@@ -25,7 +25,7 @@ You can directly reference pre-built versions of `Dockerfile` by using the `imag
 - `mcr.microsoft.com/devcontainers/php:8` (or `8-bookworm`, `8-bullseye`, `8-buster` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/php:8.2` (or `8.2-bookworm`, `8.2-bullseye`, `8.2-buster` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/php:8.1` (or `8.1-bookworm`, `8.1-bullseye`, `8.1-buster` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/php:8.0` (or `8.0-bookworm`, `8.0-bullseye`, `8.0-buster` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/php:8.0` (or `8.0-bullseye`, `8.0-buster` to pin to an OS version)
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 

--- a/src/php/manifest.json
+++ b/src/php/manifest.json
@@ -3,7 +3,6 @@
 	"variants": [
 		"8.2-apache-bookworm",
 		"8.1-apache-bookworm",
-		"8.0-apache-bookworm",
 		"8.2-apache-bullseye",
 		"8.1-apache-bullseye",
 		"8.0-apache-bullseye",
@@ -20,10 +19,6 @@
 				"linux/arm64"
 			],
 			"8.1-apache-bookworm": [
-				"linux/amd64",
-				"linux/arm64"
-			],
-			"8.0-apache-bookworm": [
 				"linux/amd64",
 				"linux/arm64"
 			],
@@ -64,10 +59,6 @@
 				"php:${VERSION}-8.1",
 				"php:${VERSION}-8.1-bookworm"
 			],
-			"8.0-apache-bookworm": [
-				"php:${VERSION}-8.0",
-				"php:${VERSION}-8.0-bookworm"
-			],
 			"8.2-apache-bullseye": [
 				"php:${VERSION}-8-bullseye",
 				"php:${VERSION}-8.2-bullseye",
@@ -77,6 +68,7 @@
 				"php:${VERSION}-8.1-bullseye"
 			],
 			"8.0-apache-bullseye": [
+				"php:${VERSION}-8.0",
 				"php:${VERSION}-8.0-bullseye"
 			],
 			"8.2-apache-buster": [


### PR DESCRIPTION
Partial revert of https://github.com/devcontainers/images/pull/624
Ref: https://github.com/devcontainers/images/issues/615

Reason: Fixes https://github.com/devcontainers/images/actions/runs/5270368037/jobs/9554878342#step:5:562

`php:8.0-apache-bookworm` image does not exist yet, hence, the builds are failing. We would support it once it's live.