### PR TITLE
[anaconda] - GHSA-cgvx-9447-vcch - nltk package - apply security patch

### DIFF
--- a/src/anaconda/.devcontainer/apply_security_patches.sh
+++ b/src/anaconda/.devcontainer/apply_security_patches.sh
@@ -4,10 +4,11 @@
 # streamlit - [GHSA-rxff-vr5r-8cj5]
 # notebook, jupyterlab - [GHSA-9q39-rmj3-p4r2]
 # cryptography, pyopenssl - [GHSA-h4gh-qq45-vh27]
+# nltk - [GHSA-cgvx-9447-vcch]
 
 vulnerable_packages=( "pydantic=2.5.3" "joblib=1.3.1" "mistune=3.0.1" "werkzeug=3.0.3" "transformers=4.36.0" "pillow=10.3.0" "aiohttp=3.10.2" "pyopenssl=24.2.1" \
           "cryptography=43.0.1" "gitpython=3.1.41"  "jupyter-lsp=2.2.2" "idna=3.7" "jinja2=3.1.4" "scrapy=2.11.2" "black=24.4.2" "requests=2.32.2" \
-          "jupyter_server=2.14.1" "tornado=6.4.1" "tqdm=4.66.4" "urllib3=2.2.2" "scikit-learn=1.5.0" "zipp=3.19.1" "streamlit=1.37.0" "notebook=7.2.2" )
+          "jupyter_server=2.14.1" "tornado=6.4.1" "tqdm=4.66.4" "urllib3=2.2.2" "scikit-learn=1.5.0" "zipp=3.19.1" "streamlit=1.37.0" "notebook=7.2.2" "nltk=3.9" )
 
 # Define the number of rows (based on the length of vulnerable_packages)
 rows=${#vulnerable_packages[@]}

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -67,6 +67,7 @@ checkCondaPackageVersion "pydantic" "2.5.3"
 checkCondaPackageVersion "tqdm" "4.66.4"
 checkCondaPackageVersion "black" "24.4.2"
 checkCondaPackageVersion "streamlit" "1.37.0"
+checkCondaPackageVersion "nltk" "3.9"
 
 check "conda-update-conda" bash -c "conda update -y conda"
 check "conda-install-tensorflow" bash -c "conda create --name test-env -c conda-forge --yes tensorflow"


### PR DESCRIPTION
 **Dev container name**:
 
 * Anaconda
 
 **Description**:
 
 This PR patches the following vulnerability:
 
 * [GHSA-cgvx-9447-vcch](https://github.com/advisories/GHSA-cgvx-9447-vcch) - related to the `nltk` package;
 
 This vulnerability comes from the `coninuumio/anaconda3` image used upstream for the `Anaconda` devcontainer.
 
 _Changelog_:
 
 * Updated Dockerfile
   * Upgraded version for patched `conda` package;
     * `nltk` - _minimum package version has been set to `3.9`_;
	 
 * Updated tests to verify `nltk` minimum version (Minimum package version set to `3.9` which fixes [GHSA-cgvx-9447-vcch](https://github.com/advisories/GHSA-cgvx-9447-vcch));
 
 **Checklist**:
 
 * [x]   Checked that applied changes work as expected