### PR TITLE
v0.3.23

### DIFF
--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -39,9 +39,7 @@ RUN python3 -m pip install --upgrade \
     # https://github.com/advisories/GHSA-r726-vmfq-j9j3 
     jupyter_server==2.7.2 \
     # https://github.com/advisories/GHSA-v845-jxx5-vc9f
-    urllib3==1.26.17 \ 
-    # https://github.com/advisories/GHSA-94vc-p8w7-5p49
-    imagecodecs==2023.9.18
+    urllib3==1.26.17
 
 # Reset and copy updated files with updated privs to keep image size down
 FROM mcr.microsoft.com/devcontainers/base:1-bullseye

--- a/src/anaconda/.devcontainer/devcontainer-lock.json
+++ b/src/anaconda/.devcontainer/devcontainer-lock.json
@@ -6,9 +6,9 @@
       "integrity": "sha256:2ab83ca71d55d5c00a1255b07f3a83a53cd2de77ce8b9637abad38095d672a5b"
     },
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "1.3.0",
-      "resolved": "ghcr.io/devcontainers/features/node@sha256:55e15045a77aea36f129a89e01cb8dfc0fa56a9094b3f7b5d9a473805288bc45",
-      "integrity": "sha256:55e15045a77aea36f129a89e01cb8dfc0fa56a9094b3f7b5d9a473805288bc45"
+      "version": "1.3.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:7d31b83459dd5110c37e7f5acb2920335cb1e5ebf014326d7eb6a0b290cc820a",
+      "integrity": "sha256:7d31b83459dd5110c37e7f5acb2920335cb1e5ebf014326d7eb6a0b290cc820a"
     }
   }
 }

--- a/src/anaconda/manifest.json
+++ b/src/anaconda/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.204.4",
+	"version": "0.204.5",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -46,7 +46,6 @@ checkPythonPackageVersion "mpmath" "1.3.0"
 checkPythonPackageVersion "aiohttp" "3.8.5"
 checkPythonPackageVersion "jupyter_server" "2.7.2"
 checkPythonPackageVersion "urllib3" "1.26.17"
-checkPythonPackageVersion "imagecodecs" "2023.9.18"
 
 # The `tornado` package doesn't have the `__version__` attribute so we can use the `version` attribute.
 tornado_version=$(python -c "import tornado; print(tornado.version)")

--- a/src/dotnet/.devcontainer/devcontainer-lock.json
+++ b/src/dotnet/.devcontainer/devcontainer-lock.json
@@ -11,9 +11,9 @@
       "integrity": "sha256:2ab83ca71d55d5c00a1255b07f3a83a53cd2de77ce8b9637abad38095d672a5b"
     },
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "1.3.0",
-      "resolved": "ghcr.io/devcontainers/features/node@sha256:55e15045a77aea36f129a89e01cb8dfc0fa56a9094b3f7b5d9a473805288bc45",
-      "integrity": "sha256:55e15045a77aea36f129a89e01cb8dfc0fa56a9094b3f7b5d9a473805288bc45"
+      "version": "1.3.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:7d31b83459dd5110c37e7f5acb2920335cb1e5ebf014326d7eb6a0b290cc820a",
+      "integrity": "sha256:7d31b83459dd5110c37e7f5acb2920335cb1e5ebf014326d7eb6a0b290cc820a"
     }
   }
 }

--- a/src/dotnet/manifest.json
+++ b/src/dotnet/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.204.14",
+	"version": "1.0.0",
 	"variants": [
 		"7.0-bookworm-slim",
 		"7.0-bullseye-slim",

--- a/src/miniconda/.devcontainer/devcontainer-lock.json
+++ b/src/miniconda/.devcontainer/devcontainer-lock.json
@@ -6,9 +6,9 @@
       "integrity": "sha256:2ab83ca71d55d5c00a1255b07f3a83a53cd2de77ce8b9637abad38095d672a5b"
     },
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "1.3.0",
-      "resolved": "ghcr.io/devcontainers/features/node@sha256:55e15045a77aea36f129a89e01cb8dfc0fa56a9094b3f7b5d9a473805288bc45",
-      "integrity": "sha256:55e15045a77aea36f129a89e01cb8dfc0fa56a9094b3f7b5d9a473805288bc45"
+      "version": "1.3.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:7d31b83459dd5110c37e7f5acb2920335cb1e5ebf014326d7eb6a0b290cc820a",
+      "integrity": "sha256:7d31b83459dd5110c37e7f5acb2920335cb1e5ebf014326d7eb6a0b290cc820a"
     },
     "ghcr.io/devcontainers/features/python:1": {
       "version": "1.2.1",

--- a/src/miniconda/manifest.json
+++ b/src/miniconda/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.203.1",
+	"version": "0.203.2",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/src/universal/manifest.json
+++ b/src/universal/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.5.7",
+	"version": "2.5.8",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",


### PR DESCRIPTION
Changelog -

- [[universal] Update cryptography package due to GHSA-v8gr-m533-ghj9](https://github.com/devcontainers/images/pull/795)
- [[anaconda] Address vulnerabilities: GHSA-j7hp-h8jx-5ppr, GHSA-v845-jxx5-vc9f](https://github.com/devcontainers/images/pull/801)
- [[miniconda] Update urllib3 package due to GHSA-v845-jxx5-vc9f](https://github.com/devcontainers/images/pull/802)
- [[universal] Update urllib3 package due to GHSA-v845-jxx5-vc9f](https://github.com/devcontainers/images/pull/803)
- [[Dotnet] - Supports bookworm (New major version)](https://github.com/devcontainers/images/pull/809)