### PR TITLE
[Anaconda]-IDNA-GHSA-jjg7-2v4v-x38h patch vulnerability

### DIFF
--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -41,7 +41,9 @@ RUN python3 -m pip install --upgrade \
     # https://github.com/advisories/GHSA-2mqj-m65w-jghx
     gitpython==3.1.41 \
     # https://github.com/advisories/GHSA-4qhp-652w-c22x
-    jupyter-lsp==2.2.2
+    jupyter-lsp==2.2.2 \
+    # https://github.com/advisories/GHSA-jjg7-2v4v-x38h
+    idna==3.7
 
 # Reset and copy updated files with updated privs to keep image size down
 FROM mcr.microsoft.com/devcontainers/base:1-bullseye

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -51,6 +51,7 @@ checkPythonPackageVersion "pillow" "10.3.0"
 checkPythonPackageVersion "jupyterlab" "4.0.11"
 checkPythonPackageVersion "gitpython" "3.1.41"
 checkPythonPackageVersion "jupyter-lsp" "2.2.2"
+checkPythonPackageVersion "idna" "3.7"
 
 checkCondaPackageVersion "pyopenssl" "23.2.0"
 checkCondaPackageVersion "requests" "2.31.0"


### PR DESCRIPTION
 **Dev container name**:
 
 * Anaconda
 
 **Description**:
 
 This PR patches the following vulnerability:
 
 * [GHSA-jjg7-2v4v-x38h](https://github.com/advisories/GHSA-jjg7-2v4v-x38h) - related to the `IDNA` package;
 
 This vulnerability comes from the coninuumio/anaconda3 image used upstream for the Anaconda devcontainer.
 
 _Changelog_:
 
 * Updated Dockerfile
   * Upgraded version for patched python package;
     * `IDNA` - _minimum package version has been set to `3.7`_;
	 
 * Updated tests to verify `IDNA` minimum version (Minimum package version set to `3.7` which fixes [GHSA-jjg7-2v4v-x38h](https://github.com/advisories/GHSA-jjg7-2v4v-x38h));
 
 **Checklist**:
 
 * [x]   Checked that applied changes work as expected