### PR TITLE
[anaconda] - scrapy - GHSA-4qqq-9vqf-3h3f patch vulnerablity

### DIFF
--- a/src/anaconda/.devcontainer/Dockerfile
+++ b/src/anaconda/.devcontainer/Dockerfile
@@ -47,7 +47,9 @@ RUN python3 -m pip install --upgrade \
     # https://github.com/advisories/GHSA-jjg7-2v4v-x38h
     idna==3.7 \ 
     # https://github.com/advisories/GHSA-h75v-3vvj-5mfj
-    jinja2==3.1.4
+    jinja2==3.1.4 \
+    # https://github.com/advisories/GHSA-4qqq-9vqf-3h3f
+    scrapy==2.11.2
 
 # Reset and copy updated files with updated privs to keep image size down
 FROM mcr.microsoft.com/devcontainers/base:1-bullseye

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -53,6 +53,7 @@ checkPythonPackageVersion "gitpython" "3.1.41"
 checkPythonPackageVersion "jupyter-lsp" "2.2.2"
 checkPythonPackageVersion "idna" "3.7"
 checkPythonPackageVersion "jinja2" "3.1.4"
+checkPythonPackageVersion "scrapy" "2.11.2"
 
 checkCondaPackageVersion "pyopenssl" "23.2.0"
 checkCondaPackageVersion "requests" "2.31.0"


### PR DESCRIPTION
 **Dev container name**:
 
 * Anaconda
 
 **Description**:
 
 This PR patches the following vulnerability:
 
 * [GHSA-4qqq-9vqf-3h3f](https://github.com/advisories/GHSA-4qqq-9vqf-3h3f) - related to the `scrapy` package;
 
 This vulnerability comes from the coninuumio/anaconda3 image used upstream for the Anaconda devcontainer.
 
 _Changelog_:
 
 * Updated Dockerfile
   * Upgraded version for patched python package;
     * `scrapy` - _minimum package version has been set to `2.11.2`_;
	 
 * Updated tests to verify `scrapy` minimum version (Minimum package version set to `2.11.2` which fixes [GHSA-4qqq-9vqf-3h3f](https://github.com/advisories/GHSA-4qqq-9vqf-3h3f));
 
 **Checklist**:
 
 * [x]   Checked that applied changes work as expected