### PR TITLE
Update tornado version up to 6.3.3

### DIFF
--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -27,8 +27,8 @@ RUN python3 -m pip install --upgrade \
     werkzeug==2.3.6 \
     # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32862
     nbconvert==7.7.3 \
-    # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-28370
-    tornado==6.3.2 \
+    # https://github.com/advisories/GHSA-qppv-j76h-2rpx
+    tornado==6.3.3 \
     # https://github.com/advisories/GHSA-282v-666c-3fvg
     transformers==4.30.0 \
     # https://github.com/advisories/GHSA-45c4-8wx5-qw6w

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -48,7 +48,7 @@ checkPythonPackageVersion "aiohttp" "3.8.5"
 
 # The `tornado` package doesn't have the `__version__` attribute so we can use the `version` attribute.
 tornado_version=$(python -c "import tornado; print(tornado.version)")
-check-version-ge "tornado-requirement" "${tornado_version}" "6.3.2"
+check-version-ge "tornado-requirement" "${tornado_version}" "6.3.3"
 
 checkCondaPackageVersion "pyopenssl" "23.2.0"
 # checkCondaPackageVersion "cryptography" "41.0.2" # Disabled temporarily due to issue with conda


### PR DESCRIPTION
Update tornado version up to 6.3.3 due to https://github.com/advisories/GHSA-qppv-j76h-2rpx