### PR TITLE
dotnet: improve dev-certs instructions

### DIFF
--- a/src/dotnet/README.md
+++ b/src/dotnet/README.md
@@ -53,10 +53,10 @@ For example, in `devcontainer.json`, add a named volume for the `x509stores` dir
         "target": "/home/vscode/.dotnet/corefx/cryptography/x509stores"
     }
 ],
-"onCreateCommand": "bash .devcontainer/on-create.sh"
+"onCreateCommand": "bash .devcontainer/setup-dotnet-dev-cert.sh"
 ```
 
-The contents of `.devcontainer/on-create.sh`:
+The contents of `.devcontainer/setup-dotnet-dev-cert.sh`:
 
 ``` bash
 #!/usr/bin/env bash

--- a/src/dotnet/README.md
+++ b/src/dotnet/README.md
@@ -66,7 +66,7 @@ sudo chown -R vscode:vscode /home/vscode/.dotnet
 
 # Export the ASP.NET Core HTTPS development certificate to a PEM file
 # If there is no development certificate, this command will generate a new one
-sudo -E dotnet dev-certs https --export-path /usr/local/share/ca-certificates/https.crt --format pem
+sudo -E dotnet dev-certs https --export-path /usr/local/share/ca-certificates/dotnet-dev-cert.crt --format pem
 
 # Add the PEM file to the trust store
 sudo update-ca-certificates

--- a/src/dotnet/README.md
+++ b/src/dotnet/README.md
@@ -39,11 +39,11 @@ See [history](history) for information on the contents of each version and [here
 
 Alternatively, you can use the contents of [.devcontainer](.devcontainer) to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
-### Enabling HTTPS in ASP.NET Core
+### Enabling HTTPS in ASP.NET Core by creating a dev certificate
 
-You can use `dotnet dev-certs https` inside the Dev Container to create a development HTTPS certificate for ASP.NET Core. However, each time the container is recreated, the development certificate will be lost. To make the development certificate survive container rebuilds, you can use a named volume. 
+You can use `dotnet dev-certs https` inside the dev container to create a development HTTPS certificate for ASP.NET Core. However, each time the container is recreated, the development certificate will be lost. To make the development certificate survive container rebuilds, you can use a named volume. 
 
-For example, in `devcontainer.json`, add a named volume for the `x509stores` directory inside the `vscode` user's home folder. Also add a lifecycle script, which adds the development certificate to the Dev Container's trust store.
+For example, in `devcontainer.json`, add a named volume for the `x509stores` directory inside the `vscode` user's home folder. Also add a lifecycle script, which adds the development certificate to the dev container's trust store.
 
 ``` json
 "mounts": [
@@ -72,7 +72,7 @@ sudo -E dotnet dev-certs https --export-path /usr/local/share/ca-certificates/ht
 sudo update-ca-certificates
 ```
 
-You should see the following output when the Dev Container is created:
+You should see the following output when the dev container is created:
 
 ``` text
 Running the onCreateCommand from devcontainer.json...
@@ -85,11 +85,11 @@ Running hooks in /etc/ca-certificates/update.d...
 done.
 ```
 
-Now this certificate will survive container rebuilds. The certificate will also be trusted by code running inside the container like `System.Net.HttpClient`, or tools like wget and curl. If needed, you can use Docker Desktop to export the development certificate to a local directory, in case you need to add it to any other trust stores.
+Now this certificate will survive container rebuilds. The certificate will also be trusted by code running inside the container like `System.Net.HttpClient`, or tools like `wget` and `curl`. If needed, you can use Docker Desktop to export the development certificate to a local directory, in case you need to add it to any other trust stores.
 
-#### Alternate solution
+### Enabling HTTPS in ASP.NET using your own dev certificate
 
-You can mount an exported copy of your local dev certificate. This solution is only suitable for private projects, as the password will become part of your `devcontainer.json`. Do not apply this solution to team projects or open source projects.
+You can mount an exported copy of your local dev certificate for enhanced convenience. This solution is ideal for private projects, but please note that the password will be included in your `devcontainer.json`. Avoid using this method for team projects or open source projects to maintain security best practices.
 
 1. Export the local certificate using the following command:
 

--- a/src/dotnet/README.md
+++ b/src/dotnet/README.md
@@ -66,12 +66,9 @@ sudo chown -R vscode:vscode /home/vscode/.dotnet
 
 # Export the ASP.NET Core HTTPS development certificate to a PEM file
 # If there is no development certificate, this command will generate a new one
-DOTNET_NOLOGO=true \
-DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
-dotnet dev-certs https --export-path /home/vscode/https.crt --format pem
+sudo -E dotnet dev-certs https --export-path /usr/local/share/ca-certificates/https.crt --format pem
 
 # Add the PEM file to the trust store
-sudo mv /home/vscode/https.crt /usr/local/share/ca-certificates/https.crt
 sudo update-ca-certificates
 ```
 


### PR DESCRIPTION
I updated the README for dotnet with a better way to manage HTTPS development certificates for ASP.NET Core.

Previously, it recommended a solution that did not work well in team or open source environments, as it required manual steps, and the solution carried a risk of unintended password disclosure.

I added a solution which does not require manual steps, nor does it have any risk of leaking passwords.

I did not remove the old instructions, but I did add a warning to avoid using it for shared projects.