### PR TITLE
chore: support go 1.23

### DIFF
--- a/src/go/.devcontainer/Dockerfile
+++ b/src/go/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG VARIANT=1.22-bookworm
+ARG VARIANT=1.23-bookworm
 FROM golang:${VARIANT}
 
 # [Optional] Uncomment the next line to use go get to install anything else you need

--- a/src/go/README.md
+++ b/src/go/README.md
@@ -10,7 +10,7 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/go |
-| *Available image variants* | 1 / 1-bookworm, 1.22 / 1.22-bookworm, 1.21 / 1.21-bookworm, 1-bullseye, 1.22-bullseye, 1.21-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/go/tags/list)) |
+| *Available image variants* | 1 / 1-bookworm, 1.23 / 1.23-bookworm, 1.22 / 1.22-bookworm, 1-bullseye, 1.22-bullseye, 1.21-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/go/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bookworm`, and `bullseye` variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -24,18 +24,18 @@ You can directly reference pre-built versions of `Dockerfile` by using the `imag
 
 - `mcr.microsoft.com/devcontainers/go` (latest)
 - `mcr.microsoft.com/devcontainers/go:1` (or `1-bookworm`, `1-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/go:1.23` (or `1.23-bookworm`, `1.23-bullseye` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/go:1.22` (or `1.22-bookworm`, `1.22-bullseye` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/go:1.21` (or `1.21-bookworm`, `1.21-bullseye` to pin to an OS version)
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/devcontainers/go:1-1.22` (or `1-1.22-bookworm`, `1-1.22-bullseye`)
-- `mcr.microsoft.com/devcontainers/go:1.1-1.22` (or `1.1-1.22-bookworm`, `1.1-1.22-bullseye`)
-- `mcr.microsoft.com/devcontainers/go:1.1.9-1.22` (or `1.1.9-1.22-bookworm`, `1.1.9-1.22-bullseye`)
+- `mcr.microsoft.com/devcontainers/go:1-1.23` (or `1-1.23-bookworm`, `1-1.23-bullseye`)
+- `mcr.microsoft.com/devcontainers/go:1.1-1.23` (or `1.1-1.23-bookworm`, `1.1-1.23-bullseye`)
+- `mcr.microsoft.com/devcontainers/go:1.1.9-1.23` (or `1.1.9-1.23-bookworm`, `1.1.9-1.23-bullseye`)
 
-However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `1-1.22`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
+However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `1-1.23`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/go/tags/list).
 

--- a/src/go/README.md
+++ b/src/go/README.md
@@ -32,8 +32,8 @@ Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/devcontainers/go:1-1.23` (or `1-1.23-bookworm`, `1-1.23-bullseye`)
-- `mcr.microsoft.com/devcontainers/go:1.1-1.23` (or `1.1-1.23-bookworm`, `1.1-1.23-bullseye`)
-- `mcr.microsoft.com/devcontainers/go:1.1.9-1.23` (or `1.1.9-1.23-bookworm`, `1.1.9-1.23-bullseye`)
+- `mcr.microsoft.com/devcontainers/go:1.2-1.23` (or `1.2-1.23-bookworm`, `1.2-1.23-bullseye`)
+- `mcr.microsoft.com/devcontainers/go:1.2.0-1.23` (or `1.2.0-1.23-bookworm`, `1.2.0-1.23-bullseye`)
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `1-1.23`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 

--- a/src/go/manifest.json
+++ b/src/go/manifest.json
@@ -9,7 +9,7 @@
     "1.21-bullseye"
   ],
   "build": {
-    "latest": "1.22-bookworm",
+    "latest": "1.23-bookworm",
     "rootDistro": "debian",
     "tags": [
       "go:${VERSION}-${VARIANT}"
@@ -51,10 +51,6 @@
         "go:${VERSION}-1.22"
       ],
       "1.23-bullseye": [
-        "go:${VERSION}-1-bullseye",
-        "go:${VERSION}-bullseye"
-      ],
-      "1.22-bullseye": [
         "go:${VERSION}-1-bullseye",
         "go:${VERSION}-bullseye"
       ],

--- a/src/go/manifest.json
+++ b/src/go/manifest.json
@@ -1,12 +1,12 @@
 {
   "version": "1.1.15",
   "variants": [
-		"1.23-bookworm",
-		"1.22-bookworm",
-		"1.21-bookworm",
-		"1.23-bullseye",
-		"1.22-bullseye",
-		"1.21-bullseye"
+    "1.23-bookworm",
+    "1.22-bookworm",
+    "1.21-bookworm",
+    "1.23-bullseye",
+    "1.22-bullseye",
+    "1.21-bullseye"
   ],
   "build": {
     "latest": "1.22-bookworm",
@@ -15,7 +15,7 @@
       "go:${VERSION}-${VARIANT}"
     ],
     "architectures": {
-			"1.23-bookworm": [
+      "1.23-bookworm": [
         "linux/amd64",
         "linux/arm64"
       ],
@@ -23,7 +23,7 @@
         "linux/amd64",
         "linux/arm64"
       ],
-			"1.21-bookworm": [
+      "1.21-bookworm": [
         "linux/amd64",
         "linux/arm64"
       ],
@@ -31,7 +31,7 @@
         "linux/amd64",
         "linux/arm64"
       ],
-			"1.22-bullseye": [
+      "1.22-bullseye": [
         "linux/amd64",
         "linux/arm64"
       ],
@@ -47,7 +47,7 @@
         "go:${VERSION}-1-bookworm",
         "go:${VERSION}-bookworm"
       ],
-			"1.22-bookworm": [
+      "1.22-bookworm": [
         "go:${VERSION}-1.22",
         "go:${VERSION}-1",
         "go:${VERSION}-1-bookworm",
@@ -57,11 +57,11 @@
         "go:${VERSION}-1-bullseye",
         "go:${VERSION}-bullseye"
       ],
-			"1.22-bullseye": [
+      "1.22-bullseye": [
         "go:${VERSION}-1-bullseye",
         "go:${VERSION}-bullseye"
       ],
-			"1.21-bookworm": [
+      "1.21-bookworm": [
         "go:${VERSION}-1.21"
       ]
     }
@@ -99,8 +99,8 @@
         "cgIgnore": true
       }
     },
-		"other": {
-			"git": {}
-		}
+    "other": {
+      "git": {}
+    }
   }
 }

--- a/src/go/manifest.json
+++ b/src/go/manifest.json
@@ -1,8 +1,10 @@
 {
   "version": "1.1.15",
   "variants": [
+		"1.23-bookworm",
 		"1.22-bookworm",
 		"1.21-bookworm",
+		"1.23-bullseye",
 		"1.22-bullseye",
 		"1.21-bullseye"
   ],
@@ -13,11 +15,19 @@
       "go:${VERSION}-${VARIANT}"
     ],
     "architectures": {
-			"1.22-bookworm": [
+			"1.23-bookworm": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "1.22-bookworm": [
         "linux/amd64",
         "linux/arm64"
       ],
 			"1.21-bookworm": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "1.23-bullseye": [
         "linux/amd64",
         "linux/arm64"
       ],
@@ -31,11 +41,21 @@
       ]
     },
     "variantTags": {
+      "1.23-bookworm": [
+        "go:${VERSION}-1.23",
+        "go:${VERSION}-1",
+        "go:${VERSION}-1-bookworm",
+        "go:${VERSION}-bookworm"
+      ],
 			"1.22-bookworm": [
         "go:${VERSION}-1.22",
         "go:${VERSION}-1",
         "go:${VERSION}-1-bookworm",
         "go:${VERSION}-bookworm"
+      ],
+      "1.23-bullseye": [
+        "go:${VERSION}-1-bullseye",
+        "go:${VERSION}-bullseye"
       ],
 			"1.22-bullseye": [
         "go:${VERSION}-1-bullseye",

--- a/src/go/manifest.json
+++ b/src/go/manifest.json
@@ -48,10 +48,7 @@
         "go:${VERSION}-bookworm"
       ],
       "1.22-bookworm": [
-        "go:${VERSION}-1.22",
-        "go:${VERSION}-1",
-        "go:${VERSION}-1-bookworm",
-        "go:${VERSION}-bookworm"
+        "go:${VERSION}-1.22"
       ],
       "1.23-bullseye": [
         "go:${VERSION}-1-bullseye",


### PR DESCRIPTION
Add support for go 1.23 as released https://go.dev/doc/go1.23