### PR TITLE
v0.3.18

### DIFF
--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -61,7 +61,8 @@
         "ghcr.io/devcontainers/features/github-cli:1": {
             "version": "latest"
         },
-        "ghcr.io/devcontainers/features/docker-in-docker:2": {
+		// Temporarily pinning until we investigate issue with docker start
+        "ghcr.io/devcontainers/features/docker-in-docker:2.3.1": {
             "version": "latest"
         },
         "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {

--- a/src/universal/manifest.json
+++ b/src/universal/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.5.2",
+	"version": "2.5.3",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",


### PR DESCRIPTION
- [Universal] Temporarily pin `docker-in-docker` Feature to v2.3.1. Opened https://github.com/devcontainers/images/issues/729