### PR TITLE
Remove support for Python 3.8

### DIFF
--- a/src/python/.devcontainer/Dockerfile
+++ b/src/python/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Python version (use -bookworm or -bullseye variants on local arm64/Apple Silicon): 3, 3.13, 3.12, 3.11, 3.10, 3.9, 3.8, 3-bookworm, 3.13-bookworm, 3.12-bookworm, 3.11-bookworm, 3.10-bookworm, 3.9-bookworm, 3.8-bookworm, 3-bullseye, 3.13-bullseye, 3.12-bullseye, 3.11-bullseye, 3.10-bullseye, 3.9-bullseye, 3.8-bullseye, 3-buster, 3.12-buster, 3.11-buster, 3.10-buster, 3.9-buster, 3.8-buster
+# [Choice] Python version (use -bookworm or -bullseye variants on local arm64/Apple Silicon): 3, 3.13, 3.12, 3.11, 3.10, 3.9, 3.8, 3-bookworm, 3.13-bookworm, 3.12-bookworm, 3.11-bookworm, 3.10-bookworm, 3.9-bookworm, 3.8-bookworm, 3-bullseye, 3.13-bullseye, 3.12-bullseye, 3.11-bullseye, 3.10-bullseye, 3.9-bullseye, 3.8-bullseye
 ARG VARIANT=3-bookworm
 FROM python:${VARIANT}
 

--- a/src/python/.devcontainer/Dockerfile
+++ b/src/python/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Python version (use -bookworm or -bullseye variants on local arm64/Apple Silicon): 3, 3.13, 3.12, 3.11, 3.10, 3.9, 3.8, 3-bookworm, 3.13-bookworm, 3.12-bookworm, 3.11-bookworm, 3.10-bookworm, 3.9-bookworm, 3.8-bookworm, 3-bullseye, 3.13-bullseye, 3.12-bullseye, 3.11-bullseye, 3.10-bullseye, 3.9-bullseye, 3.8-bullseye
+# [Choice] Python version: 3, 3.13, 3.12, 3.11, 3.10, 3.9, 3.8, 3-bookworm, 3.13-bookworm, 3.12-bookworm, 3.11-bookworm, 3.10-bookworm, 3.9-bookworm, 3.8-bookworm, 3-bullseye, 3.13-bullseye, 3.12-bullseye, 3.11-bullseye, 3.10-bullseye, 3.9-bullseye, 3.8-bullseye
 ARG VARIANT=3-bookworm
 FROM python:${VARIANT}
 

--- a/src/python/.devcontainer/Dockerfile
+++ b/src/python/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Python version: 3, 3.13, 3.12, 3.11, 3.10, 3.9, 3.8, 3-bookworm, 3.13-bookworm, 3.12-bookworm, 3.11-bookworm, 3.10-bookworm, 3.9-bookworm, 3.8-bookworm, 3-bullseye, 3.13-bullseye, 3.12-bullseye, 3.11-bullseye, 3.10-bullseye, 3.9-bullseye, 3.8-bullseye
+# [Choice] Python version: 3, 3.13, 3.12, 3.11, 3.10, 3.9, 3-bookworm, 3.13-bookworm, 3.12-bookworm, 3.11-bookworm, 3.10-bookworm, 3.9-bookworm, 3-bullseye, 3.13-bullseye, 3.12-bullseye, 3.11-bullseye, 3.10-bullseye, 3.9-bullseye
 ARG VARIANT=3-bookworm
 FROM python:${VARIANT}
 

--- a/src/python/README.md
+++ b/src/python/README.md
@@ -9,7 +9,7 @@
 | *Categories* | Core, Languages |
 | *Image type* | Dockerfile |
 | *Published image* | mcr.microsoft.com/devcontainers/python |
