### PR TITLE
Update Rust images to use `default` rustup profile

### DIFF
--- a/src/rust/.devcontainer/devcontainer.json
+++ b/src/rust/.devcontainer/devcontainer.json
@@ -11,19 +11,22 @@
             "userGid": "1000",
             "upgradePackages": "true"
         },
-        "ghcr.io/devcontainers/features/rust:1": "latest",
-		"ghcr.io/devcontainers/features/git:1": {
+        "ghcr.io/devcontainers/features/rust:1": {
+            "version": "latest",
+            "profile": "default"
+        },
+        "ghcr.io/devcontainers/features/git:1": {
             "version": "latest",
             "ppa": "false"
         }
     },
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
 
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "rustc --version",
+    // Use 'postCreateCommand' to run commands after the container is created.
+    // "postCreateCommand": "rustc --version",
 
-	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode"
+    // Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "vscode"
 }


### PR DESCRIPTION
The `default` profile including tools for formatting and linting, which are essential to development.

Also format the devcontainer config file itself a little bit.