### PR TITLE
[miniconda] Enable patch for `GHSA-5cpq-8wj7-hf2v`

### DIFF
--- a/src/miniconda/.devcontainer/Dockerfile
+++ b/src/miniconda/.devcontainer/Dockerfile
@@ -44,7 +44,7 @@ RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then umask 0002 && /opt/conda/bi
 RUN conda install \ 
     # https://github.com/pyca/cryptography/security/advisories/GHSA-5cpq-8wj7-hf2v
     pyopenssl=23.2.0 \ 
-    # cryptography=41.0.2 # Disabled temporarily due to issue with conda \
+    cryptography=41.0.2 \
     # https://github.com/advisories/GHSA-j8r2-6x86-q33q
     requests=2.31.0
 

--- a/src/miniconda/test-project/test.sh
+++ b/src/miniconda/test-project/test.sh
@@ -18,11 +18,11 @@ check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcont
 
 check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
-checkPythonPackageVersion "cryptography" "41.0.0" # Disabled temporarily due to issue with conda
+checkPythonPackageVersion "cryptography" "41.0.2"
 checkPythonPackageVersion "setuptools" "65.5.1"
 checkPythonPackageVersion "wheel" "0.38.1"
 
-checkCondaPackageVersion "cryptography" "41.0.0" # Disabled temporarily due to issue with conda
+checkCondaPackageVersion "cryptography" "41.0.2"
 checkCondaPackageVersion "pyopenssl" "23.2.0"
 checkCondaPackageVersion "setuptools" "65.5.1"
 checkCondaPackageVersion "wheel" "0.38.1"

--- a/src/miniconda/test-project/test.sh
+++ b/src/miniconda/test-project/test.sh
@@ -18,11 +18,11 @@ check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcont
 
 check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
-checkPythonPackageVersion "cryptography" "41.0.2"
+checkPythonPackageVersion "cryptography" "41.0.0"
 checkPythonPackageVersion "setuptools" "65.5.1"
 checkPythonPackageVersion "wheel" "0.38.1"
 
-checkCondaPackageVersion "cryptography" "41.0.2"
+checkCondaPackageVersion "cryptography" "41.0.0"
 checkCondaPackageVersion "pyopenssl" "23.2.0"
 checkCondaPackageVersion "setuptools" "65.5.1"
 checkCondaPackageVersion "wheel" "0.38.1"

--- a/src/miniconda/test-project/test.sh
+++ b/src/miniconda/test-project/test.sh
@@ -18,11 +18,11 @@ check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcont
 
 check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
-# checkPythonPackageVersion "cryptography" "41.0.0" # Disabled temporarily due to issue with conda
+checkPythonPackageVersion "cryptography" "41.0.0" # Disabled temporarily due to issue with conda
 checkPythonPackageVersion "setuptools" "65.5.1"
 checkPythonPackageVersion "wheel" "0.38.1"
 
-# checkCondaPackageVersion "cryptography" "41.0.0" # Disabled temporarily due to issue with conda
+checkCondaPackageVersion "cryptography" "41.0.0" # Disabled temporarily due to issue with conda
 checkCondaPackageVersion "pyopenssl" "23.2.0"
 checkCondaPackageVersion "setuptools" "65.5.1"
 checkCondaPackageVersion "wheel" "0.38.1"


### PR DESCRIPTION
**Devcontainer name**: 

- miniconda

**Description**:

This PR reverts changes from #715 since the issue with the installation of `cryptography` was resolved.

*Changelog*:

- Enabled patch for GHSA-5cpq-8wj7-hf2v;
- Enabled related tests;

**Checklist**:

- [x] Checked that applied changes work as expected
