### PR TITLE
Support Ubuntu 24.04 (noble)

### DIFF
--- a/src/base-ubuntu/.devcontainer/Dockerfile
+++ b/src/base-ubuntu/.devcontainer/Dockerfile
@@ -1,5 +1,4 @@
-# [Choice] Ubuntu version (use jammy on local arm64/Apple Silicon): jammy, focal
-ARG VARIANT="jammy"
+ARG VARIANT="noble"
 FROM buildpack-deps:${VARIANT}-curl
 
 LABEL dev.containers.features="common"

--- a/src/base-ubuntu/README.md
+++ b/src/base-ubuntu/README.md
@@ -9,8 +9,8 @@
 | *Categories* | Core, Other |
 | *Image type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/base:ubuntu |
-| *Available image variants* | ubuntu-22.04 / jammy, ubuntu-20.04 / focal ([full list](https://mcr.microsoft.com/v2/devcontainers/base/tags/list)) |
-| *Published image architecture(s)* | x86-64, aarch64/arm64 for `ubuntu-22.04` (`jammy`) variant  |
+| *Available image variants* | ubuntu-24.04 / noble, ubuntu-22.04 / jammy, ubuntu-20.04 / focal ([full list](https://mcr.microsoft.com/v2/devcontainers/base/tags/list)) |
+| *Published image architecture(s)* | x86-64, aarch64/arm64 for `ubuntu-22.04` (`jammy`) and `ubuntu-24.04` (`noble`) variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Ubuntu |
 | *Languages, platforms* | Any |
@@ -22,6 +22,7 @@ See **[history](history)** for information on the contents of published images.
 You can directly reference pre-built versions of `Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
 
 - `mcr.microsoft.com/devcontainers/base:ubuntu` (latest LTS release)
+- `mcr.microsoft.com/devcontainers/base:ubuntu-24.04` (or `noble`)
 - `mcr.microsoft.com/devcontainers/base:ubuntu-22.04` (or `jammy`)
 - `mcr.microsoft.com/devcontainers/base:ubuntu-20.04` (or `focal`)
 
@@ -29,9 +30,9 @@ Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/devcontainers/base:1-jammy`
-- `mcr.microsoft.com/devcontainers/base:1.0-jammy`
-- `mcr.microsoft.com/devcontainers/base:1.0.0-jammy`
+- `mcr.microsoft.com/devcontainers/base:1-noble`
+- `mcr.microsoft.com/devcontainers/base:1.1-noble`
+- `mcr.microsoft.com/devcontainers/base:1.1.0-noble`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/base/tags/list).
 

--- a/src/base-ubuntu/README.md
+++ b/src/base-ubuntu/README.md
@@ -30,9 +30,9 @@ Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/devcontainers/base:1-noble`
-- `mcr.microsoft.com/devcontainers/base:1.1-noble`
-- `mcr.microsoft.com/devcontainers/base:1.1.0-noble`
+- `mcr.microsoft.com/devcontainers/base:2-noble`
+- `mcr.microsoft.com/devcontainers/base:2.0-noble`
+- `mcr.microsoft.com/devcontainers/base:2.0.0-noble`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/base/tags/list).
 

--- a/src/base-ubuntu/manifest.json
+++ b/src/base-ubuntu/manifest.json
@@ -1,6 +1,7 @@
 {
-	"version": "1.0.23",
+	"version": "1.1.0",
 	"variants": [
+		"noble",
 		"jammy",
 		"focal"
 	],
@@ -8,6 +9,10 @@
 		"latest": false,
 		"rootDistro": "debian",
 		"architectures": {
+			"noble": [
+				"linux/amd64",
+				"linux/arm64"
+			],
 			"jammy": [
 				"linux/amd64",
 				"linux/arm64"
@@ -20,10 +25,14 @@
 			"base:${VERSION}-${VARIANT}"
 		],
 		"variantTags": {
+			"noble": [
+				"base:${VERSION}-ubuntu-24.04",
+				"base:${VERSION}-ubuntu24.04",
+				"base:${VERSION}-ubuntu"
+			],
 			"jammy": [
 				"base:${VERSION}-ubuntu-22.04",
-				"base:${VERSION}-ubuntu22.04",
-				"base:${VERSION}-ubuntu"
+				"base:${VERSION}-ubuntu22.04"
 			],
 			"focal": [
 				"base:${VERSION}-ubuntu-20.04",

--- a/src/base-ubuntu/manifest.json
+++ b/src/base-ubuntu/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "1.1.0",
+	"version": "2.0.0",
 	"variants": [
 		"noble",
 		"jammy",


### PR DESCRIPTION
Ref: https://github.com/devcontainers/images/issues/1016 and https://wiki.ubuntu.com/Releases

- Supports the latest LTS version of Ubuntu
- Once released, `mcr.microsoft.com/devcontainers/base:ubuntu` will now point to `noble` instead of `jammy` as the `ubuntu` tag is meant to represent the latest LTS version