### PR TITLE
[anaconda] Update Conda packages due to GHSA-j8r2-6x86-q33q and GHSA-5cpq-8wj7-hf2v

### DIFF
--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/anaconda3 as upstream
+FROM continuumio/anaconda3:2023.03-1 as upstream
 
 # Verify OS version is expected one
 RUN . /etc/os-release && if [ "${VERSION_CODENAME}" != "bullseye" ]; then exit 1; fi
@@ -58,9 +58,7 @@ RUN python3 -m pip install \
     werkzeug \
     # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32862
     nbconvert \
-    # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-32681
-    requests \
-    # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-28370
+   # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-28370
     tornado
 
 # Copy environment.yml (if found) to a temp location so we can update the environment. Also

--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -74,6 +74,15 @@ RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then umask 0002 && /opt/conda/bi
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 #     && apt-get -y install --no-install-recommends <your-package-list-here>
 
+# Temporary: Upgrade python packages due to mentioned CVEs
+# They are installed by the base image (continuumio/anaconda3) which does not have the patch.
+RUN conda install \ 
+    # https://github.com/advisories/GHSA-5cpq-8wj7-hf2v
+    pyopenssl=23.2.0 \ 
+    cryptography=41.0.2 \
+    # https://github.com/advisories/GHSA-j8r2-6x86-q33q
+    requests=2.31.0
+
 # Create conda group, update conda directory permissions, 
 # add user to conda group
 # Note: We need to execute these commands after pip install / conda update 

--- a/src/anaconda/test-project/test-utils.sh
+++ b/src/anaconda/test-project/test-utils.sh
@@ -171,3 +171,11 @@ checkPythonPackageVersion()
     current_version=$(python -c "import ${PACKAGE}; print(${PACKAGE}.__version__)")
     check-version-ge "${PACKAGE}-requirement" "${current_version}" "${REQUIRED_VERSION}"
 }
+
+checkCondaPackageVersion()
+{
+    PACKAGE=$1
+    REQUIRED_VERSION=$2
+    current_version=$(conda list "${PACKAGE}" | grep -E "^${PACKAGE}\s" | awk '{print $2}')
+    check-version-ge "conda-${PACKAGE}-requirement" "${current_version}" "${REQUIRED_VERSION}"
+}

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -41,14 +41,19 @@ checkPythonPackageVersion "nbconvert" "6.5.1"
 checkPythonPackageVersion "werkzeug" "2.2.3"
 checkPythonPackageVersion "certifi" "2022.12.07"
 checkPythonPackageVersion "requests" "2.31.0"
+checkPythonPackageVersion "cryptography" "41.0.2"
 
 # The `tornado` package doesn't have the `__version__` attribute so we can use the `version` attribute.
 tornado_version=$(python -c "import tornado; print(tornado.version)")
 check-version-ge "tornado-requirement" "${tornado_version}" "6.3.2"
 
+checkCondaPackageVersion "pyopenssl" "23.2.0"
+checkCondaPackageVersion "cryptography" "41.0.2"
+checkCondaPackageVersion "requests" "2.31.0"
+
 check "conda-update-conda" bash -c "conda update -y conda"
-check "conda-install" bash -c "conda install -c conda-forge --yes tensorflow"
-check "conda-install" bash -c "conda install -c conda-forge --yes pytorch"
+check "conda-install-tensorflow" bash -c "conda install -c conda-forge --yes tensorflow"
+check "conda-install-pytorch" bash -c "conda install -c conda-forge --yes pytorch"
 
 # Report result
 reportResults


### PR DESCRIPTION
**Dev container name**: 

- miniconda

**Description**:

This PR addresses the GHSA-j8r2-6x86-q33q and GHSA-5cpq-8wj7-hf2v vulnerabilities. These vulnerabilities come from the `continuumio/anaconda3` image and are related to the `cryptography` and `requests` packages.

*Changelog*:

- Updated Dockerfile to install the updated versions of `pyopenssl`, `cryptography`, and `requests`;
- Added tests to verify the minimum version for the `pyopenssl` and `cryptography` packages:
  - `cryptography`: Minimum package version set to `41.0.2`, which fixes GHSA-5cpq-8wj7-hf2v;
  - `pyopenssl`:  Minimum package version set to `23.2.0` to be compatible with `cryptography` packages;
  - `requests`: Minimum package version set to `2.31.0`, which fixes GHSA-j8r2-6x86-q33q;
- Added tests to verify minimum package version via the `conda list` command.

**Checklist**:

- [x] Checked that applied changes work as expected