### PR TITLE
[universal] Update `urllib3` package due to GHSA-v845-jxx5-vc9f

### DIFF
--- a/src/universal/.devcontainer/local-features/patch-conda/install.sh
+++ b/src/universal/.devcontainer/local-features/patch-conda/install.sh
@@ -58,3 +58,6 @@ update_python_package /opt/conda/bin/python3 cryptography "41.0.4"
 
 # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-32681
 update_conda_package requests "2.31.0"
+
+# https://github.com/advisories/GHSA-v8gr-m533-ghj9
+update_python_package /opt/conda/bin/python3 urllib3 "1.26.17"

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -197,6 +197,7 @@ checkPythonPackageVersion "/usr/local/python/3.9.*/bin/python" "setuptools" "65.
 checkCondaPackageVersion "requests" "2.31.0"
 checkCondaPackageVersion "cryptography" "41.0.4"
 checkCondaPackageVersion "pyopenssl" "23.2.0"
+checkCondaPackageVersion "urllib3" "1.26.17"
 
 ## Test Conda
 check "conda-update-conda" bash -c "conda update -y conda"


### PR DESCRIPTION
**Devcontainer name**: 

- universal

**Description**:

This PR addresses the GHSA-v845-jxx5-vc9f vulnerability. The vulnerability comes from the `conda` distribution and is related to the `urllib3` package.

*Changelog*:

- Updated `patch-conda` feature to install the patched `urllib3` package version;

- Added test to verify `urllib3` minimum version (_Minimum package version set to `1.26.17` which fixes GHSA-v845-jxx5-vc9f_);

**Checklist**:

- [x] Checked that applied changes work as expected