### PR TITLE
[anaconda] Update patches for `GHSA-5cpq-8wj7-hf2v` and `GHSA-45c4-8wx5-qw6w`

### DIFF
--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -8,11 +8,13 @@ RUN . /etc/os-release && if [ "${VERSION_CODENAME}" != "bullseye" ]; then exit 1
 RUN conda install \ 
     # https://github.com/advisories/GHSA-5cpq-8wj7-hf2v
     pyopenssl=23.2.0 \ 
-    # cryptography=41.0.2 # Disabled temporarily due to issue with conda \
+    cryptography=41.0.2 \
     # https://github.com/advisories/GHSA-j8r2-6x86-q33q
     requests=2.31.0 \
     # https://github.com/advisories/GHSA-f865-m6cq-j9vx
-    mpmath==1.3.0
+    mpmath=1.3.0 \
+    # https://github.com/advisories/GHSA-45c4-8wx5-qw6w
+    aiohttp=3.8.5
 
 RUN python3 -m pip install --upgrade \
     # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-21797
@@ -30,9 +32,7 @@ RUN python3 -m pip install --upgrade \
     # https://github.com/advisories/GHSA-qppv-j76h-2rpx
     tornado==6.3.3 \
     # https://github.com/advisories/GHSA-282v-666c-3fvg
-    transformers==4.30.0 \
-    # https://github.com/advisories/GHSA-45c4-8wx5-qw6w
-    aiohttp==3.8.5
+    transformers==4.30.0
 
 # Reset and copy updated files with updated privs to keep image size down
 FROM mcr.microsoft.com/devcontainers/base:1-bullseye

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -40,7 +40,7 @@ checkPythonPackageVersion "nbconvert" "6.5.1"
 checkPythonPackageVersion "werkzeug" "2.2.3"
 checkPythonPackageVersion "certifi" "2022.12.07"
 checkPythonPackageVersion "requests" "2.31.0"
-# checkPythonPackageVersion "cryptography" "41.0.2" # Disabled temporarily due to issue with conda
+checkPythonPackageVersion "cryptography" "41.0.2" # Disabled temporarily due to issue with conda
 checkPythonPackageVersion "torch" "1.13.1"
 checkPythonPackageVersion "transformers" "4.30.0"
 checkPythonPackageVersion "mpmath" "1.3.0"
@@ -51,7 +51,7 @@ tornado_version=$(python -c "import tornado; print(tornado.version)")
 check-version-ge "tornado-requirement" "${tornado_version}" "6.3.3"
 
 checkCondaPackageVersion "pyopenssl" "23.2.0"
-# checkCondaPackageVersion "cryptography" "41.0.2" # Disabled temporarily due to issue with conda
+checkCondaPackageVersion "cryptography" "41.0.2" # Disabled temporarily due to issue with conda
 checkCondaPackageVersion "requests" "2.31.0"
 checkCondaPackageVersion "pygments" "2.15.1"
 checkCondaPackageVersion "mpmath" "1.3.0"

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -40,7 +40,7 @@ checkPythonPackageVersion "nbconvert" "6.5.1"
 checkPythonPackageVersion "werkzeug" "2.2.3"
 checkPythonPackageVersion "certifi" "2022.12.07"
 checkPythonPackageVersion "requests" "2.31.0"
-checkPythonPackageVersion "cryptography" "41.0.2" # Disabled temporarily due to issue with conda
+checkPythonPackageVersion "cryptography" "41.0.2"
 checkPythonPackageVersion "torch" "1.13.1"
 checkPythonPackageVersion "transformers" "4.30.0"
 checkPythonPackageVersion "mpmath" "1.3.0"
@@ -51,7 +51,7 @@ tornado_version=$(python -c "import tornado; print(tornado.version)")
 check-version-ge "tornado-requirement" "${tornado_version}" "6.3.3"
 
 checkCondaPackageVersion "pyopenssl" "23.2.0"
-checkCondaPackageVersion "cryptography" "41.0.2" # Disabled temporarily due to issue with conda
+checkCondaPackageVersion "cryptography" "41.0.2"
 checkCondaPackageVersion "requests" "2.31.0"
 checkCondaPackageVersion "pygments" "2.15.1"
 checkCondaPackageVersion "mpmath" "1.3.0"


### PR DESCRIPTION
**Dev container name**: 

- anaconda

**Description**:

This PR reverts changes from #715 since the issue with the installation of `cryptography` was resolved.

*Changelog*:

- Enabled patch for GHSA-5cpq-8wj7-hf2v;
- Reworked patch for GHSA-45c4-8wx5-qw6w to install package from conda repo;
- Enabled related tests;

**Checklist**:

- [x] Checked that applied changes work as expected
