### PR TITLE
[Anaconda]-Pydantic-GHSA-mr82-8j83-vxmv patch security vuln

### DIFF
--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -7,7 +7,9 @@ RUN . /etc/os-release && if [ "${VERSION_CODENAME}" != "bullseye" ]; then exit 1
 # They are installed by the base image (continuumio/anaconda3) which does not have the patch.
 RUN conda install \
     # https://github.com/advisories/GHSA-v845-jxx5-vc9f
-    urllib3==1.26.18
+    urllib3==1.26.18 \
+    # https://github.com/advisories/GHSA-mr82-8j83-vxmv
+    pydantic==2.5.3
 
 RUN python3 -m pip install --upgrade \
     # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-21797

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -59,6 +59,7 @@ checkCondaPackageVersion "pygments" "2.15.1"
 checkCondaPackageVersion "mpmath" "1.3.0"
 checkCondaPackageVersion "urllib3" "1.26.17"
 checkCondaPackageVersion "pyarrow" "14.0.1"
+checkCondaPackageVersion "pydantic" "2.5.3"
 
 check "conda-update-conda" bash -c "conda update -y conda"
 check "conda-install-tensorflow" bash -c "conda create --name test-env -c conda-forge --yes tensorflow"


### PR DESCRIPTION
 **Dev container name**:
 
 * Anaconda
 
 **Description**:
 
 This PR patches the following vulnerability:
 
 * [GHSA-mr82-8j83-vxmv](https://github.com/advisories/GHSA-mr82-8j83-vxmv) - related to the `pydantic` package;
 
 This vulnerability comes from the coninuumio/anaconda3 image used upstream for the Anaconda devcontainer.
 
 _Changelog_:
 
 * Updated Dockerfile
   * Upgraded version for patched conda package;
     * `pydantic` - _minimum package version has been set to `2.5.3`_;
	 
 * Updated tests to verify `pydantic` minimum version (Minimum package version set to `2.5.3` which fixes [GHSA-mr8x2-8j83-vxmv](https://github.com/advisories/GHSA-mr82-8j83-vxmv));
 
 **Checklist**:
 
 * [x]   Checked that applied changes work as expected