### PR TITLE
[universal] Rework patch for GHSA-v845-jxx5-vc9f

### DIFF
--- a/src/universal/.devcontainer/local-features/patch-conda/install.sh
+++ b/src/universal/.devcontainer/local-features/patch-conda/install.sh
@@ -59,5 +59,5 @@ update_python_package /opt/conda/bin/python3 cryptography "41.0.4"
 # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-32681
 update_conda_package requests "2.31.0"
 
-# https://github.com/advisories/GHSA-v8gr-m533-ghj9
-update_python_package /opt/conda/bin/python3 urllib3 "1.26.17"
+# https://github.com/advisories/GHSA-v845-jxx5-vc9f
+update_conda_package urllib3 "1.26.18"


### PR DESCRIPTION
**Devcontainer name**: 

- universal

**Description**:

This PR reworks the patch for the GHSA-v845-jxx5-vc9f vulnerability to install the `urllib3` package from the Conda default channel instead of PIP. Currently, version `1.26.18` is only available in the [Conda default channel](https://anaconda.org/anaconda/urllib3/files).

*Changelog*:

- Reworked patch for GHSA-v845-jxx5-vc9f to install a patched version of the `urllib3` package via the `conda install` command;

**Checklist**:

- [x] Checked that applied changes work as expected