### PR TITLE
Universal smoke-test workflow: Update runner

### DIFF
--- a/.github/workflows/smoke-universal.yaml
+++ b/.github/workflows/smoke-universal.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   smoke-test:
     name: Smoke test
-    runs-on: ubuntu-latest
+    runs-on: devcontainer-image-builder-ubuntu
     steps:
     - name: Checkout
       id: checkout


### PR DESCRIPTION
Fixes [You are running out of disk space. The runner will stop working when the machine runs out of disk space.](https://github.com/devcontainers/images/actions/runs/5681161966?pr=627) errors on action runs for the universal image (smoke test). 