### PR TITLE
Adds a helper script for "devcontainer upgrades"

### DIFF
--- a/build/upgrade-lockfiles.sh
+++ b/build/upgrade-lockfiles.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Pass image name to upgrade only a single image, else it upgrades all the images
+IMAGE_NAME=$1
+workspaceFolder="/workspaces/images/src"
+
+if [ ! -z "$IMAGE_NAME" ]; then
+  echo "-----------------------------------------------"
+	echo "Upgrading image $IMAGE_NAME"
+	echo "-----------------------------------------------"
+  devcontainer upgrade --workspace-folder "${workspaceFolder}/${IMAGE_NAME}/"
+  exit 0
+fi
+
+for dir in /workspaces/images/src/*/
+do
+  cd "${dir}"
+  image=$(basename $dir)
+  echo "-----------------------------------------------"
+  echo "Upgrading image $image"
+  echo "-----------------------------------------------"
+  devcontainer upgrade --workspace-folder .
+  cd ..
+done

--- a/build/upgrade.sh
+++ b/build/upgrade.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-for dir in ./src/*/ ; do
-    if [ -d "$dir" ]; then
-        echo "Upgrading devcontainer lockfiles for '$dir'"
-        devcontainer upgrade --workspace-folder "$dir"
-    fi
-done


### PR DESCRIPTION
I usually run `devcontainer upgrade` command when I make any changes to an image(s). This script helps to fasten the process.