### PR TITLE
[DotNet] - Powershell - v7.4.3 patched - CVE-2024-30045

### DIFF
--- a/src/dotnet/.devcontainer/Dockerfile
+++ b/src/dotnet/.devcontainer/Dockerfile
@@ -8,12 +8,12 @@ ENV NUGET_XMLDOC_MODE=
 
 # Temporary: Upgrade packages due to mentioned CVEs
 # They are installed by the base image (mcr.microsoft.com/dotnet/sdk) which does not have the patch.
-# https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-0057
+# https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-30045
 RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
         apt-get update && \
         apt-get install -y wget && \
-        POWERSHELL_FILE_NAME="powershell_7.4.1-1.deb_amd64.deb" && \
-        wget https://github.com/PowerShell/PowerShell/releases/download/v7.4.1/${POWERSHELL_FILE_NAME} && \
+        POWERSHELL_FILE_NAME="powershell_7.4.3-1.deb_amd64.deb" && \
+        wget https://github.com/PowerShell/PowerShell/releases/download/v7.4.3/${POWERSHELL_FILE_NAME} && \
         dpkg -i ${POWERSHELL_FILE_NAME} && \
         apt-get install -f && \
         rm ${POWERSHELL_FILE_NAME} ; \
@@ -23,7 +23,7 @@ RUN if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
         apt-get update && \
         apt-get install -y curl tar && \
         POWERSHELL_FILE_PATH="/opt/microsoft/powershell/7" && \
-        curl -L -o /tmp/powershell.tar.gz https://github.com/PowerShell/PowerShell/releases/download/v7.4.1/powershell-7.4.1-linux-arm64.tar.gz && \
+        curl -L -o /tmp/powershell.tar.gz https://github.com/PowerShell/PowerShell/releases/download/v7.4.3/powershell-7.4.3-linux-arm64.tar.gz && \
         mkdir -p ${POWERSHELL_FILE_PATH} && \
         tar zxf /tmp/powershell.tar.gz -C ${POWERSHELL_FILE_PATH} && \
         chmod +x ${POWERSHELL_FILE_PATH}/pwsh && \

--- a/src/dotnet/test-project/test.sh
+++ b/src/dotnet/test-project/test.sh
@@ -27,7 +27,7 @@ check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcont
 
 check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
-checkPackageVersion "pwsh" "7.4.1" "PowerShell"
+checkPackageVersion "pwsh" "7.4.3" "PowerShell"
 
 # Report result
 reportResults


### PR DESCRIPTION
**Dev Container Name**

* Dot Net

**Description**:
 
 This PR patches the following vulnerability:
 
 * [CVE-2024-30045](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-30045) - related to the `powershell` package;
 
 _Changelog_:
 
 * Updated Dockerfile
   * Upgraded version for patched powershell package;
     * `pwsh` - _minimum package version has been set to `7.4.3`_;
	 
 * Updated tests to verify `pwsh` minimum version (Minimum package version set to `7.4.3` which fixes [CVE-2024-30045](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-30045));
 
 **Checklist**:
 
 * [x]   Checked that applied changes work as expected

