### PR TITLE
[Python] - GitPython - Patch Vulnerability - GHSA-2mqj-m65w-jghx

### DIFF
--- a/src/python/.devcontainer/Dockerfile
+++ b/src/python/.devcontainer/Dockerfile
@@ -6,9 +6,11 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     # Remove imagemagick due to https://security-tracker.debian.org/tracker/CVE-2019-10131
     && apt-get purge -y imagemagick imagemagick-6-common 
 
-# Temporary: Upgrade python packages due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40897
+# Temporary: Upgrade python package (setuptools) due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40897
 # They are installed by the base image (python) which does not have the patch.
-RUN python3 -m pip install --upgrade setuptools
+RUN python3 -m pip install --upgrade \
+    setuptools \
+    gitpython
 
 # [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
 # COPY requirements.txt /tmp/pip-tmp/

--- a/src/python/.devcontainer/Dockerfile
+++ b/src/python/.devcontainer/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     # Remove imagemagick due to https://security-tracker.debian.org/tracker/CVE-2019-10131
     && apt-get purge -y imagemagick imagemagick-6-common 
 
-# Temporary: Upgrade python package (setuptools) due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40897
+# Temporary: Upgrade python packages due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40897 and https://github.com/advisories/GHSA-2mqj-m65w-jghx
 # They are installed by the base image (python) which does not have the patch.
 RUN python3 -m pip install --upgrade \
     setuptools \

--- a/src/python/.devcontainer/Dockerfile
+++ b/src/python/.devcontainer/Dockerfile
@@ -9,8 +9,8 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 # Temporary: Upgrade python packages due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40897 and https://github.com/advisories/GHSA-2mqj-m65w-jghx
 # They are installed by the base image (python) which does not have the patch.
 RUN python3 -m pip install --upgrade \
-    setuptools \
-    gitpython
+    setuptools==69.0.3 \
+    gitpython==3.1.41
 
 # [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
 # COPY requirements.txt /tmp/pip-tmp/

--- a/src/python/test-project/test.sh
+++ b/src/python/test-project/test.sh
@@ -42,5 +42,9 @@ check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 setuptools_version=$(python -c "import setuptools; print(setuptools.__version__)")
 check-version-ge "setuptools-requirement" "${setuptools_version}" "65.5.1"
 
+# https://github.com/advisories/GHSA-2mqj-m65w-jghx
+gitpython_version=$(python -c "import git; print(git.__version__)")
+check-version-ge "gitpython-requirement" "${gitpython_version}" "3.1.41"
+
 # Report result
 reportResults


### PR DESCRIPTION
 **Dev container name**:
 
 * Python
 
 **Description**:
 
 This PR patches the following vulnerability:
 
 * [GHSA-2mqj-m65w-jghx](https://github.com/advisories/GHSA-2mqj-m65w-jghx) - related to the `gitpython` package;
 
 This vulnerability comes from the python image used upstream for the Python devcontainer.
 
 _Changelog_:
 
 * Updated Dockerfile
   
   * Upgraded version for patched python package;
    
     * `gitpython` - _minimum package version set to `3.1.41`_;
 * Updated tests to verify `gitpython` minimum version (Minimum package version set to `3.1.41` which fixes [GHSA-2mqj-m65w-jghx](https://github.com/advisories/GHSA-2mqj-m65w-jghx));
 
 **Checklist**:
 
 * [x]   Checked that applied changes work as expected