### PR TITLE
[miniconda] Update `cryptography` package due to GHSA-jm77-qphf-c4w8

### DIFF
--- a/src/miniconda/.devcontainer/Dockerfile
+++ b/src/miniconda/.devcontainer/Dockerfile
@@ -3,9 +3,10 @@ FROM continuumio/miniconda3 as upstream
 # Temporary: Upgrade python packages due to mentioned CVEs
 # They are installed by the base image (continuumio/miniconda3) which does not have the patch.
 RUN conda install \ 
-    # https://github.com/pyca/cryptography/security/advisories/GHSA-5cpq-8wj7-hf2v
+    # pyopenssl should be updated to be compatible with latest version of cryptography
     pyopenssl=23.2.0 \ 
-    cryptography=41.0.2 \
+    # https://github.com/advisories/GHSA-jm77-qphf-c4w8
+    cryptography=41.0.3 \
     # https://github.com/advisories/GHSA-j8r2-6x86-q33q
     requests=2.31.0
 

--- a/src/miniconda/README.md
+++ b/src/miniconda/README.md
@@ -67,6 +67,10 @@ Given JavaScript front-end web client code written for use in conjunction with a
 }
 ```
 
+#### Using different Conda channels
+
+This image is based on the `ContinuumIO/miniconda3` docker image, which has the conda and its dependencies (*installed from conda's default channel*) in the base environment. It is not recommended to install packages from different channels in one environment since it could cause conflicts. When installing a package from a different channel (e.g., `conda-forge`) is required, the better approach is to create a new conda environment.
+
 #### Installing or updating Python utilities
 
 This container installs all Python development utilities using [pipx](https://pipxproject.github.io/pipx/) to avoid impacting the global Python environment. You can use this same utility add additional utilities in an isolated environment. For example:

--- a/src/miniconda/test-project/test.sh
+++ b/src/miniconda/test-project/test.sh
@@ -29,8 +29,8 @@ checkCondaPackageVersion "wheel" "0.38.1"
 checkCondaPackageVersion "requests" "2.31.0"
 
 check "conda-update-conda" bash -c "conda update -y conda"
-check "conda-install-tensorflow" bash -c "conda install -c conda-forge --yes tensorflow"
-check "conda-install-pytorch" bash -c "conda install -c conda-forge --yes pytorch"
+check "conda-install-tensorflow" bash -c "conda create --name test-env -c conda-forge --yes tensorflow"
+check "conda-install-pytorch" bash -c "conda create --name test-env -c conda-forge --yes pytorch"
 
 # Report result
 reportResults

--- a/src/miniconda/test-project/test.sh
+++ b/src/miniconda/test-project/test.sh
@@ -18,11 +18,11 @@ check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcont
 
 check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
-checkPythonPackageVersion "cryptography" "41.0.0"
+checkPythonPackageVersion "cryptography" "41.0.3"
 checkPythonPackageVersion "setuptools" "65.5.1"
 checkPythonPackageVersion "wheel" "0.38.1"
 
-checkCondaPackageVersion "cryptography" "41.0.0"
+checkCondaPackageVersion "cryptography" "41.0.3"
 checkCondaPackageVersion "pyopenssl" "23.2.0"
 checkCondaPackageVersion "setuptools" "65.5.1"
 checkCondaPackageVersion "wheel" "0.38.1"


### PR DESCRIPTION
**Dev container name**: 

- miniconda

**Description**:

This PR addresses the GHSA-jm77-qphf-c4w8 vulnerability. The vulnerability comes from the `continuumio/miniconda3` image and is related to the `cryptography` package.

*Changelog*:

- Updated Dockerfile to install the latest `cryptography` package version;

- Updated test to verify `cryptography` minimum version (_Minimum package version set to `41.0.3` which fixes GHSA-jm77-qphf-c4w8_);

- Updated tests to use different environments when installing packages from the `conda-forge` channel;

- Updated `README.md` to add info about possible conflicts in Conda's environment when channels are mixed;  

**Checklist**:

- [x] Checked that applied changes work as expected