### PR TITLE
[anaconda / miniconda] Update tests

### DIFF
--- a/src/anaconda/test-project/test-utils.sh
+++ b/src/anaconda/test-project/test-utils.sh
@@ -168,7 +168,7 @@ checkPythonPackageVersion()
     PACKAGE=$1
     REQUIRED_VERSION=$2
 
-    current_version=$(python -c "import ${PACKAGE}; print(${PACKAGE}.__version__)")
+    current_version=$(python -c "import importlib.metadata; print(importlib.metadata.version('${PACKAGE}'))")
     check-version-ge "${PACKAGE}-requirement" "${current_version}" "${REQUIRED_VERSION}"
 }
 

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -45,10 +45,7 @@ checkPythonPackageVersion "transformers" "4.30.0"
 checkPythonPackageVersion "mpmath" "1.3.0"
 checkPythonPackageVersion "aiohttp" "3.8.5"
 checkPythonPackageVersion "jupyter_server" "2.7.2"
-
-# The `tornado` package doesn't have the `__version__` attribute so we can use the `version` attribute.
-tornado_version=$(python -c "import tornado; print(tornado.version)")
-check-version-ge "tornado-requirement" "${tornado_version}" "6.3.3"
+checkPythonPackageVersion "tornado" "6.3.3"
 
 checkCondaPackageVersion "pyopenssl" "23.2.0"
 checkCondaPackageVersion "cryptography" "41.0.3"

--- a/src/miniconda/test-project/test-utils.sh
+++ b/src/miniconda/test-project/test-utils.sh
@@ -169,7 +169,7 @@ checkPythonPackageVersion()
     PACKAGE=$1
     REQUIRED_VERSION=$2
 
-    current_version=$(python -c "import ${PACKAGE}; print(${PACKAGE}.__version__)")
+    current_version=$(python -c "import importlib.metadata; print(importlib.metadata.version('${PACKAGE}'))")
     check-version-ge "${PACKAGE}-requirement" "${current_version}" "${REQUIRED_VERSION}"
 }
 


### PR DESCRIPTION
**Devcontainer name**: 

- anaconda
- miniconda

**Description**:

We need to change the `checkPythonPackageVersion` function to make it work for all Python packages. In the previous implementation, the check relies on the `__version__` attribute. Now function uses the `importlib.metadata` [library](https://docs.python.org/3/library/importlib.metadata.html#distribution-versions) to get the package version. This approach should work for all packages.

**Changelog**:

anaconda:

- Reworked test for checking the `tornado` package version;
- Reworked the `checkPythonPackageVersion` function to use the `importlib.metadata` library;

miniconda:

- Reworked the `checkPythonPackageVersion` function to use the `importlib.metadata` library;

**Checklist**:

- [x] Checked that applied changes work as expected