### PR TITLE
Support Go 1.22

### DIFF
--- a/src/go/.devcontainer/Dockerfile
+++ b/src/go/.devcontainer/Dockerfile
@@ -1,5 +1,4 @@
-# [Choice] Go version (use -bookworm, or -bullseye variants on local arm64/Apple Silicon): 1, 1.21, 1.20, 1-bookworm, 1.21-bookworm, 1.20-bookworm, 1-bullseye, 1.21-bullseye, 1.20-bullseye
-ARG VARIANT=1.21-bookworm
+ARG VARIANT=1.22-bookworm
 FROM golang:${VARIANT}
 
 # [Optional] Uncomment the next line to use go get to install anything else you need

--- a/src/go/README.md
+++ b/src/go/README.md
@@ -10,7 +10,7 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/go |
-| *Available image variants* | 1 / 1-bookworm, 1.21 / 1.21-bookworm, 1.20 / 1.20-bookworm, 1-bullseye, 1.21-bullseye, 1.20-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/go/tags/list)) |
+| *Available image variants* | 1 / 1-bookworm, 1.22 / 1.22-bookworm, 1.21 / 1.21-bookworm, 1.20 / 1.20-bookworm, 1-bullseye, 1.22-bullseye, 1.21-bullseye, 1.20-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/go/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bookworm`, and `bullseye` variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -24,6 +24,7 @@ You can directly reference pre-built versions of `Dockerfile` by using the `imag
 
 - `mcr.microsoft.com/devcontainers/go` (latest)
 - `mcr.microsoft.com/devcontainers/go:1` (or `1-bookworm`, `1-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/go:1.22` (or `1.22-bookworm`, `1.22-bullseye` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/go:1.21` (or `1.21-bookworm`, `1.21-bullseye` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/go:1.20` (or `1.20-bookworm`, `1.20-bullseye` to pin to an OS version)
 

--- a/src/go/manifest.json
+++ b/src/go/manifest.json
@@ -1,23 +1,33 @@
 {
   "version": "1.1.7",
   "variants": [
+		"1.22-bookworm",
 		"1.21-bookworm",
 		"1.20-bookworm",
+		"1.22-bullseye",
 		"1.21-bullseye",
     "1.20-bullseye"
   ],
   "build": {
-    "latest": "1.21-bookworm",
+    "latest": "1.22-bookworm",
     "rootDistro": "debian",
     "tags": [
       "go:${VERSION}-${VARIANT}"
     ],
     "architectures": {
+			"1.22-bookworm": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
 			"1.21-bookworm": [
         "linux/amd64",
         "linux/arm64"
       ],
 			"1.20-bookworm": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+			"1.22-bullseye": [
         "linux/amd64",
         "linux/arm64"
       ],
@@ -31,15 +41,18 @@
       ]
     },
     "variantTags": {
-			"1.21-bookworm": [
-        "go:${VERSION}-1.21",
+			"1.22-bookworm": [
+        "go:${VERSION}-1.22",
         "go:${VERSION}-1",
         "go:${VERSION}-1-bookworm",
         "go:${VERSION}-bookworm"
       ],
-			"1.21-bullseye": [
+			"1.22-bullseye": [
         "go:${VERSION}-1-bullseye",
         "go:${VERSION}-bullseye"
+      ],
+			"1.21-bookworm": [
+        "go:${VERSION}-1.21"
       ],
       "1.20-bookworm": [
         "go:${VERSION}-1.20"


### PR DESCRIPTION
Ref: https://go.dev/doc/go1.22 and https://github.com/devcontainers/images/issues/943