### PR TITLE
v0.3.20

### DIFF
--- a/build/config.json
+++ b/build/config.json
@@ -226,7 +226,7 @@
 			"downloadUrl":"https://xdebug.org/"
 		},
 		"Java": {
-			"versionCommand": "java --version | grep -oP 'openjdk\\s+\\K[0-9]+\\.[0-9]+\\.[0-9]+'",
+			"versionCommand": "java --version | grep -oP 'openjdk\\s+\\K[0-9]+\\.[0-9]+\\.[0-9]+|[0-9]{2}' | head -n 1",
 			"downloadUrl": "https://adoptopenjdk.net/"
 		},
 		".NET": {

--- a/src/anaconda/manifest.json
+++ b/src/anaconda/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.204.2",
+	"version": "0.204.3",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/src/java-8/history/dev.md
+++ b/src/java-8/history/dev.md
@@ -11,7 +11,7 @@
 
 ## Variant: bookworm
 
-**Digest:** sha256:1b46ad14c0baf91ffe430ab0a0a381aa5d924f55c67c6a25c4ad36965837da0c
+**Digest:** sha256:019fde3660ba4c1b8f6938f43c9d3a663346189609f8b5cddb624bed9456aaca
 
 **Tags:**
 ```
@@ -38,7 +38,7 @@ mcr.microsoft.com/devcontainers/java:dev-8-jdk-bookworm
 
 | Tool | Commit | Path |
 |------|--------|------|
-| [Oh My Zsh!](https://github.com/ohmyzsh/ohmyzsh) | 01f55123118601a935f28ff6c49e625448bdd32d | /home/vscode/.oh-my-zsh |
+| [Oh My Zsh!](https://github.com/ohmyzsh/ohmyzsh) | d3b6f1fd5e42deafb3a6458213762a492e484073 | /home/vscode/.oh-my-zsh |
 | [nvm](https://github.com/nvm-sh/nvm.git) | c92adb3c479d70bb29f4399a808c972ef41510e7 | /usr/local/share/nvm |
 
 **Other tools and utilities**
@@ -93,7 +93,7 @@ mcr.microsoft.com/devcontainers/java:dev-8-jdk-bookworm
 
 ## Variant: bullseye
 
-**Digest:** sha256:904f6fbaf10ccce3e80191d3a13529ace072014046edf6292df8ad04f125e3e2
+**Digest:** sha256:974e958c0e9e8cdd072bc7c33e30e628aa71c9dd85446309dcc444e618b2c141
 
 **Tags:**
 ```
@@ -119,7 +119,7 @@ mcr.microsoft.com/devcontainers/java:dev-8-jdk-bullseye
 
 | Tool | Commit | Path |
 |------|--------|------|
-| [Oh My Zsh!](https://github.com/ohmyzsh/ohmyzsh) | 38ef5192cb1c43159b516d15ab8fed96f847b36b | /home/vscode/.oh-my-zsh |
+| [Oh My Zsh!](https://github.com/ohmyzsh/ohmyzsh) | 0e1e877ea9182f87b3ab34cbc2ea944b34f5345e | /home/vscode/.oh-my-zsh |
 | [nvm](https://github.com/nvm-sh/nvm.git) | c92adb3c479d70bb29f4399a808c972ef41510e7 | /usr/local/share/nvm |
 
 **Other tools and utilities**
@@ -175,7 +175,7 @@ mcr.microsoft.com/devcontainers/java:dev-8-jdk-bullseye
 
 ## Variant: buster
 
-**Digest:** sha256:b1928c322928853073e7567510b8f2b4030223aeae9879ac2c8042fa1be43cc1
+**Digest:** sha256:d07df994628b4795a2e0309ca332ccaa21959c497d89ef8dad83ea1642d7a6d8
 
 **Tags:**
 ```
@@ -201,7 +201,7 @@ mcr.microsoft.com/devcontainers/java:dev-8-jdk-buster
 
 | Tool | Commit | Path |
 |------|--------|------|
-| [Oh My Zsh!](https://github.com/ohmyzsh/ohmyzsh) | 01f55123118601a935f28ff6c49e625448bdd32d | /home/vscode/.oh-my-zsh |
+| [Oh My Zsh!](https://github.com/ohmyzsh/ohmyzsh) | d3b6f1fd5e42deafb3a6458213762a492e484073 | /home/vscode/.oh-my-zsh |
 | [nvm](https://github.com/nvm-sh/nvm.git) | c92adb3c479d70bb29f4399a808c972ef41510e7 | /usr/local/share/nvm |
 
 **Other tools and utilities**

--- a/src/java/history/dev.md
+++ b/src/java/history/dev.md
@@ -5,6 +5,9 @@
 **Source release/branch:** [main](https://github.com/devcontainers/images/tree/main/src/java)
 
 **Image variations:**
+- [21-bookworm](#variant-21-bookworm)
+- [21-bullseye](#variant-21-bullseye)
+- [21-buster](#variant-21-buster)
 - [17-bookworm](#variant-17-bookworm)
 - [17-bullseye](#variant-17-bullseye)
 - [17-buster](#variant-17-buster)
@@ -12,16 +15,263 @@
 - [11-bullseye](#variant-11-bullseye)
 - [11-buster](#variant-11-buster)
 
+## Variant: 21-bookworm
+
+**Digest:** sha256:3b0f48f10a4e473ad18bbc40f5d0e34a550a1cacecc252af07aa9b6a6fafd51e
+
+**Tags:**
+```
+mcr.microsoft.com/devcontainers/java:dev-21-bookworm
+mcr.microsoft.com/devcontainers/java:dev-21
+mcr.microsoft.com/devcontainers/java:dev-21-jdk-bookworm
+mcr.microsoft.com/devcontainers/java:dev-bookworm
+```
+> *To keep up to date, we recommend using partial version numbers. Use the major version number to get all non-breaking changes (e.g. `0-`) or major and minor to only get fixes (e.g. `0.200-`).*
+
+**Linux distribution:** Debian GNU/Linux 12 (bookworm)
+
+**Architectures:** linux/amd64, linux/arm64
+
+**Available (non-root) user:** vscode
+
+### Contents
+**Languages and runtimes**
+
+| Language / runtime | Version | Path |
+|--------------------|---------|------|
+| [Java](https://adoptopenjdk.net/) | 21 | /usr/local/ |
+
+**Tools installed using git**
+
+| Tool | Commit | Path |
+|------|--------|------|
+| [Oh My Zsh!](https://github.com/ohmyzsh/ohmyzsh) | d3b6f1fd5e42deafb3a6458213762a492e484073 | /home/vscode/.oh-my-zsh |
+| [nvm](https://github.com/nvm-sh/nvm.git) | c92adb3c479d70bb29f4399a808c972ef41510e7 | /usr/local/share/nvm |
+
+**Other tools and utilities**
+
+| Tool | Version | Path |
+|------|---------|------|
+| [git](https://github.com/git/git) | 2.42.0 | 
+
+**Additional linux tools and packages**
+
+| Tool / library | Version |
+|----------------|---------|
+| apt-transport-https | 2.6.1 |
+| apt-utils | 2.6.1 |
+| ca-certificates | 20230311 |
+| curl | 7.88.1-10+deb12u1 |
+| dialog | 1.3-20230209-1 |
+| git | 1:2.39.2-1.1 |
+| gnupg2 | 2.2.40-1.1 |
+| htop | 3.2.2-2 |
+| iproute2 | 6.1.0-3 |
+| jq | 1.6-2.1 |
+| less | 590-2 |
+| libc6 | 2.36-9+deb12u1 |
+| libgssapi-krb5-2 | 1.20.1-2 |
+| libicu72 | 72.1-3 |
+| libkrb5-3 | 1.20.1-2 |
+| liblttng-ust1 | 2.13.5-1 |
+| libstdc++6 | 12.2.0-14 |
+| locales | 2.36-9+deb12u1 |
+| lsb-release | 12.0-1 |
+| lsof | 4.95.0-1 |
+| man-db | 2.11.2-2 |
+| manpages | 6.03-2 |
+| manpages-dev | 6.03-2 |
+| nano | 7.2-1 |
+| ncdu | 1.18-0.2 |
+| net-tools | 2.10-0.1 |
+| openssh-client | 1:9.2p1-2 |
+| procps | 2:4.0.2-3 |
+| psmisc | 23.6-1 |
+| rsync | 3.2.7-1 |
+| strace | 6.1-0.1 |
+| sudo | 1.9.13p3-1+deb12u1 |
+| unzip | 6.0-28 |
+| vim-tiny | 2:9.0.1378-2 |
+| wget | 1.21.3-1+b2 |
+| yarn | 1.22.19-1 |
+| zip | 3.0-13 |
+| zlib1g | 1:1.2.13.dfsg-1 |
+| zsh | 5.9-4+b2 |
+
+## Variant: 21-bullseye
+
+**Digest:** sha256:334ca4fb90882610aeed6a6be74f7c38e8ea7b089c08430cd065bcca9b987cea
+
+**Tags:**
+```
+mcr.microsoft.com/devcontainers/java:dev-21-bullseye
+mcr.microsoft.com/devcontainers/java:dev-21-jdk-bullseye
+mcr.microsoft.com/devcontainers/java:dev-bullseye
+```
+> *To keep up to date, we recommend using partial version numbers. Use the major version number to get all non-breaking changes (e.g. `0-`) or major and minor to only get fixes (e.g. `0.200-`).*
+
+**Linux distribution:** Debian GNU/Linux 11 (bullseye)
+
+**Architectures:** linux/amd64, linux/arm64
+
+**Available (non-root) user:** vscode
+
+### Contents
+**Languages and runtimes**
+
+| Language / runtime | Version | Path |
+|--------------------|---------|------|
+| [Java](https://adoptopenjdk.net/) | 21 | /usr/local/ |
+
+**Tools installed using git**
+
+| Tool | Commit | Path |
+|------|--------|------|
+| [Oh My Zsh!](https://github.com/ohmyzsh/ohmyzsh) | 0e1e877ea9182f87b3ab34cbc2ea944b34f5345e | /home/vscode/.oh-my-zsh |
+| [nvm](https://github.com/nvm-sh/nvm.git) | c92adb3c479d70bb29f4399a808c972ef41510e7 | /usr/local/share/nvm |
+
+**Other tools and utilities**
+
+| Tool | Version | Path |
+|------|---------|------|
+| [git](https://github.com/git/git) | 2.42.0 | 
+
+**Additional linux tools and packages**
+
+| Tool / library | Version |
+|----------------|---------|
+| apt-transport-https | 2.2.4 |
+| apt-utils | 2.2.4 |
+| ca-certificates | 20210119 |
+| curl | 7.74.0-1.3+deb11u7 |
+| dialog | 1.3-20201126-1 |
+| git | 1:2.30.2-1+deb11u2 |
+| gnupg2 | 2.2.27-2+deb11u2 |
+| htop | 3.0.5-7 |
+| iproute2 | 5.10.0-4 |
+| jq | 1.6-2.1 |
+| less | 551-2 |
+| libc6 | 2.31-13+deb11u6 |
+| libgssapi-krb5-2 | 1.18.3-6+deb11u3 |
+| libicu67 | 67.1-7 |
+| libkrb5-3 | 1.18.3-6+deb11u3 |
+| liblttng-ust0 | 2.12.1-1 |
+| libssl1.1 | 1.1.1n-0+deb11u5 |
+| libstdc++6 | 10.2.1-6 |
+| locales | 2.31-13+deb11u6 |
+| lsb-release | 11.1.0 |
+| lsof | 4.93.2+dfsg-1.1 |
+| man-db | 2.9.4-2 |
+| manpages | 5.10-1 |
+| manpages-dev | 5.10-1 |
+| nano | 5.4-2+deb11u2 |
+| ncdu | 1.15.1-1 |
+| net-tools | 1.60+git20181103.0eebece-1 |
+| openssh-client | 1:8.4p1-5+deb11u1 |
+| procps | 2:3.3.17-5 |
+| psmisc | 23.4-2 |
+| rsync | 3.2.3-4+deb11u1 |
+| strace | 5.10-1 |
+| sudo | 1.9.5p2-3+deb11u1 |
+| unzip | 6.0-26+deb11u1 |
+| vim-tiny | 2:8.2.2434-3+deb11u1 |
+| wget | 1.21-1+deb11u1 |
+| yarn | 1.22.19-1 |
+| zip | 3.0-12 |
+| zlib1g | 1:1.2.11.dfsg-2+deb11u2 |
+| zsh | 5.8-6+deb11u1 |
+
+## Variant: 21-buster
+
+**Digest:** sha256:53d5e12a5f6a9753e6ab148ea0590a3f0dfd8fa016af6596780960744ec966fc
+
+**Tags:**
+```
+mcr.microsoft.com/devcontainers/java:dev-21-buster
+```
+> *To keep up to date, we recommend using partial version numbers. Use the major version number to get all non-breaking changes (e.g. `0-`) or major and minor to only get fixes (e.g. `0.200-`).*
+
+**Linux distribution:** Debian GNU/Linux 10 (buster)
+
+**Architectures:** linux/amd64
+
+**Available (non-root) user:** vscode
+
+### Contents
+**Languages and runtimes**
+
+| Language / runtime | Version | Path |
+|--------------------|---------|------|
+| [Java](https://adoptopenjdk.net/) | 21 | /usr/local/ |
+
+**Tools installed using git**
+
+| Tool | Commit | Path |
+|------|--------|------|
+| [Oh My Zsh!](https://github.com/ohmyzsh/ohmyzsh) | d3b6f1fd5e42deafb3a6458213762a492e484073 | /home/vscode/.oh-my-zsh |
+| [nvm](https://github.com/nvm-sh/nvm.git) | c92adb3c479d70bb29f4399a808c972ef41510e7 | /usr/local/share/nvm |
+
+**Other tools and utilities**
+
+| Tool | Version | Path |
+|------|---------|------|
+| [git](https://github.com/git/git) | 2.42.0 | 
+
+**Additional linux tools and packages**
+
+| Tool / library | Version |
+|----------------|---------|
+| apt-transport-https | 1.8.2.3 |
+| apt-utils | 1.8.2.3 |
+| ca-certificates | 20200601~deb10u2 |
+| curl | 7.64.0-4+deb10u6 |
+| dialog | 1.3-20190211-1 |
+| git | 1:2.20.1-2+deb10u8 |
+| gnupg2 | 2.2.12-1+deb10u2 |
+| htop | 2.2.0-1+b1 |
+| iproute2 | 4.20.0-2+deb10u1 |
+| jq | 1.5+dfsg-2+b1 |
+| less | 487-0.1+b1 |
+| libc6 | 2.28-10+deb10u2 |
+| libgcc1 | 1:8.3.0-6 |
+| libgssapi-krb5-2 | 1.17-3+deb10u5 |
+| libicu63 | 63.1-6+deb10u3 |
+| libkrb5-3 | 1.17-3+deb10u5 |
+| liblttng-ust0 | 2.10.3-1 |
+| libssl1.1 | 1.1.1n-0+deb10u6 |
+| libstdc++6 | 8.3.0-6 |
+| locales | 2.28-10+deb10u2 |
+| lsb-release | 10.2019051400 |
+| lsof | 4.91+dfsg-1 |
+| man-db | 2.8.5-2 |
+| manpages | 4.16-2 |
+| manpages-dev | 4.16-2 |
+| nano | 3.2-3 |
+| ncdu | 1.13-1+b1 |
+| net-tools | 1.60+git20180626.aebd88e-1 |
+| openssh-client | 1:7.9p1-10+deb10u3 |
+| procps | 2:3.3.15-2 |
+| psmisc | 23.2-1+deb10u1 |
+| rsync | 3.1.3-6 |
+| strace | 4.26-0.2 |
+| sudo | 1.8.27-1+deb10u5 |
+| unzip | 6.0-23+deb10u3 |
+| vim-tiny | 2:8.1.0875-5+deb10u5 |
+| wget | 1.20.1-1.1 |
+| yarn | 1.22.19-1 |
+| zip | 3.0-11+b1 |
+| zlib1g | 1:1.2.11.dfsg-1+deb10u2 |
+| zsh | 5.7.1-1+deb10u1 |
+
 ## Variant: 17-bookworm
 
-**Digest:** sha256:339c2953070d6e2ef83e8df7954826728880928b5660b9a84d0e0c6b1611fbe4
+**Digest:** sha256:12cbc90cd4fc7717f3a2c68e01ca040bf35b8224e617e717b876f378e3d1a949
 
 **Tags:**
 ```
 mcr.microsoft.com/devcontainers/java:dev-17-bookworm
 mcr.microsoft.com/devcontainers/java:dev-17
 mcr.microsoft.com/devcontainers/java:dev-17-jdk-bookworm
-mcr.microsoft.com/devcontainers/java:dev-bookworm
 ```
 > *To keep up to date, we recommend using partial version numbers. Use the major version number to get all non-breaking changes (e.g. `0-`) or major and minor to only get fixes (e.g. `0.200-`).*
 
@@ -42,7 +292,7 @@ mcr.microsoft.com/devcontainers/java:dev-bookworm
 
 | Tool | Commit | Path |
 |------|--------|------|
-| [Oh My Zsh!](https://github.com/ohmyzsh/ohmyzsh) | 01f55123118601a935f28ff6c49e625448bdd32d | /home/vscode/.oh-my-zsh |
+| [Oh My Zsh!](https://github.com/ohmyzsh/ohmyzsh) | d3b6f1fd5e42deafb3a6458213762a492e484073 | /home/vscode/.oh-my-zsh |
 | [nvm](https://github.com/nvm-sh/nvm.git) | c92adb3c479d70bb29f4399a808c972ef41510e7 | /usr/local/share/nvm |
 
 **Other tools and utilities**
@@ -97,13 +347,12 @@ mcr.microsoft.com/devcontainers/java:dev-bookworm
 
 ## Variant: 17-bullseye
 
-**Digest:** sha256:f3523c0fae8d8a0fdff1aebc00b29f0b2de101a9b9a6645132131427ea7cf819
+**Digest:** sha256:48c7287f8ef6124513cee4ee513e84b8a898e8f119af694149fffd70a4de5fda
 
 **Tags:**
 ```
 mcr.microsoft.com/devcontainers/java:dev-17-bullseye
 mcr.microsoft.com/devcontainers/java:dev-17-jdk-bullseye
-mcr.microsoft.com/devcontainers/java:dev-bullseye
 ```
 > *To keep up to date, we recommend using partial version numbers. Use the major version number to get all non-breaking changes (e.g. `0-`) or major and minor to only get fixes (e.g. `0.200-`).*
 
@@ -124,7 +373,7 @@ mcr.microsoft.com/devcontainers/java:dev-bullseye
 
 | Tool | Commit | Path |
 |------|--------|------|
-| [Oh My Zsh!](https://github.com/ohmyzsh/ohmyzsh) | 38ef5192cb1c43159b516d15ab8fed96f847b36b | /home/vscode/.oh-my-zsh |
+| [Oh My Zsh!](https://github.com/ohmyzsh/ohmyzsh) | 0e1e877ea9182f87b3ab34cbc2ea944b34f5345e | /home/vscode/.oh-my-zsh |
 | [nvm](https://github.com/nvm-sh/nvm.git) | c92adb3c479d70bb29f4399a808c972ef41510e7 | /usr/local/share/nvm |
 
 **Other tools and utilities**
@@ -180,7 +429,7 @@ mcr.microsoft.com/devcontainers/java:dev-bullseye
 
 ## Variant: 17-buster
 
-**Digest:** sha256:cfaa3e459aa706b59d40f3d01a7f7ef91aa98d9a10891d92d48faffa07022e81
+**Digest:** sha256:0ef5b69774470c2a41710353f774d57d46254533c2e8dea4bb97d9b4f95f570a
 
 **Tags:**
 ```
@@ -205,7 +454,7 @@ mcr.microsoft.com/devcontainers/java:dev-17-buster
 
 | Tool | Commit | Path |
 |------|--------|------|
-| [Oh My Zsh!](https://github.com/ohmyzsh/ohmyzsh) | 01f55123118601a935f28ff6c49e625448bdd32d | /home/vscode/.oh-my-zsh |
+| [Oh My Zsh!](https://github.com/ohmyzsh/ohmyzsh) | d3b6f1fd5e42deafb3a6458213762a492e484073 | /home/vscode/.oh-my-zsh |
 | [nvm](https://github.com/nvm-sh/nvm.git) | c92adb3c479d70bb29f4399a808c972ef41510e7 | /usr/local/share/nvm |
 
 **Other tools and utilities**
@@ -262,7 +511,7 @@ mcr.microsoft.com/devcontainers/java:dev-17-buster
 
 ## Variant: 11-bookworm
 
-**Digest:** sha256:1e53471ddc16d9d26736954b9cdebbc45623df73dc8d328a1d04706abdf125db
+**Digest:** sha256:8a10743272019b307e5895b35b7e43c740435a90ed1f386f62082d6b7ef45641
 
 **Tags:**
 ```
@@ -289,7 +538,7 @@ mcr.microsoft.com/devcontainers/java:dev-11-jdk-bookworm
 
 | Tool | Commit | Path |
 |------|--------|------|
-| [Oh My Zsh!](https://github.com/ohmyzsh/ohmyzsh) | 01f55123118601a935f28ff6c49e625448bdd32d | /home/vscode/.oh-my-zsh |
+| [Oh My Zsh!](https://github.com/ohmyzsh/ohmyzsh) | d3b6f1fd5e42deafb3a6458213762a492e484073 | /home/vscode/.oh-my-zsh |
 | [nvm](https://github.com/nvm-sh/nvm.git) | c92adb3c479d70bb29f4399a808c972ef41510e7 | /usr/local/share/nvm |
 
 **Other tools and utilities**
@@ -344,7 +593,7 @@ mcr.microsoft.com/devcontainers/java:dev-11-jdk-bookworm
 
 ## Variant: 11-bullseye
 
-**Digest:** sha256:672105bd8a3a1b976c07ca12ad2694960ff8792077eccc10d0c3a6a897f3aff1
+**Digest:** sha256:a811594995d1dfdfa648fd37687d16279a52631315cbc2612a4b9769480be51b
 
 **Tags:**
 ```
@@ -370,7 +619,7 @@ mcr.microsoft.com/devcontainers/java:dev-11-jdk-bullseye
 
 | Tool | Commit | Path |
 |------|--------|------|
-| [Oh My Zsh!](https://github.com/ohmyzsh/ohmyzsh) | 38ef5192cb1c43159b516d15ab8fed96f847b36b | /home/vscode/.oh-my-zsh |
+| [Oh My Zsh!](https://github.com/ohmyzsh/ohmyzsh) | 0e1e877ea9182f87b3ab34cbc2ea944b34f5345e | /home/vscode/.oh-my-zsh |
 | [nvm](https://github.com/nvm-sh/nvm.git) | c92adb3c479d70bb29f4399a808c972ef41510e7 | /usr/local/share/nvm |
 
 **Other tools and utilities**
@@ -426,7 +675,7 @@ mcr.microsoft.com/devcontainers/java:dev-11-jdk-bullseye
 
 ## Variant: 11-buster
 
-**Digest:** sha256:7608d27c0ca84f889f5a9180e84624720b7601b75d9782b2e7fbc857afcef4ed
+**Digest:** sha256:3e9c4d741d967b94304fa4e92f8977c4b28830881360a662627a1c86e9f18036
 
 **Tags:**
 ```
@@ -452,7 +701,7 @@ mcr.microsoft.com/devcontainers/java:dev-11-jdk-buster
 
 | Tool | Commit | Path |
 |------|--------|------|
-| [Oh My Zsh!](https://github.com/ohmyzsh/ohmyzsh) | 01f55123118601a935f28ff6c49e625448bdd32d | /home/vscode/.oh-my-zsh |
+| [Oh My Zsh!](https://github.com/ohmyzsh/ohmyzsh) | d3b6f1fd5e42deafb3a6458213762a492e484073 | /home/vscode/.oh-my-zsh |
 | [nvm](https://github.com/nvm-sh/nvm.git) | c92adb3c479d70bb29f4399a808c972ef41510e7 | /usr/local/share/nvm |
 
 **Other tools and utilities**

--- a/src/java/manifest.json
+++ b/src/java/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "1.0.3",
+	"version": "1.1.0",
 	"variants": [
 		"21-bookworm",
 		"21-bullseye",

--- a/src/universal/manifest.json
+++ b/src/universal/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.5.4",
+	"version": "2.5.5",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",


### PR DESCRIPTION
Changelog

- [[anaconda] Update `jupyter_server` package due to GHSA-r726-vmfq-j9j3](https://github.com/devcontainers/images/pull/754)
- [[Typesrcipt-node][Javascript-node] EOL Node 16](https://github.com/devcontainers/images/pull/751)
- [[universal] Address GHSA-jm77-qphf-c4w8 and GHSA-r9hx-vwmv-q579 vulnerabilities](https://github.com/devcontainers/images/pull/753)
- [Support: Java 21](https://github.com/devcontainers/images/pull/770)