### PR TITLE
[anaconda] - streamlit - GHSA-rxff-vr5r-8cj5

### DIFF
--- a/src/anaconda/.devcontainer/apply_security_patches.sh
+++ b/src/anaconda/.devcontainer/apply_security_patches.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
+# vulnerabilities:
+# streamlit - [GHSA-rxff-vr5r-8cj5]
+
 vulnerable_packages=( "pydantic=2.5.3" "joblib=1.3.1" "mistune=3.0.1" "werkzeug=3.0.3" "transformers=4.36.0" "pillow=10.3.0" "aiohttp=3.10.2" \
-          "cryptography=42.0.4" "gitpython=3.1.41"  "jupyter-lsp=2.2.2" "idna=3.7" "jinja2=3.1.4" "scrapy=2.11.2" "black=24.4.2" "requests=2.32.2" "jupyter_server=2.14.1" "tornado=6.4.1" "tqdm=4.66.4" "urllib3=2.2.2" "scikit-learn=1.5.0" "zipp=3.19.1" )
+          "cryptography=42.0.4" "gitpython=3.1.41"  "jupyter-lsp=2.2.2" "idna=3.7" "jinja2=3.1.4" "scrapy=2.11.2" "black=24.4.2" "requests=2.32.2" \
+          "jupyter_server=2.14.1" "tornado=6.4.1" "tqdm=4.66.4" "urllib3=2.2.2" "scikit-learn=1.5.0" "zipp=3.19.1" "streamlit=1.37.0" )
 
 # Define the number of rows (based on the length of vulnerable_packages)
 rows=${#vulnerable_packages[@]}

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -65,6 +65,7 @@ checkCondaPackageVersion "pyarrow" "14.0.1"
 checkCondaPackageVersion "pydantic" "2.5.3"
 checkCondaPackageVersion "tqdm" "4.66.4"
 checkCondaPackageVersion "black" "24.4.2"
+checkCondaPackageVersion "streamlit" "1.37.0"
 
 check "conda-update-conda" bash -c "conda update -y conda"
 check "conda-install-tensorflow" bash -c "conda create --name test-env -c conda-forge --yes tensorflow"


### PR DESCRIPTION
**Dev container name**:
 
 * Anaconda
 
 **Description**:
 
 This PR patches the following vulnerability:
 
 * [GHSA-rxff-vr5r-8cj5](https://github.com/advisories/GHSA-rxff-vr5r-8cj5) - related to the `streamlit` package;
 
 This vulnerability comes from the `coninuumio/anaconda3` image used upstream for the Anaconda devcontainer.
 
 _Changelog_:
 
 * Updated `apply_security_patches.sh` file
   * Upgraded version for patched `conda package`;
     * `streamlit` - _minimum package version has been set to `1.37.0`_;
	 
 * Updated tests to verify `streamlit` minimum version (Minimum package version set to `1.37.0` which fixes [GHSA-rxff-vr5r-8cj5](https://github.com/advisories/GHSA-rxff-vr5r-8cj5));
 
 **Checklist**:
 
 * [x]   Checked that applied changes work as expected

