### PR TITLE
[Miniconda] - idna - GHSA-jjg7-2v4v-x38h security patch for vulnerability

### DIFF
--- a/src/miniconda/.devcontainer/Dockerfile
+++ b/src/miniconda/.devcontainer/Dockerfile
@@ -2,15 +2,15 @@ FROM continuumio/miniconda3 as upstream
 
 # Temporary: Upgrade python packages due to mentioned CVEs
 # They are installed by the base image (continuumio/miniconda3) which does not have the patch.
-# RUN conda install \ 
-    # https://github.com/advisories/<CVE_ID>
-    # <package_name> = <version>
+RUN conda install \ 
+    # https://github.com/advisories/GHSA-jjg7-2v4v-x38h
+    idna==3.7
 
 RUN python3 -m pip install --upgrade \
     # https://github.com/advisories/GHSA-6vqw-3v5j-54x4
     cryptography==42.0.4 \
     # installed for compatibility with cryptography v42.0.4
-    pyopenssl==24.0.0 
+    pyopenssl==24.0.0
 
 # Reset and copy updated files with updated privs to keep image size down
 FROM mcr.microsoft.com/devcontainers/base:1-bullseye

--- a/src/miniconda/test-project/test.sh
+++ b/src/miniconda/test-project/test.sh
@@ -28,6 +28,7 @@ checkCondaPackageVersion "setuptools" "65.5.1"
 checkCondaPackageVersion "wheel" "0.38.1"
 checkCondaPackageVersion "requests" "2.31.0"
 checkCondaPackageVersion "urllib3" "1.26.17"
+checkCondaPackageVersion "idna" "3.7"
 
 check "conda-update-conda" bash -c "conda update -y conda"
 check "conda-install-tensorflow" bash -c "conda create --name test-env -c conda-forge --yes tensorflow"


### PR DESCRIPTION
 **Dev container name**:
 
 * Miniconda
 
 **Description**:
 
 This PR patches the following vulnerability:
 
 * [GHSA-jjg7-2v4v-x38h](https://github.com/advisories/GHSA-jjg7-2v4v-x38h) - related to the `idna` package;
 
 This vulnerability comes from the coninuumio/Miniconda3 image used upstream for the Miniconda devcontainer.
 
 _Changelog_:
 
 * Updated `Dockerfile`
   * Upgraded version for patched conda package;
     * `idna` - _minimum package version has been set to `3.7`_;
	 
 * Updated tests to verify `idna` minimum version (Minimum package version set to `3.7` which fixes [GHSA-mr8x2-8j83-vxmv](https://github.com/advisories/GHSA-jjg7-2v4v-x38h));
 
 **Checklist**:
 
 * [x]   Checked that applied changes work as expected