### PR TITLE
Revert to use secrets since ODIC is not enabled for OSS

### DIFF
--- a/.github/workflows/push-dev.yml
+++ b/.github/workflows/push-dev.yml
@@ -5,11 +5,6 @@ on:
   schedule:
     - cron: '0 14 * * MON'
 
-permissions:
-  id-token: write
-  contents: write
-  pull-requests: write
-
 jobs:
   build-and-push:
     name: Build and push
@@ -20,7 +15,6 @@ jobs:
         page-total: [66]
       fail-fast: false
     runs-on: devcontainer-image-builder-ubuntu
-    environment: documentation
     steps:
     - name: Free more space
       id: free_space 
@@ -39,9 +33,7 @@ jobs:
       id: az_login
       uses: azure/login@v1
       with:
-        client-id: ${{ secrets.AZURE_CLIENT_ID }}
-        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        creds: ${{ secrets.AZ_ACR_CREDS }}
 
     - name: Build and push dev tags
       id: build_and_push

--- a/.github/workflows/version-history.yml
+++ b/.github/workflows/version-history.yml
@@ -52,9 +52,7 @@ jobs:
       id: az_login
       uses: azure/login@v1
       with:
-        client-id: ${{ secrets.AZURE_CLIENT_ID }}
-        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        creds: ${{ secrets.AZ_ACR_CREDS }}
 
     - name: Get image info
       id: Get_image_info


### PR DESCRIPTION
Since ODIC is not enabled for OSS org, reverting back to using secrets for azure auth