### PR TITLE
Grant permissions required by nested pipeline, on push-dev.yml

### DIFF
--- a/.github/workflows/push-dev.yml
+++ b/.github/workflows/push-dev.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   id-token: write
+  contents: write
+  pull-requests: write
 
 jobs:
   build-and-push:


### PR DESCRIPTION
https://github.com/devcontainers/internal/issues/67

Followup on https://github.com/devcontainers/images/pull/873 to fix the error from this [run](https://github.com/devcontainers/images/actions/runs/7105582683): 

`Error calling workflow 'devcontainers/images/.github/workflows/version-history.yml@main'. The nested job 'image_info' is requesting 'contents: write, pull-requests: write', but is only allowed 'contents: none, pull-requests: none'.`

Learned that all permissions must be allowed on the calling workflow too (or not define anything)