### PR TITLE
[Miniconda] Update cryptography package due to GHSA-jfhm-5ghh-2f97 vulnerability

### DIFF
--- a/src/miniconda/.devcontainer/Dockerfile
+++ b/src/miniconda/.devcontainer/Dockerfile
@@ -6,6 +6,10 @@ FROM continuumio/miniconda3 as upstream
     # https://github.com/advisories/<CVE_ID>
     # <package_name> = <version>
 
+RUN conda install \
+    # https://github.com/advisories/GHSA-jfhm-5ghh-2f97
+    cryptography==41.0.7
+
 # Reset and copy updated files with updated privs to keep image size down
 FROM mcr.microsoft.com/devcontainers/base:1-bullseye
 

--- a/src/miniconda/test-project/test.sh
+++ b/src/miniconda/test-project/test.sh
@@ -18,11 +18,11 @@ check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcont
 
 check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
-checkPythonPackageVersion "cryptography" "41.0.3"
+checkPythonPackageVersion "cryptography" "41.0.7"
 checkPythonPackageVersion "setuptools" "65.5.1"
 checkPythonPackageVersion "wheel" "0.38.1"
 
-checkCondaPackageVersion "cryptography" "41.0.3"
+checkCondaPackageVersion "cryptography" "41.0.7"
 checkCondaPackageVersion "pyopenssl" "23.2.0"
 checkCondaPackageVersion "setuptools" "65.5.1"
 checkCondaPackageVersion "wheel" "0.38.1"


### PR DESCRIPTION
 **Dev container name**:
 
 * miniconda
 
 **Description**:
 
 This PR patches the following vulnerability:
 
 * [GHSA-jfhm-5ghh-2f97](https://github.com/advisories/GHSA-jfhm-5ghh-2f97) - related to the `cryptography` package;
 
 This vulnerability comes from the continuumio/miniconda3 image used upstream for the miniconda devcontainer.
 
 _Changelog_:
 
 * Updated Dockerfile
   
   * Locked version for patched conda package;
    
     * `cryptography` - _minimum package version set to `41.0.7`_;
 * Updated tests to verify `cryptography` minimum version (Minimum package version set to `41.0.7` which fixes [GHSA-jfhm-5ghh-2f97](https://github.com/advisories/GHSA-jfhm-5ghh-2f97));
 
 **Checklist**:
 
 * [x]   Checked that applied changes work as expected