### PR TITLE
Tool for generating image release changes

### DIFF
--- a/build/prepare-release.sh
+++ b/build/prepare-release.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# This script is used to prepare a release of the dev containers.
+# It will bump the version of the manifest.json file and run the devcontainer upgrade command.
+# It will only run on the images that have been modified since the last release commit that is passed in as the first argument.
+# If the second argument is "monthly", it will run on all images.
+# Example adhoc release: ./build/prepare-release.sh 1c6f558dc86aafd7749074ec44e238f331303517
+# Example monthly release: ./build/prepare-release.sh 1c6f558dc86aafd7749074ec44e238f331303517 monthly
+
+
+SCRIPT_SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+SRC_DIR=$(readlink -m $SCRIPT_SOURCE_DIR/../src)
+MANIFEST_FILE="manifest.json"
+COMMIT_HASH=$1
+RELEASE_TYPE=$2
+
+get_modified_images() {
+	git diff --name-only --diff-filter=ACMRTUB ${COMMIT_HASH} HEAD ${SRC_DIR} | while read file; do
+		if [ ! -z $file ]; then
+			commitMessage=$(git log -1 $file)
+			# omit auto commits from bot
+			if [[ $commitMessage != *"Dev containers Bot"* ]]; then
+				# only get the top level directory for the image
+				if [ $(echo $file | tr "/" "\n" | wc -l) -eq 3 ]; then
+					readlink -m $(dirname $file)
+				fi
+			fi
+		fi
+	done | sort | uniq
+}
+
+get_all_images() {
+	find $SRC_DIR -maxdepth 1 -type d | tail -n +2 | sort | uniq
+}
+
+bump_version() {
+	directory=$1
+	manifestPath="$directory/$MANIFEST_FILE"
+	version=$(grep -oP '(?<="version": ")[^"]*' $manifestPath)
+	newVersion=$(echo $version | awk -F. -v OFS=. '{$NF += 1 ; print}')
+	sed -i "s/\"version\": \"$version\"/\"version\": \"$newVersion\"/g" $manifestPath
+}
+
+release_image() {
+	image=$1
+	echo "-----------------------------------------------"
+	echo "Releasing image $image"
+	echo "-----------------------------------------------"
+
+	bump_version $image
+	devcontainer upgrade --workspace-folder $image
+}
+
+adhoc_release() {
+    for image in $(get_modified_images); do
+        release_image $image
+    done
+}
+
+monthly_release() {
+    for image in $(get_all_images); do
+        release_image $image
+    done
+}
+
+main() {
+	if [ "$COMMIT_HASH" == "" ]; then
+		echo "Commit hash is required"
+		exit 1
+	fi
+
+	if [ "$RELEASE_TYPE" == "monthly" ]; then
+		monthly_release
+	else
+		adhoc_release
+	fi
+}
+
+main

--- a/build/prepare-release.sh
+++ b/build/prepare-release.sh
@@ -2,17 +2,16 @@
 
 # This script is used to prepare a release of the dev containers.
 # It will bump the version of the manifest.json file and run the devcontainer upgrade command.
-# It will only run on the images that have been modified since the last release commit that is passed in as the first argument.
-# If the second argument is "monthly", it will run on all images.
+# It will only run on the images that have been modified since the last release.
+# If no commit hash is provided, it will run in monthly release mode and bump the version of all images.
 # Example adhoc release: ./build/prepare-release.sh 1c6f558dc86aafd7749074ec44e238f331303517
-# Example monthly release: ./build/prepare-release.sh 1c6f558dc86aafd7749074ec44e238f331303517 monthly
+# Example monthly release: ./build/prepare-release.sh
 
 
 SCRIPT_SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 SRC_DIR=$(readlink -m $SCRIPT_SOURCE_DIR/../src)
 MANIFEST_FILE="manifest.json"
 COMMIT_HASH=$1
-RELEASE_TYPE=$2
 
 get_modified_images() {
 	git diff --name-only --diff-filter=ACMRTUB ${COMMIT_HASH} HEAD ${SRC_DIR} | while read file; do
@@ -65,11 +64,7 @@ monthly_release() {
 
 main() {
 	if [ "$COMMIT_HASH" == "" ]; then
-		echo "Commit hash is required"
-		exit 1
-	fi
-
-	if [ "$RELEASE_TYPE" == "monthly" ]; then
+		echo "No commit hash provided, running in monthly release mode"
 		monthly_release
 	else
 		adhoc_release


### PR DESCRIPTION
https://github.com/devcontainers/internal/issues/68

This pull request introduces a new script, `prepare-release.sh`, in the `build` directory. The script is designed to automate the process of preparing a release of the dev containers. It includes functionality to bump the version of the `manifest.json` file and run the `devcontainer upgrade` command. The script operates on either all images (useful for monthly release) or only those that have been modified since the last release commit (useful for ad-hoc release)

**The release PR https://github.com/devcontainers/images/pull/869 is created using this tool**

* <a href="diffhunk://#diff-f80c39bf43ffeebef6eee854c376f3f5fc899182c6154b9cb4e38275fda11249R1-R79">`build/prepare-release.sh`</a>: A new shell script that prepares a release of the dev containers. The script includes functions to get modified images, get all images, bump the version of the `manifest.json` file, and release an image. It also includes two types of releases: adhoc and monthly. The adhoc release operates on images modified since the last release commit, while the monthly release operates on all images. The script accepts a commit hash as input. If no commit hash is provided, it defaults to an monthly release.

Example adhoc release:
 `./build/prepare-release.sh 1c6f558dc86aafd7749074ec44e238f331303517`
Example monthly release:
 `./build/prepare-release.sh`

Note: It only bumps patch version. If you need to bump minor/major versions, that needs to be done manually.


<img width="1089" alt="image" src="https://github.com/devcontainers/images/assets/15967687/0d004755-5a81-4273-8faf-c137889b338b">

