### PR TITLE
[anaconda] Devcontainer maintenance: Remove outdated patches

### DIFF
--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -5,15 +5,7 @@ RUN . /etc/os-release && if [ "${VERSION_CODENAME}" != "bullseye" ]; then exit 1
 
 # Temporary: Upgrade python packages due to mentioned CVEs
 # They are installed by the base image (continuumio/anaconda3) which does not have the patch.
-RUN conda install \ 
-    # pyopenssl should be updated to be compatible with latest version of cryptography
-    pyopenssl=23.2.0 \ 
-    # https://github.com/advisories/GHSA-jm77-qphf-c4w8
-    cryptography=41.0.3 \
-    # https://github.com/advisories/GHSA-j8r2-6x86-q33q
-    requests=2.31.0 \
-    # https://github.com/advisories/GHSA-f865-m6cq-j9vx
-    mpmath=1.3.0 \
+RUN conda install \
     # https://github.com/advisories/GHSA-gfw2-4jvh-wgfg
     aiohttp=3.8.6 \
     # https://github.com/advisories/GHSA-j7hp-h8jx-5ppr
@@ -36,8 +28,6 @@ RUN python3 -m pip install --upgrade \
     nbconvert==7.7.3 \
     # https://github.com/advisories/GHSA-qppv-j76h-2rpx
     tornado==6.3.3 \
-    # https://github.com/advisories/GHSA-282v-666c-3fvg
-    transformers==4.30.0 \ 
     # https://github.com/advisories/GHSA-r726-vmfq-j9j3 
     jupyter_server==2.7.2
 


### PR DESCRIPTION
**Dev container name**: 

- anaconda

**Description**:

Last month a newer version of `continuumio/anaconda3` was released. This version ships with updated versions of the Python packages. Thus, we can revisit our patches and see which patches could be removed from the devcontainer.

I checked the versions of the packages in `continuumio/anaconda3`, and here are the results:

<details>
  <summary>Results</summary>

  ```console
(base) root@1a82830ff111:/# conda list pyopenssl
# packages in environment at /opt/conda:
#
# Name                    Version                   Build  Channel
pyopenssl                 23.2.0          py311h06a4308_0

(base) root@1a82830ff111:/# conda list cryptography
# packages in environment at /opt/conda:
#
# Name                    Version                   Build  Channel
cryptography              41.0.3          py311hdda0065_0

(base) root@1a82830ff111:/# conda list requests
# packages in environment at /opt/conda:
#
# Name                    Version                   Build  Channel
requests                  2.31.0          py311h06a4308_0

(base) root@1a82830ff111:/# conda list mpmath
# packages in environment at /opt/conda:
#
# Name                    Version                   Build  Channel
mpmath                    1.3.0           py311h06a4308_0

(base) root@1a82830ff111:/# conda list aiohttp
# packages in environment at /opt/conda:
#
# Name                    Version                   Build  Channel
aiohttp                   3.8.5           py311h5eee18b_0

(base) root@1a82830ff111:/# conda list pillow
# packages in environment at /opt/conda:
#
# Name                    Version                   Build  Channel
pillow                    9.4.0           py311h6a678d5_1

(base) root@1a82830ff111:/# conda list urllib3
# packages in environment at /opt/conda:
#
# Name                    Version                   Build  Channel
urllib3                   1.26.16         py311h06a4308_0

(base) root@1a82830ff111:/# conda list joblib
# packages in environment at /opt/conda:
#
# Name                    Version                   Build  Channel
joblib                    1.2.0           py311h06a4308_0

(base) root@1a82830ff111:/# conda list cookiecutter
# packages in environment at /opt/conda:
#
# Name                    Version                   Build  Channel
cookiecutter              1.7.3              pyhd3eb1b0_0

(base) root@1a82830ff111:/# conda list mistune
# packages in environment at /opt/conda:
#
# Name                    Version                   Build  Channel
mistune                   0.8.4           py311h5eee18b_1000

(base) root@1a82830ff111:/# conda list numpy
# packages in environment at /opt/conda:
#
# Name                    Version                   Build  Channel
numpy                     1.24.3          py311h08b1b3b_1
numpy-base                1.24.3          py311hf175353_1
numpydoc                  1.5.0           py311h06a4308_0

(base) root@1a82830ff111:/# conda list werkzeug
# packages in environment at /opt/conda:
#
# Name                    Version                   Build  Channel
werkzeug                  2.2.3           py311h06a4308_0

(base) root@1a82830ff111:/# conda list nbconvert
# packages in environment at /opt/conda:
#
# Name                    Version                   Build  Channel
nbconvert                 6.5.4           py311h06a4308_0

(base) root@1a82830ff111:/# conda list tornado
# packages in environment at /opt/conda:
#
# Name                    Version                   Build  Channel
tornado                   6.3.2           py311h5eee18b_0

(base) root@1a82830ff111:/# conda list transformers
# packages in environment at /opt/conda:
#
# Name                    Version                   Build  Channel
transformers              4.32.1          py311h06a4308_0
  ```

</details>

Considering the results, I removed unactual patches because the upstream contains all the patched versions.

**Changelog**:

Dockerfile:

- Removed outdated patches to be in sync with the upstream image;

**Checklist**:

- [x] Checked that applied changes work as expected;