### PR TITLE
Remove deprecated Ruby extension

### DIFF
--- a/src/ruby/.devcontainer/devcontainer.json
+++ b/src/ruby/.devcontainer/devcontainer.json
@@ -24,7 +24,7 @@
         "vscode": {
             // Add the IDs of extensions you want installed when the container is created.
             "extensions": [
-                "rebornix.Ruby"
+                "Shopify.ruby-lsp"
             ]
         }
     },

--- a/src/ruby/.devcontainer/devcontainer.json
+++ b/src/ruby/.devcontainer/devcontainer.json
@@ -23,9 +23,7 @@
         // Configure properties specific to VS Code.
         "vscode": {
             // Add the IDs of extensions you want installed when the container is created.
-            "extensions": [
-                "Shopify.ruby-lsp"
-            ]
+            "extensions": []
         }
     },
     // Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/src/ruby/.devcontainer/devcontainer.json
+++ b/src/ruby/.devcontainer/devcontainer.json
@@ -18,20 +18,6 @@
             "ppa": "false"
         }
     },
-    // Configure tool-specific properties.
-    "customizations": {
-        // Configure properties specific to VS Code.
-        "vscode": {
-            // Add the IDs of extensions you want installed when the container is created.
-            "extensions": []
-        }
-    },
-    // Use 'forwardPorts' to make a list of ports inside the container available locally.
-    // "forwardPorts": [],
-
-    // Use 'postCreateCommand' to run commands after the container is created.
-    // "postCreateCommand": "ruby --version",
-
     // Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
     "remoteUser": "vscode"
 }


### PR DESCRIPTION
Helps https://github.com/devcontainers/images/issues/870

Does what it says on the tin. `rebornix.Ruby` has been deprecated and the Ruby feature is already installing the replacement: https://github.com/devcontainers/features/blob/3ea4d6bbd7864bcf7b5a91fdeeb66e4f5a6f46c0/src/ruby/devcontainer-feature.json#L21-L27