### PR TITLE
[anaconda] - zipp- GHSA-jfmj-5v4g-7637 apply security patch..

### DIFF
--- a/src/anaconda/.devcontainer/apply_security_patches.sh
+++ b/src/anaconda/.devcontainer/apply_security_patches.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 vulnerable_packages=( "pydantic=2.5.3" "joblib=1.3.1" "mistune=3.0.1" "werkzeug=3.0.3" "transformers=4.36.0" "pillow=10.3.0" "aiohttp=3.9.4" \
-          "cryptography=42.0.4" "gitpython=3.1.41"  "jupyter-lsp=2.2.2" "idna=3.7" "jinja2=3.1.4" "scrapy=2.11.2" "black=24.4.2" "requests=2.32.2" "jupyter_server=2.14.1" "tornado=6.4.1" "tqdm=4.66.4" "urllib3=2.2.2" "scikit-learn=1.5.0")
+          "cryptography=42.0.4" "gitpython=3.1.41"  "jupyter-lsp=2.2.2" "idna=3.7" "jinja2=3.1.4" "scrapy=2.11.2" "black=24.4.2" "requests=2.32.2" "jupyter_server=2.14.1" "tornado=6.4.1" "tqdm=4.66.4" "urllib3=2.2.2" "scikit-learn=1.5.0" "zipp=3.19.1" )
 
 # Define the number of rows (based on the length of vulnerable_packages)
 rows=${#vulnerable_packages[@]}

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -54,6 +54,7 @@ checkPythonPackageVersion "jinja2" "3.1.4"
 checkPythonPackageVersion "scrapy" "2.11.2"
 checkPythonPackageVersion "requests" "2.32.2"
 checkPythonPackageVersion "scikit-learn" "1.5.0"
+checkPythonPackageVersion "zipp" "3.19.1"
 
 checkCondaPackageVersion "pyopenssl" "23.2.0"
 checkCondaPackageVersion "requests" "2.32.2"


### PR DESCRIPTION
 **Dev container name**:
 
 * Anaconda
 
 **Description**:
 
 This PR patches the following vulnerability:
 
 * [GHSA-jfmj-5v4g-7637](https://github.com/advisories/GHSA-jfmj-5v4g-7637) - related to the `zipp` package;
 
 This vulnerability comes from the coninuumio/Anaconda3 image used upstream for the Anaconda devcontainer.
 
 _Changelog_:
 
 * Updated Dockerfile
   * Upgraded version for patched conda package;
     * `zipp` - _minimum package version has been set to `3.19.1`_;
	 
 * Updated tests to verify `zipp` minimum version (Minimum package version set to `3.19.1` which fixes [GHSA-jfmj-5v4g-7637](https://github.com/advisories/GHSA-jfmj-5v4g-7637));
 
 **Checklist**:
 
 * [x]   Checked that applied changes work as expected