### PR TITLE
[miniconda] Update `urllib3` package due to GHSA-v845-jxx5-vc9f

### DIFF
--- a/src/miniconda/.devcontainer/Dockerfile
+++ b/src/miniconda/.devcontainer/Dockerfile
@@ -10,6 +10,10 @@ RUN conda install \
     # https://github.com/advisories/GHSA-j8r2-6x86-q33q
     requests=2.31.0
 
+RUN python3 -m pip install --upgrade \
+    # https://github.com/advisories/GHSA-v845-jxx5-vc9f
+    urllib3==1.26.17
+
 # Reset and copy updated files with updated privs to keep image size down
 FROM mcr.microsoft.com/devcontainers/base:1-bullseye
 

--- a/src/miniconda/test-project/test.sh
+++ b/src/miniconda/test-project/test.sh
@@ -21,6 +21,7 @@ check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 checkPythonPackageVersion "cryptography" "41.0.3"
 checkPythonPackageVersion "setuptools" "65.5.1"
 checkPythonPackageVersion "wheel" "0.38.1"
+checkPythonPackageVersion "urllib3" "1.26.17"
 
 checkCondaPackageVersion "cryptography" "41.0.3"
 checkCondaPackageVersion "pyopenssl" "23.2.0"


### PR DESCRIPTION
**Devcontainer name**: 

- miniconda

**Description**:

This PR addresses the GHSA-v845-jxx5-vc9f vulnerability. The vulnerability comes from the `continuumio/miniconda3` image and is related to the `urllib3` package.

*Changelog*:

- Bumped `urllib3` package version to address GHSA-v845-jxx5-vc9f;

- Added test to verify `urllib3` minimum version (_Minimum package version set to `1.26.17` which fixes GHSA-v845-jxx5-vc9f_);

**Checklist**:

- [x] Checked that applied changes work as expected