### PR TITLE
[universal] Update `setuptools` for Python 3.10 due to GHSA-r9hx-vwmv-q579

### DIFF
--- a/src/universal/.devcontainer/local-features/patch-python/install.sh
+++ b/src/universal/.devcontainer/local-features/patch-python/install.sh
@@ -44,7 +44,7 @@ update_package() {
 
 # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40897
 update_package /usr/local/python/3.9.*/bin/python setuptools 65.5.1
-update_package /usr/local/python/3.10.*/bin/python setuptools 65.5.1
+update_package /usr/local/python/3.10.*/bin/python setuptools 68.2.2
 
 # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-45803
 update_package /usr/local/python/3.10.*/bin/python urllib3 2.0.7

--- a/src/universal/.devcontainer/local-features/patch-python/install.sh
+++ b/src/universal/.devcontainer/local-features/patch-python/install.sh
@@ -44,6 +44,7 @@ update_package() {
 
 # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40897
 update_package /usr/local/python/3.9.*/bin/python setuptools 65.5.1
+update_package /usr/local/python/3.10.*/bin/python setuptools 65.5.1
 
 # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-45803
 update_package /usr/local/python/3.10.*/bin/python urllib3 2.0.7


### PR DESCRIPTION
**Devcontainer name**: 

- universal

**Description**:

Recently, a test for verifying the `setuptools` package version started to fail due to the `setuptools` version downgrade. The original patch was removed in the following PR because the Python v3.10.13 version was shipped with `setuptools v68.2.2`:

- #831

It seems that the Python v3.10.13 distribution was changed and the `setuptools` package was downgraded for some reason.

*Changelog*:

- Updated `patch-python` feature to restore patch for `setuptools` package (The version is set to `68.2.2` to align it with [v2.6.0](https://github.com/devcontainers/images/blob/main/src/universal/history/2.6.0.md));

**Checklist**:

- [x] Checked that applied changes work as expected