### PR TITLE
[miniconda] Update `requests` package due to GHSA-j8r2-6x86-q33q

### DIFF
--- a/src/miniconda/.devcontainer/Dockerfile
+++ b/src/miniconda/.devcontainer/Dockerfile
@@ -44,7 +44,9 @@ RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then umask 0002 && /opt/conda/bi
 RUN conda install \ 
     # https://github.com/pyca/cryptography/security/advisories/GHSA-5cpq-8wj7-hf2v
     pyopenssl=23.2.0 \ 
-    cryptography=41.0.2
+    cryptography=41.0.2 \
+    # https://github.com/advisories/GHSA-j8r2-6x86-q33q
+    requests=2.31.0
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/src/miniconda/test-project/test-utils.sh
+++ b/src/miniconda/test-project/test-utils.sh
@@ -177,6 +177,6 @@ checkCondaPackageVersion()
 {
     PACKAGE=$1
     REQUIRED_VERSION=$2
-    current_version=$(conda list "${PACKAGE}" | grep -w "${PACKAGE}" | awk '{print $2}')
+    current_version=$(conda list "${PACKAGE}" | grep -E "^${PACKAGE}\s" | awk '{print $2}')
     check-version-ge "conda-${PACKAGE}-requirement" "${current_version}" "${REQUIRED_VERSION}"
 }

--- a/src/miniconda/test-project/test.sh
+++ b/src/miniconda/test-project/test.sh
@@ -26,6 +26,7 @@ checkCondaPackageVersion "cryptography" "41.0.0"
 checkCondaPackageVersion "pyopenssl" "23.2.0"
 checkCondaPackageVersion "setuptools" "65.5.1"
 checkCondaPackageVersion "wheel" "0.38.1"
+checkCondaPackageVersion "requests" "2.31.0"
 
 check "conda-update-conda" bash -c "conda update -y conda"
 check "conda-install-tensorflow" bash -c "conda install -c conda-forge --yes tensorflow"


### PR DESCRIPTION
**Dev container name**: 

- miniconda

**Description**:

This PR addresses the GHSA-j8r2-6x86-q33q vulnerability. The vulnerability comes from the `continuumio/miniconda3` image and is related to the `requests` package.

*Changelog*:

- Updated Dockerfile to install the latest `requests` package version;
- Added test to verify `requests` minimum version (_Minimum package version set to `2.31.0` which fixes GHSA-j8r2-6x86-q33q_).

**Checklist**:

- [x] Checked that applied changes work as expected