### PR TITLE
Try with removing contents permission so that nested jobs can override

### DIFF
--- a/.github/workflows/push-dev.yml
+++ b/.github/workflows/push-dev.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   id-token: write
-  contents: read
 
 jobs:
   build-and-push:


### PR DESCRIPTION
https://github.com/devcontainers/internal/issues/67

Followup on https://github.com/devcontainers/images/pull/872 to fix the following error on this [run](https://github.com/devcontainers/images/actions/runs/7105466881):

`The workflow is not valid. .github/workflows/push-dev.yml (Line: 77, Col: 3): Error calling workflow 'devcontainers/images/.github/workflows/version-history.yml@main'. The nested job 'image_info' is requesting 'contents: write, pull-requests: write', but is only allowed 'contents: read, pull-requests: none'.`

The idea is to remove `contents` permission so that the nested pipeline may be able to override it