### PR TITLE
[anaconda] Update `jupyter_server` package due to GHSA-r726-vmfq-j9j3

### DIFF
--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -33,7 +33,9 @@ RUN python3 -m pip install --upgrade \
     # https://github.com/advisories/GHSA-qppv-j76h-2rpx
     tornado==6.3.3 \
     # https://github.com/advisories/GHSA-282v-666c-3fvg
-    transformers==4.30.0
+    transformers==4.30.0 \ 
+    # https://github.com/advisories/GHSA-r726-vmfq-j9j3 
+    jupyter_server==2.7.2
 
 # Reset and copy updated files with updated privs to keep image size down
 FROM mcr.microsoft.com/devcontainers/base:1-bullseye

--- a/src/anaconda/manifest.json
+++ b/src/anaconda/manifest.json
@@ -39,7 +39,8 @@
 			"Werkzeug",
 			"requests",
 			"tornado",
-			"transformers"
+			"transformers",
+			"jupyter_server"
 		],
 		"other": {
 			"git": {},

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -45,6 +45,7 @@ checkPythonPackageVersion "torch" "1.13.1"
 checkPythonPackageVersion "transformers" "4.30.0"
 checkPythonPackageVersion "mpmath" "1.3.0"
 checkPythonPackageVersion "aiohttp" "3.8.5"
+checkPythonPackageVersion "jupyter_server" "2.7.2"
 
 # The `tornado` package doesn't have the `__version__` attribute so we can use the `version` attribute.
 tornado_version=$(python -c "import tornado; print(tornado.version)")


### PR DESCRIPTION
**Devcontainer name**: 

- anaconda

**Description**:

This PR addresses the GHSA-r726-vmfq-j9j3 vulnerability. The vulnerability comes from the `continuumio/anaconda3` image and is related to the `jupyter_server` package.

*Changelog*:

- Updated Dockerfile to install the latest `jupyter_server` package version;

- Added test to verify `jupyter_server` minimum version (_Minimum package version set to `2.7.2` which fixes GHSA-r726-vmfq-j9j3_);

- Updated manifest to include info about the `jupyter_server` package version;

**Checklist**:

- [x] Checked that applied changes work as expected