### PR TITLE
anaconda_jupyter-lsp_GHSA-4qhp-652w-c22x patch security vulnerability

### DIFF
--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -37,7 +37,9 @@ RUN python3 -m pip install --upgrade \
     # https://github.com/advisories/GHSA-5h86-8mv2-jq9f
     aiohttp==3.9.2 \
     # https://github.com/advisories/GHSA-6vqw-3v5j-54x4
-    cryptography==42.0.4
+    cryptography==42.0.4 \
+    # https://github.com/advisories/GHSA-4qhp-652w-c22x
+    jupyter-lsp==2.2.2
 
 # Reset and copy updated files with updated privs to keep image size down
 FROM mcr.microsoft.com/devcontainers/base:1-bullseye

--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -38,6 +38,8 @@ RUN python3 -m pip install --upgrade \
     aiohttp==3.9.2 \
     # https://github.com/advisories/GHSA-6vqw-3v5j-54x4
     cryptography==42.0.4 \
+    # https://github.com/advisories/GHSA-2mqj-m65w-jghx
+    gitpython==3.1.41 \
     # https://github.com/advisories/GHSA-4qhp-652w-c22x
     jupyter-lsp==2.2.2
 

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -49,6 +49,7 @@ checkPythonPackageVersion "tornado" "6.3.3"
 checkPythonPackageVersion "pyarrow" "14.0.1"
 checkPythonPackageVersion "pillow" "10.2.0"
 checkPythonPackageVersion "jupyterlab" "4.0.11"
+checkPythonPackageVersion "jupyter-lsp" "2.2.2"
 
 checkCondaPackageVersion "pyopenssl" "23.2.0"
 checkCondaPackageVersion "requests" "2.31.0"

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -49,6 +49,7 @@ checkPythonPackageVersion "tornado" "6.3.3"
 checkPythonPackageVersion "pyarrow" "14.0.1"
 checkPythonPackageVersion "pillow" "10.2.0"
 checkPythonPackageVersion "jupyterlab" "4.0.11"
+checkPythonPackageVersion "gitpython" "3.1.41"
 checkPythonPackageVersion "jupyter-lsp" "2.2.2"
 
 checkCondaPackageVersion "pyopenssl" "23.2.0"


### PR DESCRIPTION
**Dev container name**:
 
 * Anaconda
 
 **Description**:
 
 This PR patches the following vulnerability:
 
 * [GHSA-4qhp-652w-c22x](https://github.com/advisories/GHSA-4qhp-652w-c22x) - related to the `jupyter-lsp` package;
 
 This vulnerability comes from the coninuumio/anaconda3 image used upstream for the Anaconda devcontainer.
 
 _Changelog_:
 
 * Updated Dockerfile
   * Updated version for patched python package;
     * `jupyter-lsp` - _minimum package version has been set to `2.2.2`_;
	 
 * Updated tests to verify `jupyter-lsp` minimum version (Minimum package version set to `2.2.2` which fixes [GHSA-4qhp-652w-c22x](https://github.com/advisories/GHSA-4qhp-652w-c22x));
 
 **Checklist**:
 
 * [x]   Checked that applied changes work as expected