### PR TITLE
[DotNet] - Upgrade PowerShell Core due to CVE-2024-0057

### DIFF
--- a/src/dotnet/.devcontainer/Dockerfile
+++ b/src/dotnet/.devcontainer/Dockerfile
@@ -5,3 +5,12 @@ ENV PATH $PATH:/home/vscode/.dotnet:/home/vscode/.dotnet/tools
 # clear this environment variable so xml docs from NuGet packages are unpackaged. The default dotnet/sdk image sets it to 'skip'.
 # see https://github.com/dotnet/dotnet-docker/issues/2790
 ENV NUGET_XMLDOC_MODE=
+
+# Temporary: Upgrade packages due to mentioned CVEs
+# They are installed by the base image (mcr.microsoft.com/dotnet/sdk) which does not have the patch.
+# https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-0057
+RUN apt-get update && \
+    wget https://github.com/PowerShell/PowerShell/releases/download/v7.4.1/powershell_7.4.1-1.deb_amd64.deb && \
+    dpkg -i powershell_7.4.1-1.deb_amd64.deb && \
+    apt-get install -f && \
+    rm powershell_7.4.1-1.deb_amd64.deb

--- a/src/dotnet/test-project/test-utils.sh
+++ b/src/dotnet/test-project/test-utils.sh
@@ -143,6 +143,15 @@ checkCommon()
     check "code" which code
 }
 
+checkPackageVersion()
+{
+    PACKAGE=$1
+    REQUIRED_VERSION=$2
+    PACKAGE_NAME=$3
+    current_version=$("${PACKAGE}" -V | grep -E "^${PACKAGE_NAME}\s" | awk '{print $2}')
+    check-version-ge "${PACKAGE_NAME}-requirement" "${current_version}" "${REQUIRED_VERSION}"
+}
+
 reportResults() {
     if [ ${#FAILED[@]} -ne 0 ]; then
         echoStderr -e "\n💥  Failed tests: ${FAILED[@]}"

--- a/src/dotnet/test-project/test.sh
+++ b/src/dotnet/test-project/test.sh
@@ -27,5 +27,7 @@ check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcont
 
 check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
+checkPackageVersion "pwsh" "7.4.1" "PowerShell"
+
 # Report result
 reportResults


### PR DESCRIPTION
**Dev container name**:
 
 * DotNet
 
 **Description**:
 
 This PR patches the following vulnerability:
 
 * [CVE-2024-0057](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-0057) - related to the `PowerShell Core` package;
 
 This vulnerability comes from the mcr.microsoft.com/dotnet/sdk image used upstream for the DotNet devcontainer.
 
 _Changelog_:
 
 * Updated Dockerfile
   * Installed latest PowerShell Core package;
     * `PowerShell Core` - _minimum package version set to `7.4.1`_;
	 
 * Updated tests to verify `PowerShell Core` minimum version (Minimum package version set to `7.4.1` which fixes [CVE-2024-0057](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-0057));
 
 **Checklist**:
 
 * [x]   Checked that applied changes work as expected