### PR TITLE
Go 1.20 EOL

### DIFF
--- a/src/go/README.md
+++ b/src/go/README.md
@@ -10,7 +10,7 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/go |
-| *Available image variants* | 1 / 1-bookworm, 1.22 / 1.22-bookworm, 1.21 / 1.21-bookworm, 1.20 / 1.20-bookworm, 1-bullseye, 1.22-bullseye, 1.21-bullseye, 1.20-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/go/tags/list)) |
+| *Available image variants* | 1 / 1-bookworm, 1.22 / 1.22-bookworm, 1.21 / 1.21-bookworm, 1-bullseye, 1.22-bullseye, 1.21-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/go/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bookworm`, and `bullseye` variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -26,17 +26,16 @@ You can directly reference pre-built versions of `Dockerfile` by using the `imag
 - `mcr.microsoft.com/devcontainers/go:1` (or `1-bookworm`, `1-bullseye` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/go:1.22` (or `1.22-bookworm`, `1.22-bullseye` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/go:1.21` (or `1.21-bookworm`, `1.21-bullseye` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/go:1.20` (or `1.20-bookworm`, `1.20-bullseye` to pin to an OS version)
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/devcontainers/go:1-1.21` (or `1-1.21-bookworm`, `1-1.21-bullseye`)
-- `mcr.microsoft.com/devcontainers/go:1.1-1.21` (or `1.1-1.21-bookworm`, `1.1-1.21-bullseye`)
-- `mcr.microsoft.com/devcontainers/go:1.1.0-1.21` (or `1.1.0-1.21-bookworm`, `1.1.0-1.21-bullseye`)
+- `mcr.microsoft.com/devcontainers/go:1-1.22` (or `1-1.22-bookworm`, `1-1.22-bullseye`)
+- `mcr.microsoft.com/devcontainers/go:1.1-1.22` (or `1.1-1.22-bookworm`, `1.1-1.22-bullseye`)
+- `mcr.microsoft.com/devcontainers/go:1.1.0-1.22` (or `1.1.0-1.22-bookworm`, `1.1.0-1.22-bullseye`)
 
-However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `1-1.21`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
+However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `1-1.22`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/go/tags/list).
 

--- a/src/go/README.md
+++ b/src/go/README.md
@@ -33,7 +33,7 @@ You can decide how often you want updates by referencing a [semantic version](ht
 
 - `mcr.microsoft.com/devcontainers/go:1-1.22` (or `1-1.22-bookworm`, `1-1.22-bullseye`)
 - `mcr.microsoft.com/devcontainers/go:1.1-1.22` (or `1.1-1.22-bookworm`, `1.1-1.22-bullseye`)
-- `mcr.microsoft.com/devcontainers/go:1.1.0-1.22` (or `1.1.0-1.22-bookworm`, `1.1.0-1.22-bullseye`)
+- `mcr.microsoft.com/devcontainers/go:1.1.9-1.22` (or `1.1.9-1.22-bookworm`, `1.1.9-1.22-bullseye`)
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `1-1.22`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 

--- a/src/go/manifest.json
+++ b/src/go/manifest.json
@@ -3,10 +3,8 @@
   "variants": [
 		"1.22-bookworm",
 		"1.21-bookworm",
-		"1.20-bookworm",
 		"1.22-bullseye",
-		"1.21-bullseye",
-    "1.20-bullseye"
+		"1.21-bullseye"
   ],
   "build": {
     "latest": "1.22-bookworm",
@@ -23,19 +21,11 @@
         "linux/amd64",
         "linux/arm64"
       ],
-			"1.20-bookworm": [
-        "linux/amd64",
-        "linux/arm64"
-      ],
 			"1.22-bullseye": [
         "linux/amd64",
         "linux/arm64"
       ],
       "1.21-bullseye": [
-        "linux/amd64",
-        "linux/arm64"
-      ],
-      "1.20-bullseye": [
         "linux/amd64",
         "linux/arm64"
       ]
@@ -53,9 +43,6 @@
       ],
 			"1.21-bookworm": [
         "go:${VERSION}-1.21"
-      ],
-      "1.20-bookworm": [
-        "go:${VERSION}-1.20"
       ]
     }
   },


### PR DESCRIPTION
Go v1.20 End of Life - Updated the following files to reflect the changes :-

- [x] Made changes to manifest.json file for Go dev container
   - Removed v1.20 traces from the json
- [x] Made changes to readme.md file for Go dev container  
   - Removed traces of v1.20 from the readme file for Go 