### PR TITLE
v0.3.31

### DIFF
--- a/src/anaconda/manifest.json
+++ b/src/anaconda/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.204.9",
+	"version": "0.204.10",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/src/dotnet/manifest.json
+++ b/src/dotnet/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"variants": [
 		"8.0-bookworm-slim",
 		"8.0-jammy",

--- a/src/go/manifest.json
+++ b/src/go/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.7",
+  "version": "1.1.9",
   "variants": [
 		"1.22-bookworm",
 		"1.21-bookworm",

--- a/src/python/manifest.json
+++ b/src/python/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "1.1.5",
+	"version": "1.1.6",
 	"variants": [
 		"3.12-bookworm",
 		"3.11-bookworm",


### PR DESCRIPTION
Changelog -

- [[Anaconda] - [aiohttp] - Address Security Vulnerability - GHSA-5h86-8mv2-jq9f](https://github.com/devcontainers/images/pull/949)
- [Support Go 1.22](https://github.com/devcontainers/images/pull/950)
- [[DotNet] - Upgrade PowerShell Core due to CVE-2024-0057](https://github.com/devcontainers/images/pull/952)
- [[Python] - GitPython - Patch Vulnerability - GHSA-2mqj-m65w-jghx](https://github.com/devcontainers/images/pull/953)