### PR TITLE
[anaconda / miniconda] Temporary disable patch for `cryptography` due to issue with `conda`

### DIFF
--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -8,7 +8,7 @@ RUN . /etc/os-release && if [ "${VERSION_CODENAME}" != "bullseye" ]; then exit 1
 RUN conda install \ 
     # https://github.com/advisories/GHSA-5cpq-8wj7-hf2v
     pyopenssl=23.2.0 \ 
-    # cryptography=41.0.2 \
+    # cryptography=41.0.2 # Disabled temporarily due to issue with conda \
     # https://github.com/advisories/GHSA-j8r2-6x86-q33q
     requests=2.31.0 \
     # https://github.com/advisories/GHSA-f865-m6cq-j9vx

--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -8,7 +8,7 @@ RUN . /etc/os-release && if [ "${VERSION_CODENAME}" != "bullseye" ]; then exit 1
 RUN conda install \ 
     # https://github.com/advisories/GHSA-5cpq-8wj7-hf2v
     pyopenssl=23.2.0 \ 
-    cryptography=41.0.2 \
+    # cryptography=41.0.2 \
     # https://github.com/advisories/GHSA-j8r2-6x86-q33q
     requests=2.31.0 \
     # https://github.com/advisories/GHSA-f865-m6cq-j9vx

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -31,7 +31,6 @@ check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
 checkPythonPackageVersion "joblib" "1.2.0"
 checkPythonPackageVersion "cookiecutter" "2.1.1"
-checkPythonPackageVersion "cryptography" "38.0.3"
 checkPythonPackageVersion "mistune" "2.0.3"
 checkPythonPackageVersion "numpy" "1.22"
 checkPythonPackageVersion "setuptools" "65.5.1"
@@ -41,7 +40,7 @@ checkPythonPackageVersion "nbconvert" "6.5.1"
 checkPythonPackageVersion "werkzeug" "2.2.3"
 checkPythonPackageVersion "certifi" "2022.12.07"
 checkPythonPackageVersion "requests" "2.31.0"
-checkPythonPackageVersion "cryptography" "41.0.2"
+# checkPythonPackageVersion "cryptography" "41.0.2" # Disabled temporarily due to issue with conda
 checkPythonPackageVersion "torch" "1.13.1"
 checkPythonPackageVersion "transformers" "4.30.0"
 checkPythonPackageVersion "mpmath" "1.3.0"
@@ -52,7 +51,7 @@ tornado_version=$(python -c "import tornado; print(tornado.version)")
 check-version-ge "tornado-requirement" "${tornado_version}" "6.3.2"
 
 checkCondaPackageVersion "pyopenssl" "23.2.0"
-checkCondaPackageVersion "cryptography" "41.0.2"
+# checkCondaPackageVersion "cryptography" "41.0.2" # Disabled temporarily due to issue with conda
 checkCondaPackageVersion "requests" "2.31.0"
 checkCondaPackageVersion "pygments" "2.15.1"
 checkCondaPackageVersion "mpmath" "1.3.0"

--- a/src/miniconda/.devcontainer/Dockerfile
+++ b/src/miniconda/.devcontainer/Dockerfile
@@ -44,7 +44,7 @@ RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then umask 0002 && /opt/conda/bi
 RUN conda install \ 
     # https://github.com/pyca/cryptography/security/advisories/GHSA-5cpq-8wj7-hf2v
     pyopenssl=23.2.0 \ 
-    # cryptography=41.0.2 \
+    # cryptography=41.0.2 # Disabled temporarily due to issue with conda \
     # https://github.com/advisories/GHSA-j8r2-6x86-q33q
     requests=2.31.0
 

--- a/src/miniconda/.devcontainer/Dockerfile
+++ b/src/miniconda/.devcontainer/Dockerfile
@@ -44,7 +44,7 @@ RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then umask 0002 && /opt/conda/bi
 RUN conda install \ 
     # https://github.com/pyca/cryptography/security/advisories/GHSA-5cpq-8wj7-hf2v
     pyopenssl=23.2.0 \ 
-    cryptography=41.0.2 \
+    # cryptography=41.0.2 \
     # https://github.com/advisories/GHSA-j8r2-6x86-q33q
     requests=2.31.0
 

--- a/src/miniconda/test-project/test.sh
+++ b/src/miniconda/test-project/test.sh
@@ -18,11 +18,11 @@ check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcont
 
 check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
-checkPythonPackageVersion "cryptography" "41.0.0"
+# checkPythonPackageVersion "cryptography" "41.0.0" # Disabled temporarily due to issue with conda
 checkPythonPackageVersion "setuptools" "65.5.1"
 checkPythonPackageVersion "wheel" "0.38.1"
 
-checkCondaPackageVersion "cryptography" "41.0.0"
+# checkCondaPackageVersion "cryptography" "41.0.0" # Disabled temporarily due to issue with conda
 checkCondaPackageVersion "pyopenssl" "23.2.0"
 checkCondaPackageVersion "setuptools" "65.5.1"
 checkCondaPackageVersion "wheel" "0.38.1"


### PR DESCRIPTION
**Dev container name**: 

- anaconda
- miniconda

**Description**:

Since yesterday, the build for anaconda and miniconda devcontainers failed. The issue related to the installation of `cryptography v41.0.2` via the `conda install` command. For some reason, it's caused a conflict that Conda cannot resolve. This patch can be removed as a temporary solution to unblock the release process.

*Changelog*:

anaconda:
  - temporary disable patch for `cryptography`

miniconda:
  - temporary disable patch for `cryptography`

**Checklist**:

- [ ] Checked that applied changes work as expected