### PR TITLE
[miniconda] Refactor Dockerfile to sync with `anaconda` devcontianer

### DIFF
--- a/src/miniconda/.devcontainer/Dockerfile
+++ b/src/miniconda/.devcontainer/Dockerfile
@@ -1,10 +1,30 @@
 FROM continuumio/miniconda3 as upstream
 
+# Temporary: Upgrade python packages due to mentioned CVEs
+# They are installed by the base image (continuumio/miniconda3) which does not have the patch.
+RUN conda install \ 
+    # https://github.com/pyca/cryptography/security/advisories/GHSA-5cpq-8wj7-hf2v
+    pyopenssl=23.2.0 \ 
+    cryptography=41.0.2 \
+    # https://github.com/advisories/GHSA-j8r2-6x86-q33q
+    requests=2.31.0
+
 # Reset and copy updated files with updated privs to keep image size down
 FROM mcr.microsoft.com/devcontainers/base:0-bullseye
-USER root
-COPY --from=upstream /opt /opt/
 
+ARG USERNAME=vscode
+
+# Create the conda group and add remote user to the group
+RUN groupadd -r conda --gid 900 \ 
+    && usermod -aG conda ${USERNAME}
+
+# Copy opt folder, set ownership and group permissions
+COPY --chown=:conda --chmod=775 --from=upstream /opt/conda /opt/conda
+RUN chmod =2775 /opt/conda
+
+USER root
+
+# Copy scripts to execute
 COPY add-notice.sh /tmp/library-scripts/
 
 # Setup conda to mirror contents from https://github.com/ContinuumIO/docker-images/blob/master/miniconda3/debian/Dockerfile
@@ -39,25 +59,6 @@ COPY environment.yml* noop.txt /tmp/conda-tmp/
 RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then umask 0002 && /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment.yml; fi \
     && rm -rf /tmp/conda-tmp
 
-# Temporary: Upgrade python packages due to mentioned CVEs
-# They are installed by the base image (continuumio/miniconda3) which does not have the patch.
-RUN conda install \ 
-    # https://github.com/pyca/cryptography/security/advisories/GHSA-5cpq-8wj7-hf2v
-    pyopenssl=23.2.0 \ 
-    # cryptography=41.0.2 # Disabled temporarily due to issue with conda \
-    # https://github.com/advisories/GHSA-j8r2-6x86-q33q
-    requests=2.31.0
-
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 #     && apt-get -y install --no-install-recommends <your-package-list-here>
-
-# Create conda group, update conda directory permissions, 
-# add user to conda group
-# Note: We need to execute these commands after pip install / conda update 
-# since pip doesn't preserve directory permissions
-RUN groupadd -r conda --gid 900 \
-    && chown -R :conda /opt/conda \
-    && chmod -R g+w /opt/conda \
-    && find /opt -type d | xargs -n 1 chmod g+s \
-    && usermod -aG conda ${USERNAME}

--- a/src/miniconda/.devcontainer/Dockerfile
+++ b/src/miniconda/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ RUN conda install \
     requests=2.31.0
 
 # Reset and copy updated files with updated privs to keep image size down
-FROM mcr.microsoft.com/devcontainers/base:0-bullseye
+FROM mcr.microsoft.com/devcontainers/base:1-bullseye
 
 ARG USERNAME=vscode
 

--- a/src/miniconda/test-project/test.sh
+++ b/src/miniconda/test-project/test.sh
@@ -18,11 +18,11 @@ check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcont
 
 check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
-# checkPythonPackageVersion "cryptography" "41.0.0" # Disabled temporarily due to issue with conda
+checkPythonPackageVersion "cryptography" "41.0.0"
 checkPythonPackageVersion "setuptools" "65.5.1"
 checkPythonPackageVersion "wheel" "0.38.1"
 
-# checkCondaPackageVersion "cryptography" "41.0.0" # Disabled temporarily due to issue with conda
+checkCondaPackageVersion "cryptography" "41.0.0"
 checkCondaPackageVersion "pyopenssl" "23.2.0"
 checkCondaPackageVersion "setuptools" "65.5.1"
 checkCondaPackageVersion "wheel" "0.38.1"


### PR DESCRIPTION
**Devcontainer name**: 

- miniconda

**Description**:

This PR contains the same changes as in #692. The main idea is to make the anaconda and miniconda devcontainers consistent.

*Changelog*:

- The `pip install` and `conda install` commands now execute against the `continuumio/miniconda3` image. (_This will allow us to not worry about `opt` folder permissions and ownership since we can set them up during `COPY` instruction_);

- The `COPY` instruction [now sets up permissions](https://docs.docker.com/engine/reference/builder/#copy) and ownership for the `opt` folder. The `COPY` instruction will not create an additional layer, which should help decrease image size;

- Previous commands for setting up permissions and ownership were removed.

**Checklist**:

- [x] Checked that applied changes work as expected
