### PR TITLE
[anaconda] Update Conda packages due to GHSA-45c4-8wx5-qw6w, GHSA-f865-m6cq-j9vx

### DIFF
--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -5,6 +5,15 @@ RUN . /etc/os-release && if [ "${VERSION_CODENAME}" != "bullseye" ]; then exit 1
 
 # Temporary: Upgrade python packages due to mentioned CVEs
 # They are installed by the base image (continuumio/anaconda3) which does not have the patch.
+RUN conda install \ 
+    # https://github.com/advisories/GHSA-5cpq-8wj7-hf2v
+    pyopenssl=23.2.0 \ 
+    cryptography=41.0.2 \
+    # https://github.com/advisories/GHSA-j8r2-6x86-q33q
+    requests=2.31.0 \
+    # https://github.com/advisories/GHSA-f865-m6cq-j9vx
+    mpmath==1.3.0
+
 RUN python3 -m pip install --upgrade \
     # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-21797
     joblib==1.3.1 \
@@ -21,14 +30,9 @@ RUN python3 -m pip install --upgrade \
     # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-28370
     tornado==6.3.2 \
     # https://github.com/advisories/GHSA-282v-666c-3fvg
-    transformers==4.30.0
-
-RUN conda install \ 
-    # https://github.com/advisories/GHSA-5cpq-8wj7-hf2v
-    pyopenssl=23.2.0 \ 
-    cryptography=41.0.2 \
-    # https://github.com/advisories/GHSA-j8r2-6x86-q33q
-    requests=2.31.0
+    transformers==4.30.0 \
+    # https://github.com/advisories/GHSA-45c4-8wx5-qw6w
+    aiohttp==3.8.5
 
 # Reset and copy updated files with updated privs to keep image size down
 FROM mcr.microsoft.com/devcontainers/base:1-bullseye

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -44,6 +44,8 @@ checkPythonPackageVersion "requests" "2.31.0"
 checkPythonPackageVersion "cryptography" "41.0.2"
 checkPythonPackageVersion "torch" "1.13.1"
 checkPythonPackageVersion "transformers" "4.30.0"
+checkPythonPackageVersion "mpmath" "1.3.0"
+checkPythonPackageVersion "aiohttp" "3.8.5"
 
 # The `tornado` package doesn't have the `__version__` attribute so we can use the `version` attribute.
 tornado_version=$(python -c "import tornado; print(tornado.version)")
@@ -53,6 +55,8 @@ checkCondaPackageVersion "pyopenssl" "23.2.0"
 checkCondaPackageVersion "cryptography" "41.0.2"
 checkCondaPackageVersion "requests" "2.31.0"
 checkCondaPackageVersion "pygments" "2.15.1"
+checkCondaPackageVersion "mpmath" "1.3.0"
+checkCondaPackageVersion "aiohttp" "3.8.5"
 
 check "conda-update-conda" bash -c "conda update -y conda"
 check "conda-install-tensorflow" bash -c "conda create --name test-env -c conda-forge --yes tensorflow"


### PR DESCRIPTION
**Dev container name**: 

- anaconda

**Description**:

This PR patches the following vulnerabilities:

- GHSA-45c4-8wx5-qw6w - related to the `aiohttp` package;
- GHSA-f865-m6cq-j9vx - related to the `mpmath` package;

These vulnerabilities come from the `continuumio/anaconda3` image used upstream for the anaconda devcontainer.

*Changelog*:

- Updated Dockerfile:
  - Steps in Dockerfile were reorganized to avoid conflicts in Conda's base environment;
  - Added patch to install updated versions of `aiohttp` and `mpmath` packages;

- Added tests to verify minimum versions of the following packages:
  - `aiohttp` - _minimum package version set to `3.8.5`_;
  - `mpmath` - _minimum package version set to `1.3.0`_;

**Checklist**:

- [x] Checked that applied changes work as expected