### PR TITLE
check size for the universal image

### DIFF
--- a/.github/actions/smoke-test/action.yaml
+++ b/.github/actions/smoke-test/action.yaml
@@ -4,6 +4,10 @@ inputs:
     description: 'Image to test'
     required: true
     default: 'base-debian'
+  threshold:
+    description: 'Threshold (in GB) to validate that the image size does not excced this limit'
+    required: false
+    default: 14
 
 runs:
   using: composite
@@ -24,4 +28,4 @@ runs:
     - name: Test image
       id: test_image
       shell: bash
-      run: ${{ github.action_path }}/test.sh  ${{ inputs.image }}
+      run: ${{ github.action_path }}/test.sh  ${{ inputs.image }} ${{ inputs.threshold }}

--- a/.github/actions/smoke-test/check-image-size.sh
+++ b/.github/actions/smoke-test/check-image-size.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Function to handle errors
+handle_error() {
+    local exit_code=$?
+    local line_number=$1
+    local command=$2
+    echo "Error occurred at line $line_number with exit code $exit_code in command $command"
+    exit $exit_code
+}
+trap 'handle_error $LINENO ${BASH_COMMAND%% *}' ERR
+echo "This is line $LINENO"
+
+convert_gb_to_bytes() {
+    local gb="$1"
+    local bytes
+    bytes=$(echo "scale=0; $gb * 1024^3" | bc)
+    printf "%.0f\n" "$bytes"
+}
+
+# Check if bc is installed
+install_bc() {
+    if ! command -v bc &> /dev/null; then
+        echo "bc is not installed. Installing..."
+        # Install bc using apt-get (for Debian-based systems)
+        sudo apt-get update
+        sudo apt-get install -y bc
+    fi
+}
+
+check_image_size() {
+    IMAGE="$1"
+    THRESHOLD_IN_GB="$2"
+
+    # call install_bc
+    install_bc
+
+    CONTAINER_ID=$(docker ps -q --filter "label=test-container=$IMAGE")
+    # Find the image ID of the container
+    IMAGE_ID=$(docker inspect --format='{{.Image}}' "$CONTAINER_ID")
+    # Find the size of the image
+    IMAGE_SIZE=$(docker image inspect --format='{{.Size}}' "$IMAGE_ID")
+    # Output the size
+    echo "Size of the image $IMAGE_ID: $IMAGE_SIZE bytes"
+    threshold=$(convert_gb_to_bytes "$THRESHOLD_IN_GB")
+    # Retrieve the Docker image size
+    echo -e "\nThreshold is $threshold bytes ie $THRESHOLD_IN_GB GB"
+    # Remove the 'MB' from the size string and convert to an integer
+    image_size=${IMAGE_SIZE%bytes}
+    image_size=${image_size//.}
+    # Check if the image size is above the threshold
+    echo -e "\n🧪 Checking image size of $IMAGE :"
+    if [ -n $image_size  ] && [ $image_size -gt $threshold ]; then
+        echo -e "\nImage size exceeds the threshold of $THRESHOLD_IN_GB gb"
+        echo -e "\n❌ Image size check failed."
+    else
+        echo -e "\n✅  Passed!"
+    fi
+}

--- a/.github/actions/smoke-test/test.sh
+++ b/.github/actions/smoke-test/test.sh
@@ -1,5 +1,8 @@
 #/bin/bash
 IMAGE="$1"
+THRESHOLD_IN_GB="$2"
+
+source $(pwd)/.github/actions/smoke-test/check-image-size.sh
 
 export DOCKER_BUILDKIT=1
 set -e
@@ -11,6 +14,11 @@ devcontainer exec --workspace-folder $(pwd)/src/$IMAGE  --id-label ${id_label} /
 
 echo "(*) Docker image details..."
 docker images
+# Checking size of universal image
+
+if [ $IMAGE == "universal" ]; then
+    check_image_size $IMAGE $THRESHOLD_IN_GB
+fi
 
 # Clean up
 docker rm -f $(docker container ls -f "label=${id_label}" -q)

--- a/.github/workflows/smoke-universal.yaml
+++ b/.github/workflows/smoke-universal.yaml
@@ -26,3 +26,4 @@ jobs:
       uses: ./.github/actions/smoke-test
       with:
         image: universal
+        threshold: 14


### PR DESCRIPTION
**Dev container name**:
 * universal
 **Description**:
This PR is implementing the following functionality:
 * Github action checks the size of the universal container is exceeding the fixed threshold i.e. 14 GB or not and displays the report with the result success if it is below the threshold and fail if it is beyond the threshold.
 _Changelog_:
 * Updated test.sh
   * if Image is universal then call check_image_size function with two paramteres image and threshold.
  * Created check-image-size.sh
   * This file used to check the image size with the threshold and displays the output pass or fail

 **Checklist**:
 * [x]   Checked that the container has been created and tried to run the github action for the image universal
 * [x]   Successfully checked the size of universal image and displayed report failed as the size exceeded the threshold