### PR TITLE
New workflow - Allows manually pushing dev images from branch

### DIFF
--- a/.github/workflows/push-manual-dev.yml
+++ b/.github/workflows/push-manual-dev.yml
@@ -1,12 +1,8 @@
-name: Push dev-image manually
+name: Re-push image
 
 on:
   workflow_dispatch:
     inputs:
-      release:
-        description: 'Release branch'
-        required: true
-        default: 'main'
       image:
         description: 'Image ID'
         required: true
@@ -73,7 +69,7 @@ jobs:
         ln -s "$GITHUB_WORKSPACE/ref/node_modules" node_modules
 
         build/vscdc push  --replace-images \
-                          --release ${{ github.event.inputs.release }} \
+                          --release main \
                           --registry "$REGISTRY" \
                           --registry-path "$REGISTRY_BASE_PATH" \
                           --stub-registry "$STUB_REGISTRY" \

--- a/.github/workflows/push-manual-dev.yml
+++ b/.github/workflows/push-manual-dev.yml
@@ -1,0 +1,82 @@
+name: Push dev-image manually
+
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: 'Release branch'
+        required: true
+        default: 'main'
+      image:
+        description: 'Image ID'
+        required: true
+
+jobs:
+  build-and-push:
+    name: Build and push images
+    if: ${{ github.ref == *'refs/heads/'* }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Free more space
+      id: free_space 
+      run: |
+        set -e
+        # Ensure enough space is available for build
+        sudo apt-get autoremove -y
+        sudo apt-get clean -y
+        sudo rm -rf /usr/share/dotnet
+
+    - name: Checkout ref
+      id: checkout_ref
+      uses: actions/checkout@v3
+      with:
+        path: 'ref'
+        ref: ${{ github.ref }}
+        
+    - name: Checkout release
+      id: checkout_release
+      uses: actions/checkout@v3
+      with:
+        path: 'release'
+        ref: ${{ github.event.inputs.release }}
+
+    - name: Azure CLI login
+      id: az_login
+      uses: azure/login@v1
+      with:
+        creds: ${{ secrets.AZ_ACR_CREDS }}
+      
+    - name: Build and push
+      id: build_and_push
+      env:
+        REGISTRY: ${{ secrets.REGISTRY }}
+        REGISTRY_BASE_PATH: ${{ secrets.REGISTRY_BASE_PATH }}
+        STUB_REGISTRY: ${{ secrets.STUB_REGISTRY }}
+        STUB_REGISTRY_BASE_PATH: ${{ secrets.STUB_REGISTRY_BASE_PATH }}
+        SECONDARY_REGISTRY_BASE_PATH: ${{ secrets.SECONDARY_REGISTRY_BASE_PATH }}
+      run: |
+        set -e
+
+        # ACR login
+        ACR_REGISTRY_NAME=$(echo "$REGISTRY" | grep -oP '(.+)(?=\.azurecr\.io)')
+        az acr login --name $ACR_REGISTRY_NAME
+
+        # Setup build CLI
+        cd "$GITHUB_WORKSPACE/ref"
+        yarn install
+        npm install -g @devcontainers/cli
+
+        # Go to the release, symlink the build tool from ref since this is the version for the workflow
+        cd "$GITHUB_WORKSPACE/release"
+        rm -rf build node_modules
+        ln -s "$GITHUB_WORKSPACE/ref/build" build
+        ln -s "$GITHUB_WORKSPACE/ref/node_modules" node_modules
+
+        build/vscdc push  --replace-images \
+                          --release ${{ github.event.inputs.release }} \
+                          --registry "$REGISTRY" \
+                          --registry-path "$REGISTRY_BASE_PATH" \
+                          --stub-registry "$STUB_REGISTRY" \
+                          --stub-registry-path "$STUB_REGISTRY_BASE_PATH" \
+                          --secondary-registry-path "$SECONDARY_REGISTRY_BASE_PATH" \
+                          ${{ github.event.inputs.image }}

--- a/.github/workflows/push-manual-dev.yml
+++ b/.github/workflows/push-manual-dev.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build-and-push:
     name: Build and push images
-    if: ${{ github.ref == *'refs/heads/'* }}
+    if: ${{ startsWith(github.ref, 'refs/heads/') }}
     runs-on: ubuntu-latest
     steps:
     - name: Free more space


### PR DESCRIPTION
It will be helpful to test if changes to a branch works in an image.

Scenario - Universal image takes a while to be built, so it will be helpful to make changes to a branch and test them with an image (without merging the PR). We could use actions and tests to validate our changes but at times actions don't replicate the scenario. (eg. universal image when built with latest Feature version of dnd Feature fails to start docker within a codespace but passes in an action. This new workflow will be helpful in such cases)

Note: This workflow can only push dev tags, prod tags cannot be pushed by this workflow.