### PR TITLE
v0.3.38

### DIFF
--- a/src/anaconda/manifest.json
+++ b/src/anaconda/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.204.15",
+	"version": "0.205.0",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/src/universal/.devcontainer/devcontainer-lock.json
+++ b/src/universal/.devcontainer/devcontainer-lock.json
@@ -11,9 +11,9 @@
       "integrity": "sha256:245b89453a017490401090692650c6bad5c41159be58a7a13d7a95d542af5c7d"
     },
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
-      "version": "2.10.2",
-      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:23ae11a86089da5f0b98a6edd603f91831802b7f2d5ef1e104e1b94a3beb546c",
-      "integrity": "sha256:23ae11a86089da5f0b98a6edd603f91831802b7f2d5ef1e104e1b94a3beb546c"
+      "version": "2.11.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:503f23cd692325b3cbb8c20a0ecfabb3444b0c786b363e0c82572bd7d71dc099",
+      "integrity": "sha256:503f23cd692325b3cbb8c20a0ecfabb3444b0c786b363e0c82572bd7d71dc099"
     },
     "ghcr.io/devcontainers/features/dotnet:2": {
       "version": "2.0.5",

--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -11,8 +11,10 @@
         },
         "ghcr.io/devcontainers/features/dotnet:2": {
             "version": "8.0",
-            "dotnetRuntimeVersions": "7.0",
-            "aspNetCoreRuntimeVersions": "7.0"
+			// Temporarily pinning as the dotnet-install script is flakey (attempts to install bits of 7.0.19 of Runtime, but 7.0.18 of Core & Runtime)
+			// See https://github.com/devcontainers/images/actions/runs/9083566665/job/24962519615?pr=1065#step:3:6146
+            "dotnetRuntimeVersions": "7.0.18", 
+            "aspNetCoreRuntimeVersions": "7.0.18"
         },
         "ghcr.io/devcontainers/features/hugo:1": {
             "version": "latest"

--- a/src/universal/manifest.json
+++ b/src/universal/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.10.2",
+	"version": "2.11.0",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -9,7 +9,7 @@ checkCommon
 check "git" git --version
 
 git_version=$(git --version)
-check-version-ge "git-requirement" "${git_version}" "git version 2.40.1"
+check-version-ge "git-requirement" "${git_version}" "git version 2.45.1"
 
 check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
 check "gitconfig-file-location" sh -c "ls /etc/gitconfig"


### PR DESCRIPTION
Changelog -

- [Universal] - Updates `git` to v2.45.1 to get the latest security bugfix release. See https://github.blog/2024-05-14-securing-git-addressing-5-new-vulnerabilities/
- [Universal] - Pins .NET Runtime & Core versions to `7.0.18` to unblock from flakey dotnet-install script. See [here](https://github.com/devcontainers/images/pull/1065/files#diff-0a764bd0944b79c46597d08357a72f308324874b8e25e7d46f302ecc0bc47bafR140a764bd0944b79c46597d08357a72f308324874b8e25e7d46f302ecc0bc47bafR14)
- [[Universal] - reduce size - removed nvidia, triton - Machine Learning Packages](https://github.com/devcontainers/images/pull/1014)
- [[Anaconda]-Werkzeug-GHSA-2g68-c3qc-8985 patch for security vuln](https://github.com/devcontainers/images/pull/1062)
- [[Anaconda]-Jinja2-GHSA-h75v-3vvj-5mfj patch security vuln](https://github.com/devcontainers/images/pull/1063)