### PR TITLE
Adding inotify-tools to universal image

### DIFF
--- a/src/universal/.devcontainer/Dockerfile
+++ b/src/universal/.devcontainer/Dockerfile
@@ -55,6 +55,7 @@ RUN apt-get update \
         uuid-dev \
         curl \
         gettext \
+        inotify-tools \
     && rm -rf /var/lib/apt/lists/* \
     # This is the folder containing 'links' to benv and build script generator
     && apt-get update \

--- a/src/universal/test-project/test-utils.sh
+++ b/src/universal/test-project/test-utils.sh
@@ -130,7 +130,8 @@ checkCommon()
         zlib1g \
         locales \
         gettext \
-        sudo"
+        sudo \
+        inotify-tools"
 
     # Actual tests
     checkOSPackages "common-os-packages" ${PACKAGE_LIST}


### PR DESCRIPTION
This PR adds `inotify-tools` to the list of packages to be installed for the universal image.