-| *Available image variants* | 3 / 3-bookworm, 3.8 / 3.8-bookworm, 3.9 / 3.9-bookworm, 3.10 / 3.10-bookworm, 3.11-bookworm / 3.11, 3.12-bookworm / 3.12, 3.13-bookworm / 3.13, 3-bullseye, 3.8-bullseye, 3.9-bullseye, 3.10-bullseye, 3.11-bullseye, 3.12-bullseye, 3.13-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/python/tags/list)) |
+| *Available image variants* | 3 / 3-bookworm, 3.9 / 3.9-bookworm, 3.10 / 3.10-bookworm, 3.11-bookworm / 3.11, 3.12-bookworm / 3.12, 3.13-bookworm / 3.13, 3-bullseye, 3.9-bullseye, 3.10-bullseye, 3.11-bullseye, 3.12-bullseye, 3.13-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/python/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bookworm`, and `bullseye` variants |
 | *Container Host OS Support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -24,7 +24,6 @@ See **[history](history)** for information on the contents of published images.
 You can directly reference [pre-built](https://containers.dev/implementors/reference/#prebuilding) versions of this image by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own `Dockerfile` with one of the following:
 
 - `mcr.microsoft.com/devcontainers/python:3`    (latest)
-- `mcr.microsoft.com/devcontainers/python:3.8`  (or `3.8-bookworm`, `3.8-bullseye` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/python:3.9`  (or `3.9-bookworm`, `3.9-bullseye` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/python:3.10` (or `3.10-bookworm`, `3.10-bullseye` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/python:3.11` (or `3.11-bookworm`, `3.11-bullseye` to pin to an OS version)
@@ -131,7 +130,7 @@ If you would prefer to have multiple Python versions in your container, use `Doc
 
 ```Dockerfile
 FROM ubuntu:jammy
-ARG PYTHON_PACKAGES="python3.8 python3.9 python3 python3-pip python3-venv"
+ARG PYTHON_PACKAGES="python3.9 python3.10 python3 python3-pip python3-venv"
 RUN apt-get update && apt-get install --no-install-recommends -yq software-properties-common \
      && add-apt-repository ppa:deadsnakes/ppa && apt-get update \
      && apt-get install -yq --no-install-recommends ${PYTHON_PACKAGES} \

--- a/src/python/manifest.json
+++ b/src/python/manifest.json
@@ -6,13 +6,11 @@
 		"3.11-bookworm",
 		"3.10-bookworm",
 		"3.9-bookworm",
-		"3.8-bookworm",
 		"3.13-bullseye",
 		"3.12-bullseye",
 		"3.11-bullseye",
 		"3.10-bullseye",
-		"3.9-bullseye",
-		"3.8-bullseye"
+		"3.9-bullseye"
 	],
 	"build": {
 		"latest": "3.13-bookworm",
@@ -38,10 +36,6 @@
 				"linux/amd64",
 				"linux/arm64"
 			],
-			"3.8-bookworm": [
-				"linux/amd64",
-				"linux/arm64"
-			],
 			"3.13-bullseye": [
 				"linux/amd64",
 				"linux/arm64"
@@ -59,10 +53,6 @@
 				"linux/arm64"
 			],
 			"3.9-bullseye": [
-				"linux/amd64",
-				"linux/arm64"
-			],
-			"3.8-bullseye": [
 				"linux/amd64",
 				"linux/arm64"
 			]
@@ -88,9 +78,6 @@
 			],
 			"3.9-bookworm": [
 				"python:${VERSION}-3.9"
-			],
-			"3.8-bookworm": [
-				"python:${VERSION}-3.8"
 			],
 			"3.13-bullseye": [
 				"python:${VERSION}-3-bullseye",


### PR DESCRIPTION
Remove image variants for Python 3.8, which reached end of life on 2024-10-07. This also cleans up a couple things: removing mention of Buster image variants and arm64 image recommendations in the Dockerfile.

This is my first PR here. Let me know if there's anything I missed or if you'd want me to split any of these commits up into a separate PR. Thanks!