### PR TITLE
[anaconda] Rework patch for GHSA-94vc-p8w7-5p49

### DIFF
--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -5,9 +5,12 @@ RUN . /etc/os-release && if [ "${VERSION_CODENAME}" != "bullseye" ]; then exit 1
 
 # Temporary: Upgrade python packages due to mentioned CVEs
 # They are installed by the base image (continuumio/anaconda3) which does not have the patch.
-RUN conda install \ 
+RUN conda install \
+    # Update "setuptools" and "wheel" to avoid potential issues with installing newer versions of packages
+    setuptools=68.0.0 \
+    wheel=0.41.2 \
     # pyopenssl should be updated to be compatible with latest version of cryptography
-    pyopenssl=23.2.0 \ 
+    pyopenssl=23.2.0 \
     # https://github.com/advisories/GHSA-jm77-qphf-c4w8
     cryptography=41.0.3 \
     # https://github.com/advisories/GHSA-j8r2-6x86-q33q
@@ -39,7 +42,9 @@ RUN python3 -m pip install --upgrade \
     # https://github.com/advisories/GHSA-r726-vmfq-j9j3 
     jupyter_server==2.7.2 \
     # https://github.com/advisories/GHSA-v845-jxx5-vc9f
-    urllib3==1.26.17
+    urllib3==1.26.17 \
+    # https://github.com/advisories/GHSA-94vc-p8w7-5p49
+    imagecodecs==2023.9.18
 
 # Reset and copy updated files with updated privs to keep image size down
 FROM mcr.microsoft.com/devcontainers/base:1-bullseye

--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -44,7 +44,7 @@ RUN python3 -m pip install --upgrade \
     # https://github.com/advisories/GHSA-v845-jxx5-vc9f
     urllib3==1.26.17 \
     # https://github.com/advisories/GHSA-94vc-p8w7-5p49
-    imagecodecs==2023.9.18
+    imagecodecs[all]==2023.9.18
 
 # Reset and copy updated files with updated privs to keep image size down
 FROM mcr.microsoft.com/devcontainers/base:1-bullseye

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -46,6 +46,7 @@ checkPythonPackageVersion "mpmath" "1.3.0"
 checkPythonPackageVersion "aiohttp" "3.8.5"
 checkPythonPackageVersion "jupyter_server" "2.7.2"
 checkPythonPackageVersion "urllib3" "1.26.17"
+checkPythonPackageVersion "imagecodecs" "2023.9.18"
 
 # The `tornado` package doesn't have the `__version__` attribute so we can use the `version` attribute.
 tornado_version=$(python -c "import tornado; print(tornado.version)")


### PR DESCRIPTION
**Devcontainer name**: 

- anaconda

**Description**:

The previous patch (#807) was reverted in #812 due to the following error:

```console
ERROR: Could not build wheels for imagecodecs, which is required to install pyproject.toml-based projects
```

It seems the issue could be related to old versions of `setuptools` and `wheel` packages. To address this issue, the patch was reworked to update versions of `setuptools` and `wheel` packages along with `imagecodecs`.

*Changelog*:

- Updated `setuptools` and `wheel` to avoid potential issues with installing newer versions of packages;

- Bumped `imagecodecs` package version to address GHSA-94vc-p8w7-5p49;

- Added test to verify `imagecodecs` minimum version (_Minimum package version set to `2023.9.18` which fixes GHSA-94vc-p8w7-5p49_);

**Checklist**:

- [x] Checked that applied changes work as expected