### PR TITLE
Library search path related issue fixed

### DIFF
--- a/src/miniconda/.devcontainer/Dockerfile
+++ b/src/miniconda/.devcontainer/Dockerfile
@@ -6,13 +6,11 @@ RUN conda install \
     # https://github.com/advisories/GHSA-jjg7-2v4v-x38h
     idna==3.7
 
-RUN conda install \
-    # https://github.com/advisories/GHSA-3ww4-gg4f-jr7f
-    cryptography==42.0.5
+RUN ENV LD_LIBRARY_PATH=/opt/conda/lib
     
 RUN python3 -m pip install --upgrade \
     # https://github.com/advisories/GHSA-6vqw-3v5j-54x4
-    # cryptography==42.0.4 \
+    cryptography==42.0.4 \
     # installed for compatibility with cryptography v42.0.4
     pyopenssl==24.0.0
 

--- a/src/miniconda/.devcontainer/Dockerfile
+++ b/src/miniconda/.devcontainer/Dockerfile
@@ -6,7 +6,7 @@ RUN conda install \
     # https://github.com/advisories/GHSA-jjg7-2v4v-x38h
     idna==3.7
 
-RUN ENV LD_LIBRARY_PATH=/opt/conda/lib
+ENV LD_LIBRARY_PATH=/opt/conda/lib
     
 RUN python3 -m pip install --upgrade \
     # https://github.com/advisories/GHSA-6vqw-3v5j-54x4

--- a/src/miniconda/.devcontainer/Dockerfile
+++ b/src/miniconda/.devcontainer/Dockerfile
@@ -6,9 +6,13 @@ RUN conda install \
     # https://github.com/advisories/GHSA-jjg7-2v4v-x38h
     idna==3.7
 
+RUN conda install \
+    # https://github.com/advisories/GHSA-3ww4-gg4f-jr7f
+    cryptography==42.0.5
+    
 RUN python3 -m pip install --upgrade \
     # https://github.com/advisories/GHSA-6vqw-3v5j-54x4
-    cryptography==42.0.4 \
+    # cryptography==42.0.4 \
     # installed for compatibility with cryptography v42.0.4
     pyopenssl==24.0.0
 

--- a/src/miniconda/test-project/test.sh
+++ b/src/miniconda/test-project/test.sh
@@ -18,11 +18,11 @@ check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcont
 
 check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
-checkPythonPackageVersion "cryptography" "42.0.4"
+checkPythonPackageVersion "cryptography" "42.0.5"
 checkPythonPackageVersion "setuptools" "65.5.1"
 checkPythonPackageVersion "wheel" "0.38.1"
 
-checkCondaPackageVersion "cryptography" "42.0.4"
+checkCondaPackageVersion "cryptography" "42.0.5"
 checkCondaPackageVersion "pyopenssl" "24.0.0"
 checkCondaPackageVersion "setuptools" "65.5.1"
 checkCondaPackageVersion "wheel" "0.38.1"


### PR DESCRIPTION
https://github.com/devcontainers/images/issues/989 Library search path related issue in latest miniconda env
**Dev container name**:
 * miniconda
 
**Description**:
 This PR fixes the issue of searching `libc.so` in the `/usr/lib` due to additional environments added in the stack
 _Changelog_:
 * Updated Dockerfile
   * added environment variable `LD_LIBRARY_PATH=/opt/conda/lib`

**Checklist**:
 * [x]   built new miniconda image and added used the same image for miniconda-devcontainer-test project to run.