### PR TITLE
[universal] Update `cryptography` package due to GHSA-v8gr-m533-ghj9

### DIFF
--- a/src/universal/.devcontainer/local-features/patch-conda/install.sh
+++ b/src/universal/.devcontainer/local-features/patch-conda/install.sh
@@ -52,8 +52,9 @@ sudo_if /opt/conda/bin/python3 -m pip install --upgrade pip
 
 # pyopenssl should be updated to be compatible with latest version of cryptography
 update_conda_package pyopenssl "23.2.0"
-# https://github.com/advisories/GHSA-jm77-qphf-c4w8
-update_conda_package cryptography "41.0.3"
+
+# https://github.com/advisories/GHSA-v8gr-m533-ghj9
+update_python_package /opt/conda/bin/python3 cryptography "41.0.4"
 
 # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-32681
 update_conda_package requests "2.31.0"

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -187,7 +187,6 @@ check "java-version-on-path-is-12.0.2" java --version | grep 12.0.2
 ls -la /home/codespace
 
 ## Python - current
-checkPythonPackageVersion "python" "wheel" "0.38.1"
 checkPythonPackageVersion "python" "setuptools" "65.5.1"
 checkPythonPackageVersion "python" "requests" "2.31.0"
 
@@ -196,7 +195,7 @@ checkPythonPackageVersion "/usr/local/python/3.9.*/bin/python" "setuptools" "65.
 
 ## Conda Python
 checkCondaPackageVersion "requests" "2.31.0"
-checkCondaPackageVersion "cryptography" "41.0.3"
+checkCondaPackageVersion "cryptography" "41.0.4"
 checkCondaPackageVersion "pyopenssl" "23.2.0"
 
 ## Test Conda


### PR DESCRIPTION
**Devcontainer name**: 

- universal

**Description**:

This PR addresses the GHSA-v8gr-m533-ghj9 vulnerability. The vulnerability comes from the `conda` distribution and is related to the `cryptography` package.

*Changelog*:

- Updated `patch-conda` feature to install the latest `cryptography` package version;

- Updated test to verify `cryptography` minimum version (_Minimum package version set to `41.0.4` which fixes GHSA-v8gr-m533-ghj9_);

- Removed check for the minimum version of "wheel" since the package is no longer present in the PIP list;

**Checklist**:

- [x] Checked that applied changes work as expected