### PR TITLE
Support PHP 8.3

### DIFF
--- a/src/php/.devcontainer/Dockerfile
+++ b/src/php/.devcontainer/Dockerfile
@@ -1,5 +1,4 @@
-# [Choice] PHP version (use -bullseye variants on local arm64/Apple Silicon): 8-apache-bookworm, 8.2-apache-bookworm, 8.1-apache-bookworm, 8-apache-bullseye, 8.2-apache-bullseye, 8.1-apache-bullseye, 8.0-apache-bullseye, 8-apache-buster, 8.2-apache-buster, 8.1-apache-buster, 8.0-apache-buster
-ARG VARIANT=8.2-apache-bookworm
+ARG VARIANT=8.3-apache-bookworm
 FROM php:${VARIANT}
 
 # Install xdebug

--- a/src/php/README.md
+++ b/src/php/README.md
@@ -9,7 +9,7 @@
 | *Categories* | Languages |
 | *Image type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/php |
-| *Available image variants* | 8 / 8-bookworm, 8.2 / 8.2-bookworm, 8.1 / 8.1-bookworm, 8.0 / 8.0-bookworm, 8-bullseye, 8.2-bullseye, 8.1-bullseye, 8.0-bullseye, 8-buster, 8.2-buster, 8.1-buster, 8.0-buster ([full list](https://mcr.microsoft.com/v2/devcontainers/php/tags/list)) |
+| *Available image variants* | 8 / 8-bookworm, 8.3 / 8.3-bookworm, 8.2 / 8.2-bookworm, 8.1 / 8.1-bookworm, 8.0 / 8.0-bookworm, 8-bullseye, 8.3-bullseye, 8.2-bullseye, 8.1-bullseye, 8.0-bullseye, 8-buster, 8.2-buster, 8.1-buster, 8.0-buster ([full list](https://mcr.microsoft.com/v2/devcontainers/php/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bookworm`, and `bullseye` variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -23,6 +23,7 @@ You can directly reference pre-built versions of `Dockerfile` by using the `imag
 
 - `mcr.microsoft.com/devcontainers/php` (latest)
 - `mcr.microsoft.com/devcontainers/php:8` (or `8-bookworm`, `8-bullseye`, `8-buster` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/php:8.3` (or `8.3-bookworm`, `8.3-bullseye` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/php:8.2` (or `8.2-bookworm`, `8.2-bullseye`, `8.2-buster` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/php:8.1` (or `8.1-bookworm`, `8.1-bullseye`, `8.1-buster` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/php:8.0` (or `8.0-bullseye`, `8.0-buster` to pin to an OS version)

--- a/src/php/manifest.json
+++ b/src/php/manifest.json
@@ -1,8 +1,10 @@
 {
 	"version": "1.0.5",
 	"variants": [
+		"8.3-apache-bookworm",
 		"8.2-apache-bookworm",
 		"8.1-apache-bookworm",
+		"8.3-apache-bullseye",
 		"8.2-apache-bullseye",
 		"8.1-apache-bullseye",
 		"8.0-apache-bullseye",
@@ -11,14 +13,22 @@
 		"8.0-apache-buster"
 	],
 	"build": {
-		"latest": "8.2-apache-bookworm",
+		"latest": "8.3-apache-bookworm",
 		"rootDistro": "debian",
 		"architectures": {
+			"8.3-apache-bookworm": [
+				"linux/amd64",
+				"linux/arm64"
+			],
 			"8.2-apache-bookworm": [
 				"linux/amd64",
 				"linux/arm64"
 			],
 			"8.1-apache-bookworm": [
+				"linux/amd64",
+				"linux/arm64"
+			],
+			"8.3-apache-bullseye": [
 				"linux/amd64",
 				"linux/arm64"
 			],
@@ -48,21 +58,28 @@
 			"php:${VERSION}-${VARIANT}"
 		],
 		"variantTags": {
-			"8.2-apache-bookworm": [
+			"8.3-apache-bookworm": [
 				"php:${VERSION}-8",
-				"php:${VERSION}-8.2",
+				"php:${VERSION}-8.3",
 				"php:${VERSION}-8-bookworm",
-				"php:${VERSION}-8.2-bookworm",
+				"php:${VERSION}-8.3-bookworm",
 				"php:${VERSION}-bookworm"
+			],
+			"8.2-apache-bookworm": [
+				"php:${VERSION}-8.2",
+				"php:${VERSION}-8.2-bookworm"
 			],
 			"8.1-apache-bookworm": [
 				"php:${VERSION}-8.1",
 				"php:${VERSION}-8.1-bookworm"
 			],
-			"8.2-apache-bullseye": [
+			"8.3-apache-bullseye": [
 				"php:${VERSION}-8-bullseye",
-				"php:${VERSION}-8.2-bullseye",
+				"php:${VERSION}-8.3-bullseye",
 				"php:${VERSION}-bullseye"
+			],
+			"8.2-apache-bullseye": [
+				"php:${VERSION}-8.2-bullseye"
 			],
 			"8.1-apache-bullseye": [
 				"php:${VERSION}-8.1-bullseye"

--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -31,8 +31,8 @@
         },
         "./local-features/machine-learning-packages": "latest",
         "ghcr.io/devcontainers/features/php:1": {
-            "version": "8.2.1",
-            "additionalVersions": "8.1.14",
+            "version": "8.3.0",
+            "additionalVersions": "8.2.13",
             "installComposer": "true"
         },
         "ghcr.io/devcontainers/features/conda:1": {


### PR DESCRIPTION
Ref: https://github.com/devcontainers/images/issues/828

Adds support for PHP 8.3 for the `php` and `universal` images