### PR TITLE
[devcontainer images] - buster - eol - changes

### DIFF
--- a/src/base-debian/README.md
+++ b/src/base-debian/README.md
@@ -9,7 +9,7 @@
 | *Categories* | Core, Other |
 | *Image type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/base:debian |
-| *Available image variants* | bookworm, buster, bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/base/tags/list)) |
+| *Available image variants* | bookworm, bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/base/tags/list)) |
 | *Published image architecture(s)* | x86-64, aarch64/arm64 for `bookworm`, and `bullseye` variant |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -24,7 +24,6 @@ You can directly reference pre-built versions of `Dockerfile` by using the `imag
 - `mcr.microsoft.com/devcontainers/base:debian` (latest)
 - `mcr.microsoft.com/devcontainers/base:bookworm` (or `debian-12`)
 - `mcr.microsoft.com/devcontainers/base:bullseye` (or `debian-11`)
-- `mcr.microsoft.com/devcontainers/base:buster` (or `debian-10`)
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 

--- a/src/base-debian/manifest.json
+++ b/src/base-debian/manifest.json
@@ -2,7 +2,6 @@
 	"version": "1.0.13",
 	"variants": [
 		"bookworm",
-		"buster",
 		"bullseye"
 	],
 	"build": {
@@ -16,9 +15,6 @@
 			"bullseye": [
 				"linux/amd64",
 				"linux/arm64"
-			],
-			"buster": [
-				"linux/amd64"
 			]
 		},
 		"tags": [
@@ -34,10 +30,6 @@
 			"bullseye": [
 				"base:${VERSION}-debian-11",
 				"base:${VERSION}-debian11"
-			],
-			"buster": [
-				"base:${VERSION}-debian-10",
-				"base:${VERSION}-debian10"
 			]
 		}
 	},

--- a/src/java-8/README.md
+++ b/src/java-8/README.md
@@ -9,7 +9,7 @@
 | *Categories* | Core, Languages |
 | *Image type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/java:8 |
-| *Available image variants* | 8 / 8-bookworm, 8-buster, 8-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/java/tags/list)) |
+| *Available image variants* | 8 / 8-bookworm, 8-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/java/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bullseye` and `bookworm` variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -29,9 +29,9 @@ Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/devcontainers/java:2-8` (or `2-8-bookworm`, `2-8-bullseye`, `2-8-buster` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/java:2.0-8` (or `2.0-8-bookworm`, `2.0-8-bullseye`, `2.0-8-buster` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/java:2.0.0-8` (or `2.0.0-8-bookworm`, `2.0.0-8-bullseye`, `2.0.0-8-buster` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/java:2-8` (or `2-8-bookworm`, `2-8-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/java:2.0-8` (or `2.0-8-bookworm`, `2.0-8-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/java:2.0.0-8` (or `2.0.0-8-bookworm`, `2.0.0-8-bullseye` to pin to an OS version)
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `2-8`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 

--- a/src/java-8/manifest.json
+++ b/src/java-8/manifest.json
@@ -2,8 +2,7 @@
 	"version": "2.0.13",
 	"variants": [
 		"bookworm",
-		"bullseye",
-		"buster"
+		"bullseye"
 	],
 	"build": {
 		"latest": false,
@@ -17,9 +16,6 @@
 			"bullseye": [
 				"linux/amd64",
 				"linux/arm64"
-			],
-			"buster": [
-				"linux/amd64"
 			]
 		},
 		"tags": [
@@ -29,9 +25,6 @@
 			"bookworm": [
 				"java:${VERSION}-8",
 				"java:${VERSION}-8-jdk-bookworm"
-			],
-			"buster": [
-				"java:${VERSION}-8-jdk-buster"
 			],
 			"bullseye": [
 				"java:${VERSION}-8-jdk-bullseye"

--- a/src/java/README.md
+++ b/src/java/README.md
@@ -9,7 +9,7 @@
 | *Categories* | Core, Languages |
 | *Image type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/java |
-| *Available image variants* | 11 / 11-bookworm, 17 / 17-bookworm, 21 / 21-bookworm, 11-bullseye, 17-bullseye, 21-bullseye, 11-buster, 17-buster, 21-buster ([full list](https://mcr.microsoft.com/v2/devcontainers/java/tags/list)) |
+| *Available image variants* | 11 / 11-bookworm, 17 / 17-bookworm, 21 / 21-bookworm, 11-bullseye, 17-bullseye, 21-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/java/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bookworm`, and `bullseye` variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -22,17 +22,17 @@ See **[history](history)** for information on the contents of published images.
 You can directly reference pre-built versions of `Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
 
 - `mcr.microsoft.com/devcontainers/java` (latest)
-- `mcr.microsoft.com/devcontainers/java:21` (or `21-bookworm`, `21-bullseye`, `21-buster` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/java:11` (or `17-bookworm`, `11-bullseye`, `11-buster` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/java:17` (or `17-bookworm`, `17-bullseye`, `17-buster` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/java:21` (or `21-bookworm`, `21-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/java:11` (or `17-bookworm`, `11-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/java:17` (or `17-bookworm`, `17-bullseye` to pin to an OS version)
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/devcontainers/java:1-11` (or `1-11-bookworm`, `1-11-bullseye`, `1-11-buster` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/java:1.0-11` (or `1.0-11-bookworm`, `1.0-11-bullseye`, `1.0-11-buster` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/java:1.0.0-11` (or `1.0.0-11-bookworm`, `1.0.0-11-bullseye`, `1.0.0-11-buster` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/java:1-11` (or `1-11-bookworm`, `1-11-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/java:1.0-11` (or `1.0-11-bookworm`, `1.0-11-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/java:1.0.0-11` (or `1.0.0-11-bookworm`, `1.0.0-11-bullseye` to pin to an OS version)
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `1-11`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 

--- a/src/java/manifest.json
+++ b/src/java/manifest.json
@@ -3,13 +3,10 @@
 	"variants": [
 		"21-bookworm",
 		"21-bullseye",
-		"21-buster",
 		"17-bookworm",
 		"17-bullseye",
-		"17-buster",
 		"11-bookworm",
-		"11-bullseye",
-		"11-buster"
+		"11-bullseye"
 	],
 	"build": {
 		"latest": "21-bookworm",
@@ -40,18 +37,6 @@
 			"11-bullseye": {
 				"TARGET_JAVA_VERSION": "11",
 				"BASE_IMAGE_VERSION_CODENAME": "bullseye"
-			},
-			"21-buster": {
-				"TARGET_JAVA_VERSION": "21",
-				"BASE_IMAGE_VERSION_CODENAME": "buster"
-			},
-			"17-buster": {
-				"TARGET_JAVA_VERSION": "17",
-				"BASE_IMAGE_VERSION_CODENAME": "buster"
-			},
-			"11-buster": {
-				"TARGET_JAVA_VERSION": "11",
-				"BASE_IMAGE_VERSION_CODENAME": "buster"
 			}
 		},
 		"architectures": {
@@ -78,15 +63,6 @@
 			"11-bullseye": [
 				"linux/amd64",
 				"linux/arm64"
-			],
-			"21-buster": [
-				"linux/amd64"
-			],
-			"17-buster": [
-				"linux/amd64"
-			],
-			"11-buster": [
-				"linux/amd64"
 			]
 		},
 		"tags": [
@@ -115,16 +91,6 @@
 			],
 			"11-bullseye": [
 				"java:${VERSION}-11-jdk-bullseye"
-			],
-			"21-jdk-buster": [
-				"java:${VERSION}-21-jdk-buster",
-				"java:${VERSION}-buster"
-			],
-			"17-jdk-buster": [
-				"java:${VERSION}-17-jdk-buster"
-			],
-			"11-buster": [
-				"java:${VERSION}-11-jdk-buster"
 			]
 		}
 	},

--- a/src/javascript-node/README.md
+++ b/src/javascript-node/README.md
@@ -9,7 +9,7 @@
 | *Categories* | Core, Languages |
 | *Image type* | Dockerfile |
 | *Published image* | mcr.microsoft.com/devcontainers/javascript-node |
-| *Available image variants* | 22 / 22-bookworm, 20 / 20-bookworm, 18 / 18-bookworm, 20-bullseye, 18-bullseye, 20-buster, 18-buster ([full list](https://mcr.microsoft.com/v2/devcontainers/javascript-node/tags/list)) |
+| *Available image variants* | 22 / 22-bookworm, 20 / 20-bookworm, 18 / 18-bookworm, 20-bullseye, 18-bullseye, ([full list](https://mcr.microsoft.com/v2/devcontainers/javascript-node/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bookworm`, and `bullseye` variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -21,8 +21,8 @@ You can directly reference pre-built versions of `Dockerfile` by using the `imag
 
 - `mcr.microsoft.com/devcontainers/javascript-node` (latest)
 - `mcr.microsoft.com/devcontainers/javascript-node:22` (or `22-bookworm`, `22-bullseye` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/javascript-node:20` (or `20-bookworm`, `20-bullseye`, `20-buster` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/javascript-node:18` (or `18-bookworm`, `18-bullseye`, `18-buster` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/javascript-node:20` (or `20-bookworm`, `20-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/javascript-node:18` (or `18-bookworm`, `18-bullseye` to pin to an OS version)
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 

--- a/src/javascript-node/manifest.json
+++ b/src/javascript-node/manifest.json
@@ -6,9 +6,7 @@
 		"18-bookworm",
 		"22-bullseye",
 		"20-bullseye",
-		"18-bullseye",
-		"20-buster",
-		"18-buster"
+		"18-bullseye"
 	],
 	"build": {
 		"latest": "22-bookworm",
@@ -37,12 +35,6 @@
 			"18-bullseye": [
 				"linux/amd64",
 				"linux/arm64"
-			],
-			"20-buster": [
-				"linux/amd64"
-			],
-			"18-buster": [
-				"linux/amd64"
 			]
 		},
 		"tags": [
@@ -61,9 +53,6 @@
 			],
 			"22-bullseye": [
 				"javascript-node:${VERSION}-bullseye"
-			],
-			"20-buster": [
-				"javascript-node:${VERSION}-buster"
 			]
 		}
 	},

--- a/src/php/README.md
+++ b/src/php/README.md
@@ -9,7 +9,7 @@
 | *Categories* | Languages |
 | *Image type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/php |
-| *Available image variants* | 8 / 8-bookworm, 8.3 / 8.3-bookworm, 8.2 / 8.2-bookworm, 8.1 / 8.1-bookworm, 8-bullseye, 8.3-bullseye, 8.2-bullseye, 8.1-bullseye, 8-buster, 8.2-buster, 8.1-buster ([full list](https://mcr.microsoft.com/v2/devcontainers/php/tags/list)) |
+| *Available image variants* | 8 / 8-bookworm, 8.3 / 8.3-bookworm, 8.2 / 8.2-bookworm, 8.1 / 8.1-bookworm, 8-bullseye, 8.3-bullseye, 8.2-bullseye, 8.1-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/php/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bookworm`, and `bullseye` variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -22,18 +22,18 @@ See **[history](history)** for information on the contents of published images.
 You can directly reference pre-built versions of `Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own `Dockerfile` with one of the following:
 
 - `mcr.microsoft.com/devcontainers/php` (latest)
-- `mcr.microsoft.com/devcontainers/php:8` (or `8-bookworm`, `8-bullseye`, `8-buster` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/php:8` (or `8-bookworm`, `8-bullseye` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/php:8.3` (or `8.3-bookworm`, `8.3-bullseye` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/php:8.2` (or `8.2-bookworm`, `8.2-bullseye`, `8.2-buster` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/php:8.1` (or `8.1-bookworm`, `8.1-bullseye`, `8.1-buster` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/php:8.2` (or `8.2-bookworm`, `8.2-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/php:8.1` (or `8.1-bookworm`, `8.1-bullseye` to pin to an OS version)
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/devcontainers/php:1-8` (or `1-8-bookworm`, `1-8-bullseye`, `1-8-buster`)
-- `mcr.microsoft.com/devcontainers/php:1.0-8` (or `1.0-8-bookworm`, `1.0-8-bullseye`, `1.0-8-buster`)
-- `mcr.microsoft.com/devcontainers/php:1.0.3-8` (or `1.0.3-8-bookworm`, `1.0.3-8-bullseye`, `1.0.3-8-buster`)
+- `mcr.microsoft.com/devcontainers/php:1-8` (or `1-8-bookworm`, `1-8-bullseye`)
+- `mcr.microsoft.com/devcontainers/php:1.0-8` (or `1.0-8-bookworm`, `1.0-8-bullseye`)
+- `mcr.microsoft.com/devcontainers/php:1.0.3-8` (or `1.0.3-8-bookworm`, `1.0.3-8-bullseye`)
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `1-8`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 

--- a/src/php/manifest.json
+++ b/src/php/manifest.json
@@ -6,9 +6,7 @@
 		"8.1-apache-bookworm",
 		"8.3-apache-bullseye",
 		"8.2-apache-bullseye",
-		"8.1-apache-bullseye",
-		"8.2-apache-buster",
-		"8.1-apache-buster"
+		"8.1-apache-bullseye"
 	],
 	"build": {
 		"latest": "8.3-apache-bookworm",
@@ -37,12 +35,6 @@
 			"8.1-apache-bullseye": [
 				"linux/amd64",
 				"linux/arm64"
-			],
-			"8.2-apache-buster": [
-				"linux/amd64"
-			],
-			"8.1-apache-buster": [
-				"linux/amd64"
 			]
 		},
 		"tags": [
@@ -74,14 +66,6 @@
 			],
 			"8.1-apache-bullseye": [
 				"php:${VERSION}-8.1-bullseye"
-			],
-			"8.2-apache-buster": [
-				"php:${VERSION}-8-buster",
-				"php:${VERSION}-8.2-buster",
-				"php:${VERSION}-buster"
-			],
-			"8.1-apache-buster": [
-				"php:${VERSION}-8.1-buster"
 			]
 		}
 	},

--- a/src/python/README.md
+++ b/src/python/README.md
@@ -9,7 +9,7 @@
 | *Categories* | Core, Languages |
 | *Image type* | Dockerfile |
 | *Published image* | mcr.microsoft.com/devcontainers/python |
-| *Available image variants* | 3 / 3-bookworm, 3.8 / 3.8-bookworm, 3.9 / 3.9-bookworm, 3.10 / 3.10-bookworm, 3.11-bookworm / 3.11, 3.12-bookworm / 3.12, 3-bullseye, 3.8-bullseye, 3.9-bullseye, 3.10-bullseye, 3.11-bullseye, 12-bullseye, 3.8-buster, 3.9-buster, 3.10-buster, 3.11-buster ([full list](https://mcr.microsoft.com/v2/devcontainers/python/tags/list)) |
+| *Available image variants* | 3 / 3-bookworm, 3.8 / 3.8-bookworm, 3.9 / 3.9-bookworm, 3.10 / 3.10-bookworm, 3.11-bookworm / 3.11, 3.12-bookworm / 3.12, 3-bullseye, 3.8-bullseye, 3.9-bullseye, 3.10-bullseye, 3.11-bullseye, 12-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/python/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bookworm`, and `bullseye` variants |
 | *Container Host OS Support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -24,19 +24,19 @@ See **[history](history)** for information on the contents of published images.
 You can directly reference [pre-built](https://containers.dev/implementors/reference/#prebuilding) versions of this image by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own `Dockerfile` with one of the following:
 
 - `mcr.microsoft.com/devcontainers/python:3`    (latest)
-- `mcr.microsoft.com/devcontainers/python:3.8`  (or `3.8-bookworm`, `3.8-bullseye`, `3.8-buster` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/python:3.9`  (or `3.9-bookworm`, `3.9-bullseye`, `3.9-buster` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/python:3.10` (or `3.10-bookworm`, `3.10-bullseye`, `3.10-buster` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/python:3.11` (or `3.11-bookworm`, `3.11-bullseye`, `3.11-buster` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/python:3.12` (or `3.12-bookworm`, `3.12-bullseye`, `3.12-buster` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/python:3.8`  (or `3.8-bookworm`, `3.8-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/python:3.9`  (or `3.9-bookworm`, `3.9-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/python:3.10` (or `3.10-bookworm`, `3.10-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/python:3.11` (or `3.11-bookworm`, `3.11-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/python:3.12` (or `3.12-bookworm`, `3.12-bullseye` to pin to an OS version)
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/devcontainers/python:1-3.9` (or `1-3.9-bullseye`, `1-3.9-buster`)
-- `mcr.microsoft.com/devcontainers/python:1.0-3.9` (or `1.0-3.9-bullseye`, `1.0-3.9-buster`)
-- `mcr.microsoft.com/devcontainers/python:1.0.0-3.9` (or `1.0.0-3.9-bullseye`, `1.0.0-3.9-buster`)
+- `mcr.microsoft.com/devcontainers/python:1-3.9` (or `1-3.9-bullseye`)
+- `mcr.microsoft.com/devcontainers/python:1.0-3.9` (or `1.0-3.9-bullseye`)
+- `mcr.microsoft.com/devcontainers/python:1.0.0-3.9` (or `1.0.0-3.9-bullseye`)
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `1-3`). 
 You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.

--- a/src/python/manifest.json
+++ b/src/python/manifest.json
@@ -10,11 +10,7 @@
 		"3.11-bullseye",
 		"3.10-bullseye",
 		"3.9-bullseye",
-		"3.8-bullseye",
-		"3.11-buster",
-		"3.10-buster",
-		"3.9-buster",
-		"3.8-buster"
+		"3.8-bullseye"
 	],
 	"build": {
 		"latest": "3.12-bookworm",
@@ -59,18 +55,6 @@
 			"3.8-bullseye": [
 				"linux/amd64",
 				"linux/arm64"
-			],
-			"3.11-buster": [
-				"linux/amd64"
-			],
-			"3.10-buster": [
-				"linux/amd64"
-			],
-			"3.9-buster": [
-				"linux/amd64"
-			],
-			"3.8-buster": [
-				"linux/amd64"
 			]
 		},
 		"tags": [
@@ -98,10 +82,6 @@
 			"3.12-bullseye": [
 				"python:${VERSION}-3-bullseye",
 				"python:${VERSION}-bullseye"
-			],
-			"3.11-buster": [
-				"python:${VERSION}-3-buster",
-				"python:${VERSION}-buster"
 			]
 		}
 	},

--- a/src/ruby/README.md
+++ b/src/ruby/README.md
@@ -9,7 +9,7 @@
 | *Categories* | Core, Languages |
 | *Image type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/ruby |
-| *Available image variants* | 3 / 3-bookworm, 3.3 / 3.3-bookworm, 3.2 / 3.2-bookworm, 3.1 / 3.1-bookworm, 3-bullseye, 3.3-bullseye, 3.2-bullseye, 3.1-bullseye, 3-buster, 3.2-buster, 3.1-buster, ([full list](https://mcr.microsoft.com/v2/devcontainers/ruby/tags/list)) |
+| *Available image variants* | 3 / 3-bookworm, 3.3 / 3.3-bookworm, 3.2 / 3.2-bookworm, 3.1 / 3.1-bookworm, 3-bullseye, 3.3-bullseye, 3.2-bullseye, 3.1-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/ruby/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bookworm` , and `bullseye` variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -22,18 +22,18 @@ See **[history](history)** for information on the contents of published images.
 You can directly reference pre-built versions of `Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
 
 - `mcr.microsoft.com/devcontainers/ruby`     (latest)
-- `mcr.microsoft.com/devcontainers/ruby:3`   (or `3-bookworm`, `3-bullseye`, `3-buster` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/ruby:3`   (or `3-bookworm`, `3-bullseye` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/ruby:3.3` (or `3.3-bookworm`, `3.3-bullseye` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/ruby:3.2` (or `3.2-bookworm`, `3.2-bullseye`, `3.2-buster` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/ruby:3.1` (or `3.1-bookworm`, `3.1-bullseye`, `3.1-buster` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/ruby:3.2` (or `3.2-bookworm`, `3.2-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/ruby:3.1` (or `3.1-bookworm`, `3.1-bullseye` to pin to an OS version)
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/devcontainers/ruby:1-3`     (or `1-3-bookworm`, `1-3-bullseye`, `1-3-buster` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/ruby:1.0-3`   (or `1.0-3-bookworm`, `1.0-3-bullseye`, `1.0-3-buster` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/ruby:1.0.0-3` (or `1.0.0-3-bookworm`, `1.0.0-3-bullseye`, `1.0.0-3-buster` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/ruby:1-3`     (or `1-3-bookworm`, `1-3-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/ruby:1.0-3`   (or `1.0-3-bookworm`, `1.0-3-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/ruby:1.0.0-3` (or `1.0.0-3-bookworm`, `1.0.0-3-bullseye` to pin to an OS version)
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `1-3.2`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 

--- a/src/ruby/manifest.json
+++ b/src/ruby/manifest.json
@@ -6,9 +6,7 @@
 		"3.1-bookworm",
 		"3.3-bullseye",
 		"3.2-bullseye",
-		"3.1-bullseye",
-		"3.2-buster",
-		"3.1-buster"
+		"3.1-bullseye"
 	],
 	"build": {
 		"latest": "3.3-bookworm",
@@ -37,12 +35,6 @@
 			"3.1-bullseye": [
 				"linux/amd64",
 				"linux/arm64"
-			],
-			"3.2-buster": [
-				"linux/amd64"
-			],
-			"3.1-buster": [
-				"linux/amd64"
 			]
 		},
 		"tags": [
@@ -67,10 +59,6 @@
 			],
 			"3.2-bullseye": [
 				"ruby:${VERSION}-3.2-bullseye"
-			],
-			"3.2-buster": [
-				"ruby:${VERSION}-3-buster",
-				"ruby:${VERSION}-buster"
 			]
 		}
 	},

--- a/src/rust/README.md
+++ b/src/rust/README.md
@@ -9,7 +9,7 @@
 | *Categories* | Core, Languages |
 | *Image type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/rust |
-| *Available image variants* | bookworm, bullseye, buster,  ([full list](https://mcr.microsoft.com/v2/devcontainers/rust/tags/list)) |
+| *Available image variants* | bookworm, bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/rust/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bookworm`, and  `bullseye` variant |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -21,16 +21,16 @@ See **[history](history)** for information on the contents of published images.
 
 You can directly reference pre-built versions of `.devcontainer/Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own `Dockerfile` to the following. An example `Dockerfile` is included in this repository.
 
-- `mcr.microsoft.com/devcontainers/rust:latest` (or `bookworm`, `bullseye`, `buster` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/rust:1` (or `1-bookworm`, `1-bullseye`, `1-buster` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/rust:latest` (or `bookworm`, `bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/rust:1` (or `1-bookworm`, `1-bullseye` to pin to an OS version)
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/devcontainers/rust:1-1` (or `1-1-bookworm`, `1-1-bullseye`, `1-1-buster` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/rust:1.0-1` (or `1.0-1-bookworm`, `1.0-1-bullseye`, `1.0-1-buster` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/rust:1.0.0-1` (or `1.0.0-1-bookworm`, `1.0.0-1-bullseye`, `1.0.0-1-buster` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/rust:1-1` (or `1-1-bookworm`, `1-1-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/rust:1.0-1` (or `1.0-1-bookworm`, `1.0-1-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/rust:1.0.0-1` (or `1.0.0-1-bookworm`, `1.0.0-1-bullseye` to pin to an OS version)
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `1-1`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 

--- a/src/rust/manifest.json
+++ b/src/rust/manifest.json
@@ -2,7 +2,6 @@
 	"version": "1.0.14",
 	"variants": [
 		"bookworm",
-		"buster",
 		"bullseye"
 	],
 	"build": {
@@ -16,18 +15,12 @@
 			"bullseye": [
 				"linux/amd64",
 				"linux/arm64"
-			],
-			"buster": [
-				"linux/amd64"
 			]
 		},
 		"tags": [
 			"rust:${VERSION}-${VARIANT}"
 		],
 		"variantTags": {
-			"buster": [
-				"rust:${VERSION}-1-buster"
-			],
 			"bullseye": [
 				"rust:${VERSION}-1-bullseye"
 			],

--- a/src/typescript-node/manifest.json
+++ b/src/typescript-node/manifest.json
@@ -6,9 +6,7 @@
 		"18-bookworm",
 		"22-bullseye",
 		"20-bullseye",
-		"18-bullseye",
-		"20-buster",
-		"18-buster"
+		"18-bullseye"
 	],
 	"build": {
 		"latest": "22-bookworm",
@@ -38,12 +36,6 @@
 			"18-bullseye": [
 				"linux/amd64",
 				"linux/arm64"
-			],
-			"20-buster": [
-				"linux/amd64"
-			],
-			"18-buster": [
-				"linux/amd64"
 			]
 		},
 		"tags": [
@@ -65,9 +57,6 @@
 			],
 			"20-bullseye": [
 				"typescript-node:${VERSION}-bullseye"
-			],
-			"20-buster": [
-				"typescript-node:${VERSION}-buster"
 			]
 		}
 	},


### PR DESCRIPTION
**DevContainer Images**

* Debian
* Java
* Java-8
* Javascript-Node
* Ruby
* Rust
* PHP
* Python
* Typescript-Node

**Changes**

* The required changes to the `manifest.json` and `readme.md` files have been made for `Buster` EOL


**Checklist**

* [x]  Checked that the applied changes work as expected