### PR TITLE
Add permissions for OpenID connect auth to work on action workflows

### DIFF
--- a/.github/workflows/push-dev.yml
+++ b/.github/workflows/push-dev.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '0 14 * * MON'
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build-and-push:
     name: Build and push


### PR DESCRIPTION
https://github.com/devcontainers/internal/issues/67

Followup on https://github.com/devcontainers/images/pull/871 to fix the error: `Please make sure to give write permissions to id-token in the workflow.` seen on [this run](https://github.com/devcontainers/images/actions/runs/7105356581)