### PR TITLE
[anaconda] Address vulnerabilities: GHSA-j7hp-h8jx-5ppr, GHSA-v845-jxx5-vc9f

### DIFF
--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -15,7 +15,9 @@ RUN conda install \
     # https://github.com/advisories/GHSA-f865-m6cq-j9vx
     mpmath=1.3.0 \
     # https://github.com/advisories/GHSA-45c4-8wx5-qw6w
-    aiohttp=3.8.5
+    aiohttp=3.8.5 \
+    # https://github.com/advisories/GHSA-j7hp-h8jx-5ppr
+    pillow=10.0.1
 
 RUN python3 -m pip install --upgrade \
     # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-21797
@@ -35,7 +37,9 @@ RUN python3 -m pip install --upgrade \
     # https://github.com/advisories/GHSA-282v-666c-3fvg
     transformers==4.30.0 \ 
     # https://github.com/advisories/GHSA-r726-vmfq-j9j3 
-    jupyter_server==2.7.2
+    jupyter_server==2.7.2 \
+    # https://github.com/advisories/GHSA-v845-jxx5-vc9f
+    urllib3==1.26.17
 
 # Reset and copy updated files with updated privs to keep image size down
 FROM mcr.microsoft.com/devcontainers/base:1-bullseye

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -45,6 +45,7 @@ checkPythonPackageVersion "transformers" "4.30.0"
 checkPythonPackageVersion "mpmath" "1.3.0"
 checkPythonPackageVersion "aiohttp" "3.8.5"
 checkPythonPackageVersion "jupyter_server" "2.7.2"
+checkPythonPackageVersion "urllib3" "1.26.17"
 
 # The `tornado` package doesn't have the `__version__` attribute so we can use the `version` attribute.
 tornado_version=$(python -c "import tornado; print(tornado.version)")
@@ -56,6 +57,7 @@ checkCondaPackageVersion "requests" "2.31.0"
 checkCondaPackageVersion "pygments" "2.15.1"
 checkCondaPackageVersion "mpmath" "1.3.0"
 checkCondaPackageVersion "aiohttp" "3.8.5"
+checkCondaPackageVersion "pillow" "10.0.1"
 
 check "conda-update-conda" bash -c "conda update -y conda"
 check "conda-install-tensorflow" bash -c "conda create --name test-env -c conda-forge --yes tensorflow"


### PR DESCRIPTION
**Devcontainer name**: 

- anaconda

**Description**:

This PR patches the following vulnerabilities:

- GHSA-j7hp-h8jx-5ppr - related to the `Pillow` package;
- GHSA-v845-jxx5-vc9f - related to the `urllib3` package.

These vulnerabilities come from the `continuumio/anaconda3` image.


**Changelog**:

- Bumped `Pillow` package version to address GHSA-j7hp-h8jx-5ppr;
- Bumped `urllib3` package version to address GHSA-v845-jxx5-vc9f;

_Tests_:

- Added test to verify `Pillow` minimum version (_Minimum package version set to `10.0.1` which fixes GHSA-j7hp-h8jx-5ppr_);
- Added test to verify `urllib3` minimum version (_Minimum package version set to `1.26.17` which fixes GHSA-v845-jxx5-vc9f_);


**Checklist**:

- [x] Checked that applied changes work as expected