### PR TITLE
[miniconda] - certifi - security patch - GHSA-248v-346w-9cwc 

### DIFF
--- a/src/miniconda/.devcontainer/apply_security_patches.sh
+++ b/src/miniconda/.devcontainer/apply_security_patches.sh
@@ -2,7 +2,7 @@
 
 # define array of packages for pinning to the patched versions
 # vulnerable_packages=( "package1=version1" "package2=version2" "package3=version3" )
-vulnerable_packages=( "tqdm=4.66.4" "requests=2.32.0" "urllib3=2.2.2")
+vulnerable_packages=( "tqdm=4.66.4" "requests=2.32.0" "urllib3=2.2.2" "certifi=2024.7.4")
 
 # Define the number of rows (based on the length of vulnerable_packages)
 rows=${#vulnerable_packages[@]}

--- a/src/miniconda/test-project/test.sh
+++ b/src/miniconda/test-project/test.sh
@@ -30,6 +30,7 @@ checkCondaPackageVersion "requests" "2.32.0"
 checkCondaPackageVersion "urllib3" "1.26.17"
 checkCondaPackageVersion "idna" "3.7"
 checkCondaPackageVersion "tqdm" "4.66.4"
+checkCondaPackageVersion "certifi" "2024.7.4"
 
 check "conda-update-conda" bash -c "conda update -y conda"
 check "conda-install-tensorflow" bash -c "conda create --name test-env -c conda-forge --yes tensorflow"


### PR DESCRIPTION
 
 **Dev container name**:
 
 * Miniconda
 
 **Description**:
 
 This PR patches the following vulnerability:
 
 * [GHSA-248v-346w-9cwc](https://github.com/advisories/GHSA-248v-346w-9cwc) - related to the `certifi` package;
 
 This vulnerability comes from the `continuumio/miniconda3` image used upstream for the `miniconda` devcontainer.
 
 _Changelog_:
 
 * Updated `Dockerfile`
   * Upgraded version for patched `conda` package;
     * `certifi` - _minimum package version has been set to `2024.7.4`_;
	 
 * Updated tests to verify `certifi` minimum version (Minimum package version set to `2024.7.4` which fixes [GHSA-248v-346w-9cwc](https://github.com/advisories/GHSA-248v-346w-9cwc));
 
 **Checklist**:
 
 * [x]   Checked that applied changes work as expected