### PR TITLE
Update docs - Point to `.devcontainer` folder instead of the `Dockerfile` file

### DIFF
--- a/src/anaconda/README.md
+++ b/src/anaconda/README.md
@@ -34,7 +34,7 @@ You can decide how often you want updates by referencing a [semantic version](ht
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/anaconda/tags/list).
 
-Alternatively, you can use the contents of [.devcontainer](.devcontainer folder) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
+Alternatively, you can use the contents of [.devcontainer](.devcontainer) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
 ### Using Conda
 This dev container and its associated image includes [the `conda` package manager](https://aka.ms/vscode-remote/conda/about). Additional packages installed using Conda will be downloaded from Anaconda or another repository if you configure one. To reconfigure Conda in this container to access an alternative repository, please see information on [configuring Conda channels here](https://aka.ms/vscode-remote/conda/channel-setup).

--- a/src/anaconda/README.md
+++ b/src/anaconda/README.md
@@ -34,7 +34,7 @@ You can decide how often you want updates by referencing a [semantic version](ht
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/anaconda/tags/list).
 
-Alternatively, you can use the contents of `Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
+Alternatively, you can use the contents of [.devcontainer](.devcontainer folder) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
 ### Using Conda
 This dev container and its associated image includes [the `conda` package manager](https://aka.ms/vscode-remote/conda/about). Additional packages installed using Conda will be downloaded from Anaconda or another repository if you configure one. To reconfigure Conda in this container to access an alternative repository, please see information on [configuring Conda channels here](https://aka.ms/vscode-remote/conda/channel-setup).

--- a/src/base-debian/README.md
+++ b/src/base-debian/README.md
@@ -36,7 +36,7 @@ You can decide how often you want updates by referencing a [semantic version](ht
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/base/tags/list).
 
-Alternatively, you can use the contents of `Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
+Alternatively, you can use the contents of [.devcontainer](.devcontainer folder) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
 Beyond `git`, this image / `Dockerfile` includes `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, and a set of common dependencies for development.
 

--- a/src/base-debian/README.md
+++ b/src/base-debian/README.md
@@ -36,7 +36,7 @@ You can decide how often you want updates by referencing a [semantic version](ht
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/base/tags/list).
 
-Alternatively, you can use the contents of [.devcontainer](.devcontainer folder) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
+Alternatively, you can use the contents of [.devcontainer](.devcontainer) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
 Beyond `git`, this image / `Dockerfile` includes `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, and a set of common dependencies for development.
 

--- a/src/base-ubuntu/README.md
+++ b/src/base-ubuntu/README.md
@@ -35,7 +35,7 @@ You can decide how often you want updates by referencing a [semantic version](ht
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/base/tags/list).
 
-Alternatively, you can use the contents of the `Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
+Alternatively, you can use the contents of [.devcontainer](.devcontainer folder) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
 Beyond `git`, this image / `Dockerfile` includes `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, and a set of common dependencies for development.
 

--- a/src/base-ubuntu/README.md
+++ b/src/base-ubuntu/README.md
@@ -35,7 +35,7 @@ You can decide how often you want updates by referencing a [semantic version](ht
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/base/tags/list).
 
-Alternatively, you can use the contents of [.devcontainer](.devcontainer folder) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
+Alternatively, you can use the contents of [.devcontainer](.devcontainer) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
 Beyond `git`, this image / `Dockerfile` includes `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, and a set of common dependencies for development.
 

--- a/src/cpp/README.md
+++ b/src/cpp/README.md
@@ -42,7 +42,7 @@ However, we only do security patching on the latest [non-breaking, in support](h
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/cpp/tags/list).
 
-Alternatively, you can use the contents of `Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
+Alternatively, you can use the contents of [.devcontainer](.devcontainer folder) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
 Beyond `git`, this image / `Dockerfile` includes `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, a set of common dependencies for development, and [Vcpkg](https://github.com/microsoft/vcpkg) a cross-platform package manager for C++.
 

--- a/src/cpp/README.md
+++ b/src/cpp/README.md
@@ -42,7 +42,7 @@ However, we only do security patching on the latest [non-breaking, in support](h
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/cpp/tags/list).
 
-Alternatively, you can use the contents of [.devcontainer](.devcontainer folder) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
+Alternatively, you can use the contents of [.devcontainer](.devcontainer) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
 Beyond `git`, this image / `Dockerfile` includes `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, a set of common dependencies for development, and [Vcpkg](https://github.com/microsoft/vcpkg) a cross-platform package manager for C++.
 

--- a/src/dotnet/README.md
+++ b/src/dotnet/README.md
@@ -35,7 +35,7 @@ You can decide how often you want updates by referencing a [semantic version](ht
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/dotnet/tags/list).
 
-Alternatively, you can use the contents of `Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
+Alternatively, you can use the contents of [.devcontainer](.devcontainer folder) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
 ### Enabling HTTPS in ASP.NET using your own dev certificate
 

--- a/src/dotnet/README.md
+++ b/src/dotnet/README.md
@@ -35,7 +35,7 @@ You can decide how often you want updates by referencing a [semantic version](ht
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/dotnet/tags/list).
 
-Alternatively, you can use the contents of [.devcontainer](.devcontainer folder) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
+Alternatively, you can use the contents of [.devcontainer](.devcontainer) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
 ### Enabling HTTPS in ASP.NET using your own dev certificate
 

--- a/src/java-8/README.md
+++ b/src/java-8/README.md
@@ -37,7 +37,7 @@ However, we only do security patching on the latest [non-breaking, in support](h
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/java/tags/list).
 
-Alternatively, you can use the contents of [.devcontainer](.devcontainer folder) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
+Alternatively, you can use the contents of [.devcontainer](.devcontainer) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
 ### Installing Maven or Gradle
 

--- a/src/java-8/README.md
+++ b/src/java-8/README.md
@@ -37,7 +37,7 @@ However, we only do security patching on the latest [non-breaking, in support](h
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/java/tags/list).
 
-Alternatively, you can use the contents of `Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
+Alternatively, you can use the contents of [.devcontainer](.devcontainer folder) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
 ### Installing Maven or Gradle
 

--- a/src/java/README.md
+++ b/src/java/README.md
@@ -37,7 +37,7 @@ However, we only do security patching on the latest [non-breaking, in support](h
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/java/tags/list).
 
-Alternatively, you can use the contents of [.devcontainer](.devcontainer folder) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
+Alternatively, you can use the contents of [.devcontainer](.devcontainer) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
 ### Installing Maven or Gradle
 

--- a/src/java/README.md
+++ b/src/java/README.md
@@ -37,7 +37,7 @@ However, we only do security patching on the latest [non-breaking, in support](h
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/java/tags/list).
 
-Alternatively, you can use the contents of `Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
+Alternatively, you can use the contents of [.devcontainer](.devcontainer folder) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
 ### Installing Maven or Gradle
 

--- a/src/jekyll/README.md
+++ b/src/jekyll/README.md
@@ -44,7 +44,7 @@ However, we only do security patching on the latest [non-breaking, in support](h
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/jekyll/tags/list).
 
-Alternatively, you can use the contents of `Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
+Alternatively, you can use the contents of [.devcontainer](.devcontainer folder) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
 ### Installing Node.js
 

--- a/src/jekyll/README.md
+++ b/src/jekyll/README.md
@@ -44,7 +44,7 @@ However, we only do security patching on the latest [non-breaking, in support](h
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/jekyll/tags/list).
 
-Alternatively, you can use the contents of [.devcontainer](.devcontainer folder) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
+Alternatively, you can use the contents of [.devcontainer](.devcontainer) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
 ### Installing Node.js
 

--- a/src/miniconda/README.md
+++ b/src/miniconda/README.md
@@ -34,7 +34,7 @@ You can decide how often you want updates by referencing a [semantic version](ht
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/miniconda/tags/list).
 
-Alternatively, you can use the contents of `Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
+Alternatively, you can use the contents of [.devcontainer](.devcontainer folder) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
 ### Using Conda
 This dev container and its associated image includes [the `conda` package manager](https://aka.ms/vscode-remote/conda/about). Additional packages installed using Conda will be downloaded from Anaconda or another repository if you configure one. To reconfigure Conda in this container to access an alternative repository, please see information on [configuring Conda channels here](https://aka.ms/vscode-remote/conda/channel-setup).

--- a/src/miniconda/README.md
+++ b/src/miniconda/README.md
@@ -34,7 +34,7 @@ You can decide how often you want updates by referencing a [semantic version](ht
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/miniconda/tags/list).
 
-Alternatively, you can use the contents of [.devcontainer](.devcontainer folder) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
+Alternatively, you can use the contents of [.devcontainer](.devcontainer) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
 ### Using Conda
 This dev container and its associated image includes [the `conda` package manager](https://aka.ms/vscode-remote/conda/about). Additional packages installed using Conda will be downloaded from Anaconda or another repository if you configure one. To reconfigure Conda in this container to access an alternative repository, please see information on [configuring Conda channels here](https://aka.ms/vscode-remote/conda/channel-setup).

--- a/src/php/README.md
+++ b/src/php/README.md
@@ -39,7 +39,7 @@ However, we only do security patching on the latest [non-breaking, in support](h
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/php/tags/list).
 
-Alternatively, you can use the contents of `Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
+Alternatively, you can use the contents of [.devcontainer](.devcontainer folder) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
 ### Installing Node.js
 

--- a/src/php/README.md
+++ b/src/php/README.md
@@ -39,7 +39,7 @@ However, we only do security patching on the latest [non-breaking, in support](h
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/php/tags/list).
 
-Alternatively, you can use the contents of [.devcontainer](.devcontainer folder) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
+Alternatively, you can use the contents of [.devcontainer](.devcontainer) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
 ### Installing Node.js
 

--- a/src/python/README.md
+++ b/src/python/README.md
@@ -41,7 +41,7 @@ However, we only do security patching on the latest [non-breaking, in support](h
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/python/tags/list).
 
-Alternatively, you can use the contents of `Dockerfile` to fully customize the your container's contents or build for a container architecture the image does not support.
+Alternatively, you can use the contents of [.devcontainer](.devcontainer) to fully customize the your container's contents or build for a container architecture the image does not support.
 
 Beyond Python and `git`, this image / `Dockerfile` includes a number of Python tools, `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, and a set of common dependencies for development.
 

--- a/src/ruby/README.md
+++ b/src/ruby/README.md
@@ -39,7 +39,7 @@ However, we only do security patching on the latest [non-breaking, in support](h
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/ruby/tags/list).
 
-Alternatively, you can use the contents of `Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
+Alternatively, you can use the contents of [.devcontainer](.devcontainer folder) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
 ### Installing Node.js
 

--- a/src/ruby/README.md
+++ b/src/ruby/README.md
@@ -39,7 +39,7 @@ However, we only do security patching on the latest [non-breaking, in support](h
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/ruby/tags/list).
 
-Alternatively, you can use the contents of [.devcontainer](.devcontainer folder) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
+Alternatively, you can use the contents of [.devcontainer](.devcontainer) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
 ### Installing Node.js
 

--- a/src/rust/README.md
+++ b/src/rust/README.md
@@ -36,7 +36,7 @@ However, we only do security patching on the latest [non-breaking, in support](h
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/rust/tags/list).
 
-Alternatively, you can use the contents of [.devcontainer](.devcontainer folder) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
+Alternatively, you can use the contents of [.devcontainer](.devcontainer) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
 ## License
 

--- a/src/rust/README.md
+++ b/src/rust/README.md
@@ -36,7 +36,7 @@ However, we only do security patching on the latest [non-breaking, in support](h
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/rust/tags/list).
 
-Alternatively, you can use the contents of `Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
+Alternatively, you can use the contents of [.devcontainer](.devcontainer folder) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
 ## License
 

--- a/src/universal/README.md
+++ b/src/universal/README.md
@@ -49,7 +49,7 @@ While the image itself works unmodified, you can also directly reference pre-bui
 
 `mcr.microsoft.com/devcontainers/universal:2-linux`
 
-Alternatively, you can use the contents of the `Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
+Alternatively, you can use the contents of [.devcontainer](.devcontainer folder) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 

--- a/src/universal/README.md
+++ b/src/universal/README.md
@@ -49,7 +49,7 @@ While the image itself works unmodified, you can also directly reference pre-bui
 
 `mcr.microsoft.com/devcontainers/universal:2-linux`
 
-Alternatively, you can use the contents of [.devcontainer](.devcontainer folder) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
+Alternatively, you can use the contents of [.devcontainer](.devcontainer) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 


### PR DESCRIPTION
Ref: https://github.com/devcontainers/images/issues/653#issuecomment-1629823470