### PR TITLE
[Dotnet] - Supports bookworm (New major version)

### DIFF
--- a/src/dotnet/.devcontainer/Dockerfile
+++ b/src/dotnet/.devcontainer/Dockerfile
@@ -1,3 +1,3 @@
-ARG VARIANT=7.0-bullseye-slim
+ARG VARIANT=7.0-bookworm-slim
 FROM mcr.microsoft.com/dotnet/sdk:${VARIANT}
 ENV PATH $PATH:/home/vscode/.dotnet:/home/vscode/.dotnet/tools

--- a/src/dotnet/README.md
+++ b/src/dotnet/README.md
@@ -9,10 +9,10 @@
 | *Categories* | Core, Languages |
 | *Image type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/dotnet |
-| *Available image variants* | 6.0 /6.0-bullseye, 6.0-jammy, 6.0-focal, 7.0 /7.0-bullseye, 7.0-jammy ([full list](https://mcr.microsoft.com/v2/devcontainers/dotnet/tags/list)) |
-| *Published image architecture(s)* | x86-64, arm64/aarch64 for `bullseye`, `jammy` variants |
+| *Available image variants* | 6.0 /6.0-bookworm, 6.0-bullseye, 6.0-jammy, 6.0-focal, 7.0 /7.0-bookworm, 7.0-bullseye, 7.0-jammy ([full list](https://mcr.microsoft.com/v2/devcontainers/dotnet/tags/list)) |
+| *Published image architecture(s)* | x86-64, arm64/aarch64 for `bookworm`, `bullseye`, `jammy` variants |
 | *Container host OS support* | Linux, macOS, Windows |
-| *Container OS* | Ubuntu (`-focal`, `-jammy`), Debian (`-bullseye`) |
+| *Container OS* | Ubuntu (`-focal`, `-jammy`), Debian (`-bullseye`, `-bookworm`) |
 | *Languages, platforms* | .NET, .NET Core, C# |
 
 See **[history](history)** for information on the contents of published images.
@@ -22,16 +22,16 @@ See **[history](history)** for information on the contents of published images.
 You can directly reference pre-built versions of `Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
 
 - `mcr.microsoft.com/devcontainers/dotnet` (latest)
-- `mcr.microsoft.com/devcontainers/dotnet:6.0` (or `6.0-bullseye`, `6.0-jammy`, `6.0-focal` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/dotnet:7.0` (or `7.0-bullseye`, `7.0-jammy` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/dotnet:6.0` (or `6.0-bookworm`, `6.0-bullseye`, `6.0-jammy`, `6.0-focal` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/dotnet:7.0` (or `7.0-bookworm`, `7.0-bullseye`, `7.0-jammy` to pin to an OS version)
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/devcontainers/dotnet:0-7.0`
-- `mcr.microsoft.com/devcontainers/dotnet:0.204-7.0`
-- `mcr.microsoft.com/devcontainers/dotnet:0.204.0-7.0`
+- `mcr.microsoft.com/devcontainers/dotnet:1-7.0`
+- `mcr.microsoft.com/devcontainers/dotnet:1.0-7.0`
+- `mcr.microsoft.com/devcontainers/dotnet:1.0.0-7.0`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/dotnet/tags/list).
 

--- a/src/dotnet/manifest.json
+++ b/src/dotnet/manifest.json
@@ -1,8 +1,10 @@
 {
 	"version": "0.204.14",
 	"variants": [
+		"7.0-bookworm-slim",
 		"7.0-bullseye-slim",
 		"7.0-jammy",
+		"6.0-bookworm-slim",
 		"6.0-bullseye-slim",
 		"6.0-jammy",
 		"6.0-focal"
@@ -14,11 +16,19 @@
 			"dotnet:${VERSION}-${VARIANT}"
 		],
 		"architectures": {
+			"7.0-bookworm-slim": [
+				"linux/amd64",
+				"linux/arm64"
+			],
 			"7.0-bullseye-slim": [
 				"linux/amd64",
 				"linux/arm64"
 			],
 			"7.0-jammy": [
+				"linux/amd64",
+				"linux/arm64"
+			],
+			"6.0-bookworm-slim": [
 				"linux/amd64",
 				"linux/arm64"
 			],
@@ -35,12 +45,18 @@
 			]
 		},
 		"variantTags": {
-			"7.0-bullseye-slim": [
+			"7.0-bookworm-slim": [
 				"dotnet:${VERSION}-7.0",
+				"dotnet:${VERSION}-7.0-bookworm"
+			],
+			"7.0-bullseye-slim": [
 				"dotnet:${VERSION}-7.0-bullseye"
 			],
-			"6.0-bullseye-slim": [
+			"6.0-bookworm-slim": [
 				"dotnet:${VERSION}-6.0",
+				"dotnet:${VERSION}-6.0-bookworm"
+			],
+			"6.0-bullseye-slim": [
 				"dotnet:${VERSION}-6.0-bullseye"
 			]
 		}

--- a/src/dotnet/test-project/test-utils.sh
+++ b/src/dotnet/test-project/test-utils.sh
@@ -126,7 +126,7 @@ checkCommon()
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        liblttng-ust0 \
+        liblttng-ust1 \
         libstdc++6 \
         zlib1g \
         locales \


### PR DESCRIPTION
Closes: https://github.com/devcontainers/images/issues/612

As supporting bookworm by default is a breaking change, the images release will bump the major version of this image. See https://github.com/devcontainers/images/issues/607 for more information