### PR TITLE
Clear NUGET_XMLDOC_MODE

### DIFF
--- a/src/dotnet/.devcontainer/Dockerfile
+++ b/src/dotnet/.devcontainer/Dockerfile
@@ -1,3 +1,7 @@
 ARG VARIANT=8.0-bookworm-slim
 FROM mcr.microsoft.com/dotnet/sdk:${VARIANT}
 ENV PATH $PATH:/home/vscode/.dotnet:/home/vscode/.dotnet/tools
+
+# clear this environment variable so xml docs from NuGet packages are unpackaged. The default dotnet/sdk image sets it to 'skip'.
+# see https://github.com/dotnet/dotnet-docker/issues/2790
+ENV NUGET_XMLDOC_MODE=


### PR DESCRIPTION
Clear this environment variable so xml docs from NuGet packages are unpackaged. The default dotnet/sdk image sets it to 'skip'.

Without clearing this environment variable, the XML docs are not unpackaged and won't be used in intellisense.

See https://github.com/dotnet/dotnet-docker/issues/2790

cc @radical @mthalman @MichaelSimons