### PR TITLE
[universal] Address GHSA-jm77-qphf-c4w8 and GHSA-r9hx-vwmv-q579 vulnerabilities 

### DIFF
--- a/src/universal/.devcontainer/local-features/patch-conda/install.sh
+++ b/src/universal/.devcontainer/local-features/patch-conda/install.sh
@@ -50,9 +50,10 @@ sudo_if /opt/conda/bin/python3 -m pip install --upgrade pip
 # Temporary: Upgrade python packages due to security vulnerabilities
 # They are installed by the conda feature and Conda distribution does not have the patches.
 
-# https://github.com/advisories/GHSA-5cpq-8wj7-hf2v
+# pyopenssl should be updated to be compatible with latest version of cryptography
 update_conda_package pyopenssl "23.2.0"
-update_conda_package cryptography "41.0.2"
+# https://github.com/advisories/GHSA-jm77-qphf-c4w8
+update_conda_package cryptography "41.0.3"
 
 # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-32681
 update_conda_package requests "2.31.0"

--- a/src/universal/.devcontainer/local-features/patch-python/install.sh
+++ b/src/universal/.devcontainer/local-features/patch-python/install.sh
@@ -34,7 +34,7 @@ update_package() {
     PACKAGE=$2
 
     sudo_if "$PYTHON_PATH -m pip uninstall --yes $PACKAGE"
-    sudo_if "$PYTHON_PATH -m pip install --user --upgrade --no-cache-dir $PACKAGE"
+    sudo_if "$PYTHON_PATH -m pip install --upgrade --no-cache-dir $PACKAGE"
 }
 
 # Temporary: Upgrade python packages due to security vulnerabilities

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -196,13 +196,13 @@ checkPythonPackageVersion "/usr/local/python/3.9.*/bin/python" "setuptools" "65.
 
 ## Conda Python
 checkCondaPackageVersion "requests" "2.31.0"
-checkCondaPackageVersion "cryptography" "41.0.2"
+checkCondaPackageVersion "cryptography" "41.0.3"
 checkCondaPackageVersion "pyopenssl" "23.2.0"
 
 ## Test Conda
 check "conda-update-conda" bash -c "conda update -y conda"
-check "conda-install" bash -c "conda install -c conda-forge --yes tensorflow"
-check "conda-install" bash -c "conda install -c conda-forge --yes pytorch"
+check "conda-install-tensorflow" bash -c "conda create --name test-env -c conda-forge --yes tensorflow"
+check "conda-install-pytorch" bash -c "conda create --name test-env -c conda-forge --yes pytorch"
 
 # Report result
 reportResults


### PR DESCRIPTION
**Devcontainer name**: 

- universal

**Description**:

This PR patches the following vulnerabilities:

- GHSA-jm77-qphf-c4w8 - related to the `cryptography` package;
- GHSA-r9hx-vwmv-q579 - related to the `setuptools` package. The vulnerability was patched a while ago, but the `site-packages` folder contained an older version of the related package, which triggers security scanners;

**Changelog**:

`patch-conda` feature:

- Bumped `cryptography` package version to address GHSA-jm77-qphf-c4w8;


`patch-python` feature:

- Removed the `--user` option from the `pip install` command. To make sure that the `site-packages` folder doesn't contain older versions of patched packages.
 
Tests:

- Updated test to verify `cryptography` minimum version (_Minimum package version set to `41.0.3` which fixes GHSA-jm77-qphf-c4w8_);

- Updated tests to use different environments when installing packages from the `conda-forge` channel;

- Conda tests were renamed to make names more explicit;

**Checklist**:

- [x] Checked that applied changes work as expected