### PR TITLE
Drop dotnet:8.0-bullseye due to upstream unavailability

### DIFF
--- a/src/dotnet/README.md
+++ b/src/dotnet/README.md
@@ -9,7 +9,7 @@
 | *Categories* | Core, Languages |
 | *Image type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/dotnet |
-| *Available image variants* | 8.0 /8.0-bookworm, 8.0-bullseye, 8.0-jammy, 7.0 /7.0-bookworm, 7.0-bullseye, 7.0-jammy, 6.0 /6.0-bookworm, 6.0-bullseye, 6.0-jammy, 6.0-focal ([full list](https://mcr.microsoft.com/v2/devcontainers/dotnet/tags/list)) |
+| *Available image variants* | 8.0 /8.0-bookworm, 8.0-jammy, 7.0 /7.0-bookworm, 7.0-bullseye, 7.0-jammy, 6.0 /6.0-bookworm, 6.0-bullseye, 6.0-jammy, 6.0-focal ([full list](https://mcr.microsoft.com/v2/devcontainers/dotnet/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bookworm`, `bullseye`, `jammy` variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Ubuntu (`-focal`, `-jammy`), Debian (`-bullseye`, `-bookworm`) |
@@ -22,7 +22,7 @@ See **[history](history)** for information on the contents of published images.
 You can directly reference pre-built versions of `Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
 
 - `mcr.microsoft.com/devcontainers/dotnet` (latest)
-- `mcr.microsoft.com/devcontainers/dotnet:8.0` (or `8.0-bookworm`, `8.0-bullseye`, `8.0-jammy` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/dotnet:8.0` (or `8.0-bookworm`, `8.0-jammy` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/dotnet:7.0` (or `7.0-bookworm`, `7.0-bullseye`, `7.0-jammy` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/dotnet:6.0` (or `6.0-bookworm`, `6.0-bullseye`, `6.0-jammy`, `6.0-focal` to pin to an OS version)
 

--- a/src/dotnet/manifest.json
+++ b/src/dotnet/manifest.json
@@ -2,7 +2,6 @@
 	"version": "1.0.1",
 	"variants": [
 		"8.0-bookworm-slim",
-		"8.0-bullseye-slim",
 		"8.0-jammy",
 		"7.0-bookworm-slim",
 		"7.0-bullseye-slim",
@@ -13,17 +12,13 @@
 		"6.0-focal"
 	],
 	"build": {
-		"latest": "8.0-bullseye-slim",
+		"latest": "8.0-bookworm-slim",
 		"rootDistro": "debian",
 		"tags": [
 			"dotnet:${VERSION}-${VARIANT}"
 		],
 		"architectures": {
 			"8.0-bookworm-slim": [
-				"linux/amd64",
-				"linux/arm64"
-			],
-			"8.0-bullseye-slim": [
 				"linux/amd64",
 				"linux/arm64"
 			],
@@ -63,9 +58,6 @@
 			"8.0-bookworm-slim": [
 				"dotnet:${VERSION}-8.0",
 				"dotnet:${VERSION}-8.0-bookworm"
-			],
-			"8.0-bullseye-slim": [
-				"dotnet:${VERSION}-8.0-bullseye"
 			],
 			"7.0-bookworm-slim": [
 				"dotnet:${VERSION}-7.0",


### PR DESCRIPTION
Fixes https://github.com/devcontainers/images/actions/runs/6882081495/job/18719819258#step:6:3594

Opened https://github.com/dotnet/dotnet-docker/issues/5001 as dotnet images for `8.0-bullseye` are unavailable.