### PR TITLE
[universal] Update npm due to GHSA-c2qf-rxjj-qqgw

### DIFF
--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
             "userGid": "1000"
         },
         "ghcr.io/devcontainers/features/dotnet:1": {
-            "version": "7",
+            "version": "7.0.306",
             "installUsingApt": "false",
             "additionalVersions": "6"
         },

--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
         },
         "./local-features/nvs": "latest",
         "ghcr.io/devcontainers/features/python:1": {
-            "version": "3.10.8",
+            "version": "3.10.12",
             "additionalVersions": "3.9.16",
             "installJupyterlab": "true",
             "configureJupyterlabAllowOrigin": "*"

--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
         },
         "./local-features/nvs": "latest",
         "ghcr.io/devcontainers/features/python:1": {
-            "version": "3.10.12",
+            "version": "3.10.8",
             "additionalVersions": "3.9.16",
             "installJupyterlab": "true",
             "configureJupyterlabAllowOrigin": "*"

--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -26,7 +26,8 @@
             "version": "3.10.8",
             "additionalVersions": "3.9.16",
             "installJupyterlab": "true",
-            "configureJupyterlabAllowOrigin": "*"
+            "configureJupyterlabAllowOrigin": "*",
+            "useOryxIfAvailable": "false",
         },
         "./local-features/machine-learning-packages": "latest",
         "ghcr.io/devcontainers/features/php:1": {

--- a/src/universal/.devcontainer/local-features/patch-python/install.sh
+++ b/src/universal/.devcontainer/local-features/patch-python/install.sh
@@ -42,6 +42,7 @@ update_package() {
 
 # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40897
 update_package /usr/local/python/3.9.*/bin/python setuptools==65.5.1
+update_package /usr/local/python/3.10.*/bin/python setuptools==68.0.0
 
 # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-32681
 update_package /usr/local/python/3.10.*/bin/python requests==2.31.0

--- a/src/universal/.devcontainer/local-features/patch-python/install.sh
+++ b/src/universal/.devcontainer/local-features/patch-python/install.sh
@@ -39,6 +39,8 @@ update_package() {
 
 # Temporary: Upgrade python packages due to security vulnerabilities
 # They are installed by the base image (python) which does not have the patch.
+ls -la /usr/local/python/3.9.16/lib/python3.9
+ls -la /usr/local/python/3.10.8/lib/python3.10
 
 # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40897
 update_package /usr/local/python/3.9.*/bin/python setuptools==65.5.1

--- a/src/universal/.devcontainer/local-features/patch-python/install.sh
+++ b/src/universal/.devcontainer/local-features/patch-python/install.sh
@@ -41,8 +41,7 @@ update_package() {
 # They are installed by the base image (python) which does not have the patch.
 
 # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40897
-update_package /usr/local/python/3.9.*/bin/python setuptools
-update_package /usr/local/python/3.10.*/bin/python setuptools
+update_package /usr/local/python/3.9.*/bin/python setuptools==65.5.1
 
 # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-32681
-update_package /usr/local/python/3.10.*/bin/python requests
+update_package /usr/local/python/3.10.*/bin/python requests==2.31.0

--- a/src/universal/.devcontainer/local-features/patch-python/install.sh
+++ b/src/universal/.devcontainer/local-features/patch-python/install.sh
@@ -37,8 +37,6 @@ update_package() {
     sudo_if "$PYTHON_PATH -m pip install --user --upgrade --no-cache-dir $PACKAGE"
 }
 
-sudo_if /usr/local/python/3.10.*/bin/python -m pip install --upgrade pip
-
 # Temporary: Upgrade python packages due to security vulnerabilities
 # They are installed by the base image (python) which does not have the patch.
 

--- a/src/universal/.devcontainer/local-features/patch-python/install.sh
+++ b/src/universal/.devcontainer/local-features/patch-python/install.sh
@@ -39,8 +39,6 @@ update_package() {
 
 # Temporary: Upgrade python packages due to security vulnerabilities
 # They are installed by the base image (python) which does not have the patch.
-ls -la /usr/local/python/3.9.16/lib/python3.9
-ls -la /usr/local/python/3.10.8/lib/python3.10
 
 # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40897
 update_package /usr/local/python/3.9.*/bin/python setuptools==65.5.1

--- a/src/universal/.devcontainer/local-features/patch-python/install.sh
+++ b/src/universal/.devcontainer/local-features/patch-python/install.sh
@@ -37,6 +37,8 @@ update_package() {
     sudo_if "$PYTHON_PATH -m pip install --user --upgrade --no-cache-dir $PACKAGE"
 }
 
+sudo_if /usr/local/python/3.10.*/bin/python -m pip install --upgrade pip
+
 # Temporary: Upgrade python packages due to security vulnerabilities
 # They are installed by the base image (python) which does not have the patch.
 

--- a/src/universal/.devcontainer/local-features/setup-user/install.sh
+++ b/src/universal/.devcontainer/local-features/setup-user/install.sh
@@ -97,4 +97,10 @@ find "${OPT_DIR}" -type d | xargs -n 1 chmod g+s
 
 echo "Defaults secure_path=\"${DOTNET_PATH}:${NODE_PATH}/bin:${PHP_PATH}/bin:${PYTHON_PATH}/bin:${JAVA_PATH}/bin:${RUBY_PATH}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:/usr/local/share:/home/${USERNAME}/.local/bin:${PATH}\"" >> /etc/sudoers.d/$USERNAME
 
+# Temporary: Due to GHSA-c2qf-rxjj-qqgw
+source "${NVM_DIR}/nvm.sh"
+nvm use 18
+npm -g install -g npm@9.8.1
+nvm use stable
+
 echo "Done!"

--- a/src/universal/.devcontainer/local-features/setup-user/install.sh
+++ b/src/universal/.devcontainer/local-features/setup-user/install.sh
@@ -98,9 +98,8 @@ find "${OPT_DIR}" -type d | xargs -n 1 chmod g+s
 echo "Defaults secure_path=\"${DOTNET_PATH}:${NODE_PATH}/bin:${PHP_PATH}/bin:${PYTHON_PATH}/bin:${JAVA_PATH}/bin:${RUBY_PATH}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:/usr/local/share:/home/${USERNAME}/.local/bin:${PATH}\"" >> /etc/sudoers.d/$USERNAME
 
 # Temporary: Due to GHSA-c2qf-rxjj-qqgw
-source "${NVM_DIR}/nvm.sh"
-nvm use 18
-npm -g install -g npm@9.8.1
-nvm use stable
+bash -c ". /usr/local/share/nvm/nvm.sh && nvm use 18"
+bash -c "npm -g install -g npm@9.8.1"
+bash -c ". /usr/local/share/nvm/nvm.sh && nvm use stable"
 
 echo "Done!"

--- a/src/universal/manifest.json
+++ b/src/universal/manifest.json
@@ -117,7 +117,7 @@
 			"torch",
 			"requests",
 			"plotly",
-			"jupyterlab-git",
+			"jupyterlab_git",
 			"certifi",
 			"setuptools",
 			"wheel"

--- a/src/universal/test-project/test-utils.sh
+++ b/src/universal/test-project/test-utils.sh
@@ -235,3 +235,18 @@ checkCondaPackageVersion()
     current_version=$(conda list "${PACKAGE}" | grep -E "^${PACKAGE}\s" | awk '{print $2}')
     check-version-ge "conda-${PACKAGE}-requirement" "${current_version}" "${REQUIRED_VERSION}"
 }
+
+checkBundledNpmVersion()
+{
+    NODE_VERSION=$1
+    REQUIRED_NPM_VERSION=$2
+    bash -c ". /usr/local/share/nvm/nvm.sh && nvm use ${NODE_VERSION}"
+
+    current_npm_version=$(npm --version)
+
+    if [[ "$NODE_VERSION" != "default" ]]; then
+      bash -c ". /usr/local/share/nvm/nvm.sh && nvm use default"
+    fi
+    
+    check-version-ge "node-${NODE_VERSION}-requirement" "${current_npm_version}" "${REQUIRED_NPM_VERSION}"
+}

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -95,6 +95,8 @@ count=$(ls /usr/local/share/nvm/versions/node | wc -l)
 expectedCount=2
 checkVersionCount "two versions of node are present" $count $expectedCount
 echo $(echo "node versions" && ls -a /usr/local/share/nvm/versions/node)
+npm_version=$(npm --version)
+check-version-ge "npm-requirement" "${npm_version}" "9.8.1"
 
 # PHP
 check "php" php --version

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -95,8 +95,8 @@ count=$(ls /usr/local/share/nvm/versions/node | wc -l)
 expectedCount=2
 checkVersionCount "two versions of node are present" $count $expectedCount
 echo $(echo "node versions" && ls -a /usr/local/share/nvm/versions/node)
-npm_version=$(npm --version)
-check-version-ge "npm-requirement" "${npm_version}" "9.8.0"
+checkBundledNpmVersion "default" "9.8.0"
+checkBundledNpmVersion "18" "9.8.1"
 
 # PHP
 check "php" php --version

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -53,7 +53,7 @@ check "seaborn" python -c "import seaborn; print(seaborn.__version__)"
 check "scikit-learn" python -c "import sklearn; print(sklearn.__version__)"
 check "torch" python -c "import torch; print(torch.__version__)"
 check "requests" python -c "import requests; print(requests.__version__)"
-check "jupyterlab-git" bash -c "python3 -m pip list | grep jupyterlab-git"
+check "jupyterlab-git" python -c "import jupyterlab_git; print(jupyterlab_git.__version__)"
 
 # Check JupyterLab
 check "jupyter-lab" jupyter-lab --version
@@ -96,7 +96,7 @@ expectedCount=2
 checkVersionCount "two versions of node are present" $count $expectedCount
 echo $(echo "node versions" && ls -a /usr/local/share/nvm/versions/node)
 npm_version=$(npm --version)
-check-version-ge "npm-requirement" "${npm_version}" "9.8.1"
+check-version-ge "npm-requirement" "${npm_version}" "9.8.0"
 
 # PHP
 check "php" php --version


### PR DESCRIPTION
**Dev container name**: 

- universal

**Description**:

This PR addresses the GHSA-c2qf-rxjj-qqgw vulnerability. The vulnerability is related to the `smever` package. This package is a dependency for `npm` shipped with Node v18.17.0.

*Changelog*:

- Bumped npm to the `9.8.1` version;
- Added test to verify npm version;

*Other changes*:

- Locked the `dotnet` version to resolve the issue with Oryx;
- The `patch-python` feature updated:
  - Removed the `setuptools` patch for Python 3.10 since not required anymore;
  - Locked versions for packages;


**Checklist**:

- [x] Checked that applied changes work as expected











