### PR TITLE
Fix version history failures

### DIFF
--- a/src/universal/manifest.json
+++ b/src/universal/manifest.json
@@ -175,8 +175,8 @@
 			},
 			".NET": {
 				"cgIgnore": true,
-				"versionCommand": "ls /usr/local/dotnet | grep -oE '[0-9]'",
-				"path": "/usr/local/dotnet"
+				"versionCommand": "dotnet --version",
+				"path": "/usr/share/dotnet/dotnet"
 			},
 			"Ruby": {
 				"cgIgnore": true,


### PR DESCRIPTION
Fixes action run failures, see https://github.com/devcontainers/images/actions/runs/7747817526/job/21165203940#step:6:18614

It was failing due to https://github.com/devcontainers/images/pull/855/files#diff-0a764bd0944b79c46597d08357a72f308324874b8e25e7d46f302ecc0bc47bafL12 change where we bumped .NET Feature version to 2 which resulted to path change.