### PR TITLE
[universal] Update `urllib3` package due to GHSA-g4mx-q9vg-27p4

### DIFF
--- a/src/universal/.devcontainer/local-features/patch-python/install.sh
+++ b/src/universal/.devcontainer/local-features/patch-python/install.sh
@@ -44,3 +44,6 @@ update_package() {
 
 # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40897
 update_package /usr/local/python/3.9.*/bin/python setuptools 65.5.1
+
+# https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-45803
+update_package /usr/local/python/3.10.*/bin/python urllib3 2.0.7

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -189,6 +189,7 @@ ls -la /home/codespace
 ## Python - current
 checkPythonPackageVersion "python" "setuptools" "65.5.1"
 checkPythonPackageVersion "python" "requests" "2.31.0"
+checkPythonPackageVersion "python" "urllib3" "2.0.7"
 
 ## Python 3.9
 checkPythonPackageVersion "/usr/local/python/3.9.*/bin/python" "setuptools" "65.5.1"


### PR DESCRIPTION
**Devcontainer name**: 

- universal

**Description**:

This PR addresses the GHSA-g4mx-q9vg-27p4 vulnerability. The vulnerability comes from the `Python` distribution and is related to the `urllib3` package.

*Changelog*:

- Updated `patch-python` feature to install the patched `urllib3` package version;

- Added test to verify `urllib3` minimum version (_Minimum package version set to `2.0.7` which fixes GHSA-g4mx-q9vg-27p4_);

**Checklist**:

- [x] Checked that applied changes work as expected