### PR TITLE
dotnet: amend dev-cert script in README

### DIFF
--- a/src/dotnet/README.md
+++ b/src/dotnet/README.md
@@ -64,8 +64,10 @@ The contents of `.devcontainer/setup-dotnet-dev-cert.sh`:
 # Change ownership of the .dotnet directory to the vscode user (to avoid permission errors)
 sudo chown -R vscode:vscode /home/vscode/.dotnet
 
-# Export the ASP.NET Core HTTPS development certificate to a PEM file
 # If there is no development certificate, this command will generate a new one
+dotnet dev-certs https
+
+# Export the ASP.NET Core HTTPS development certificate to a PEM file
 sudo -E dotnet dev-certs https --export-path /usr/local/share/ca-certificates/dotnet-dev-cert.crt --format pem
 
 # Add the PEM file to the trust store


### PR DESCRIPTION
Hello again,

This is a minor correction for the dev-cert instructions that I added earlier this week in #1095.

In the original instructions, `sudo` is used to generate a new dev-cert. As a result, the `vscode` user might be unable to use the dev-cert due to insufficient permissions. The dev-cert is owned by `root:root` and the file permissions are `-rw------` (600).

The solution is simply to run the `dotnet dev-certs https` command first as the `vscode` user, resulting in the file being created with correct ownership. The use of `sudo` is still needed to export the dev-cert to the `ca-certificates/` directory.