### PR TITLE
[anaconda] Update `imagecodecs` package due to GHSA-94vc-p8w7-5p49

### DIFF
--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -39,7 +39,9 @@ RUN python3 -m pip install --upgrade \
     # https://github.com/advisories/GHSA-r726-vmfq-j9j3 
     jupyter_server==2.7.2 \
     # https://github.com/advisories/GHSA-v845-jxx5-vc9f
-    urllib3==1.26.17
+    urllib3==1.26.17 \ 
+    # https://github.com/advisories/GHSA-94vc-p8w7-5p49
+    imagecodecs==2023.9.18
 
 # Reset and copy updated files with updated privs to keep image size down
 FROM mcr.microsoft.com/devcontainers/base:1-bullseye

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -46,6 +46,7 @@ checkPythonPackageVersion "mpmath" "1.3.0"
 checkPythonPackageVersion "aiohttp" "3.8.5"
 checkPythonPackageVersion "jupyter_server" "2.7.2"
 checkPythonPackageVersion "urllib3" "1.26.17"
+checkPythonPackageVersion "imagecodecs" "2023.9.18"
 
 # The `tornado` package doesn't have the `__version__` attribute so we can use the `version` attribute.
 tornado_version=$(python -c "import tornado; print(tornado.version)")


### PR DESCRIPTION
**Devcontainer name**: 

- anaconda

**Description**:

This PR addresses the GHSA-94vc-p8w7-5p49 vulnerability. The vulnerability comes from the `continuumio/anaconda3` image and is related to the `imagecodecs` package.

*Changelog*:

- Bumped `imagecodecs` package version to address GHSA-v845-jxx5-vc9f;

- Added test to verify `imagecodecs` minimum version (_Minimum package version set to `2023.9.18` which fixes GHSA-94vc-p8w7-5p49_);

**Checklist**:

- [x] Checked that applied changes work as expected