### PR TITLE
[miniconda] - cryptography - GHSA-h4gh-qq45-vh27

### DIFF
--- a/src/miniconda/.devcontainer/apply_security_patches.sh
+++ b/src/miniconda/.devcontainer/apply_security_patches.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
+# vulnerablities 
+# cryptography - [GHSA-h4gh-qq45-vh27]
+
 # define array of packages for pinning to the patched versions
 # vulnerable_packages=( "package1=version1" "package2=version2" "package3=version3" )
-vulnerable_packages=( "tqdm=4.66.4" "requests=2.32.0" "urllib3=2.2.2" "certifi=2024.7.4")
+vulnerable_packages=( "tqdm=4.66.4" "requests=2.32.0" "urllib3=2.2.2" "certifi=2024.7.4" "cryptography=43.0.1" )
 
 # Define the number of rows (based on the length of vulnerable_packages)
 rows=${#vulnerable_packages[@]}

--- a/src/miniconda/test-project/test.sh
+++ b/src/miniconda/test-project/test.sh
@@ -18,12 +18,12 @@ check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcont
 
 check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
-checkPythonPackageVersion "cryptography" "42.0.4"
+checkPythonPackageVersion "cryptography" "43.0.1"
 checkPythonPackageVersion "setuptools" "65.5.1"
 checkPythonPackageVersion "wheel" "0.38.1"
 checkPythonPackageVersion "urllib3" "2.2.2"
 
-checkCondaPackageVersion "cryptography" "42.0.4"
+checkCondaPackageVersion "cryptography" "43.0.1"
 checkCondaPackageVersion "setuptools" "65.5.1"
 checkCondaPackageVersion "wheel" "0.38.1"
 checkCondaPackageVersion "requests" "2.32.0"


### PR DESCRIPTION
 **Dev container name**:
 
 * Miniconda
 
 **Description**:
 
 This PR patches the following vulnerability:
 
 * [GHSA-h4gh-qq45-vh27](https://github.com/advisories/GHSA-h4gh-qq45-vh27) - related to the `cryptography` package;
 
 This vulnerability comes from the coninuumio/miniconda3 image used upstream for the Miniconda devcontainer.
 
 _Changelog_:
 
 * Updated Dockerfile
   * Upgraded version for patched python package;
     * `cryptography` - _minimum package version has been set to `43.0.1`_;
	 
 * Updated tests to verify `cryptography` minimum version (Minimum package version set to `43.0.1` which fixes [GHSA-h4gh-qq45-vh27](https://github.com/advisories/GHSA-h4gh-qq45-vh27));
 
 **Checklist**:
 
 * [x]   Checked that applied changes work as expected


