### PR TITLE
[Go] Adds 1.21 ; EOL 1.19 ; EOL buster variants

### DIFF
--- a/src/go/.devcontainer/Dockerfile
+++ b/src/go/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Go version (use -bookworm, or -bullseye variants on local arm64/Apple Silicon): 1, 1.20, 1.19, 1-bookworm, 1.20-bookworm, 1.19-bookworm, 1-bullseye, 1.20-bullseye, 1.19-bullseye, 1-buster, 1.20-buster, 1.19-buster
+# [Choice] Go version (use -bookworm, or -bullseye variants on local arm64/Apple Silicon): 1, 1.21, 1.20, 1-bookworm, 1.21-bookworm, 1.20-bookworm, 1-bullseye, 1.21-bullseye, 1.20-bullseye
 ARG VARIANT=1.20-bookworm
 FROM golang:${VARIANT}
 

--- a/src/go/.devcontainer/Dockerfile
+++ b/src/go/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # [Choice] Go version (use -bookworm, or -bullseye variants on local arm64/Apple Silicon): 1, 1.21, 1.20, 1-bookworm, 1.21-bookworm, 1.20-bookworm, 1-bullseye, 1.21-bullseye, 1.20-bullseye
-ARG VARIANT=1.20-bookworm
+ARG VARIANT=1.21-bookworm
 FROM golang:${VARIANT}
 
 # [Optional] Uncomment the next line to use go get to install anything else you need

--- a/src/go/README.md
+++ b/src/go/README.md
@@ -10,7 +10,7 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/go |
-| *Available image variants* | 1 / 1-bookworm, 1.20 / 1.20-bookworm, 1.19 / 1.19-bookworm, 1-bullseye, 1.20-bullseye, 1.19-bullseye, 1-buster, 1.20-buster, 1.19-buster ([full list](https://mcr.microsoft.com/v2/devcontainers/go/tags/list)) |
+| *Available image variants* | 1 / 1-bookworm, 1.21 / 1.21-bookworm, 1.20 / 1.20-bookworm, 1-bullseye, 1.21-bullseye, 1.20-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/go/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bookworm`, and `bullseye` variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -23,19 +23,19 @@ See **[history](history)** for information on the contents of published images.
 You can directly reference pre-built versions of `Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
 
 - `mcr.microsoft.com/devcontainers/go` (latest)
-- `mcr.microsoft.com/devcontainers/go:1` (or `1-bookworm`, `1-bullseye`, `1-buster` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/go:1.20` (or `1.20-bookworm`, `1.20-bullseye`, `1.20-buster` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/go:1.19` (or `1.19-bookworm`, `1.19-bullseye`, `1.19-buster` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/go:1` (or `1-bookworm`, `1-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/go:1.21` (or `1.21-bookworm`, `1.21-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/go:1.20` (or `1.20-bookworm`, `1.20-bullseye` to pin to an OS version)
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/devcontainers/go:1-1.20` (or `1-1.20-bullseye`, `1-1.20-buster`)
-- `mcr.microsoft.com/devcontainers/go:1.0-1.20` (or `1.0-1.20-bullseye`, `1.0-1.20-buster`)
-- `mcr.microsoft.com/devcontainers/go:1.0.0-1.20` (or `1.0.0-1.20-bullseye`, `1.0.0-1.20-buster`)
+- `mcr.microsoft.com/devcontainers/go:1-1.21` (or `1-1.21-bookworm`, `1-1.21-bullseye`)
+- `mcr.microsoft.com/devcontainers/go:1.1-1.21` (or `1.1-1.21-bookworm`, `1.1-1.21-bullseye`)
+- `mcr.microsoft.com/devcontainers/go:1.1.0-1.21` (or `1.1.0-1.21-bookworm`, `1.1.0-1.21-bullseye`)
 
-However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `1-1.20`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
+However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `1-1.21`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/go/tags/list).
 

--- a/src/go/manifest.json
+++ b/src/go/manifest.json
@@ -1,60 +1,48 @@
 {
   "version": "1.0.2",
   "variants": [
+		"1.21-bookworm",
 		"1.20-bookworm",
-    "1.20-bullseye",
-    "1.20-buster",
-		"1.19-bookworm",
-    "1.19-bullseye",
-    "1.19-buster"
+		"1.21-bullseye",
+    "1.20-bullseye"
   ],
   "build": {
-    "latest": "1.20-bookworm",
+    "latest": "1.21-bookworm",
     "rootDistro": "debian",
     "tags": [
       "go:${VERSION}-${VARIANT}"
     ],
     "architectures": {
+			"1.21-bookworm": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
 			"1.20-bookworm": [
         "linux/amd64",
         "linux/arm64"
       ],
-      "1.19-bookworm": [
+      "1.21-bullseye": [
         "linux/amd64",
         "linux/arm64"
       ],
       "1.20-bullseye": [
         "linux/amd64",
         "linux/arm64"
-      ],
-      "1.19-bullseye": [
-        "linux/amd64",
-        "linux/arm64"
-      ],
-      "1.20-buster": [
-        "linux/amd64"
-      ],
-      "1.19-buster": [
-        "linux/amd64"
       ]
     },
     "variantTags": {
-      "1.20-bookworm": [
+			"1.21-bookworm": [
         "go:${VERSION}-1.20",
         "go:${VERSION}-1",
         "go:${VERSION}-1-bookworm",
         "go:${VERSION}-bookworm"
       ],
-			"1.20-bullseye": [
+			"1.21-bullseye": [
         "go:${VERSION}-1-bullseye",
         "go:${VERSION}-bullseye"
       ],
-      "1.20-buster": [
-        "go:${VERSION}-1-buster",
-        "go:${VERSION}-buster"
-      ],
-      "1.19-bookworm": [
-        "go:${VERSION}-1.19"
+      "1.20-bookworm": [
+        "go:${VERSION}-1.20"
       ]
     }
   },


### PR DESCRIPTION
Ref: https://github.com/devcontainers/images/issues/697 and https://github.com/devcontainers/images/issues/698

- Adds support for 1.21. See https://go.dev/blog/go1.21
- Deprecates support for 1.19. See https://github.com/docker-library/golang/pull/479
- Deprecates support for buster variants. See https://github.com/docker-library/golang/pull/456