### PR TITLE
anaconda_gitpython_GHSA-2mqj-m65w-jghx patch vulnerability

### DIFF
--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -37,7 +37,9 @@ RUN python3 -m pip install --upgrade \
     # https://github.com/advisories/GHSA-5h86-8mv2-jq9f
     aiohttp==3.9.2 \
     # https://github.com/advisories/GHSA-6vqw-3v5j-54x4
-    cryptography==42.0.4
+    cryptography==42.0.4 \
+    # https://github.com/advisories/GHSA-2mqj-m65w-jghx
+    gitpython==3.1.41
 
 # Reset and copy updated files with updated privs to keep image size down
 FROM mcr.microsoft.com/devcontainers/base:1-bullseye

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -49,6 +49,7 @@ checkPythonPackageVersion "tornado" "6.3.3"
 checkPythonPackageVersion "pyarrow" "14.0.1"
 checkPythonPackageVersion "pillow" "10.2.0"
 checkPythonPackageVersion "jupyterlab" "4.0.11"
+checkPythonPackageVersion "gitpython" "3.1.41"
 
 checkCondaPackageVersion "pyopenssl" "23.2.0"
 checkCondaPackageVersion "requests" "2.31.0"


### PR DESCRIPTION
 **Dev container name**:
 
 * Anaconda
 
 **Description**:
 
 This PR patches the following vulnerability:
 
 * [GHSA-2mqj-m65w-jghx](https://github.com/advisories/GHSA-2mqj-m65w-jghx) - related to the `gitpython` package;
 
 This vulnerability comes from the coninuumio/Anaconda3 image used upstream for the Anaconda devcontainer.
 
 _Changelog_:
 
 * Updated Dockerfile
   * Updated version for patched python package;
     * `gitpython` - _minimum package version has been set to `3.1.41`_;
	 
 * Updated tests to verify `gitpython` minimum version (Minimum package version set to `3.1.41` which fixes [GHSA-2mqj-m65w-jghx](https://github.com/advisories/GHSA-2mqj-m65w-jghx));
 
 **Checklist**:
 
 * [x]   Checked that applied changes work as expected