### PR TITLE
[python] - add 3.13 - manifest, dockerfile, readme

### DIFF
--- a/src/python/.devcontainer/Dockerfile
+++ b/src/python/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Python version (use -bookworm or -bullseye variants on local arm64/Apple Silicon): 3, 3.12, 3.11, 3.10, 3.9, 3.8, 3-bookworm, 3.12-bookworm, 3.11-bookworm, 3.10-bookworm, 3.9-bookworm, 3.8-bookworm, 3-bullseye, 3.12-bullseye, 3.11-bullseye, 3.10-bullseye, 3.9-bullseye, 3.8-bullseye, 3-buster, 3.12-buster, 3.11-buster, 3.10-buster, 3.9-buster, 3.8-buster
+# [Choice] Python version (use -bookworm or -bullseye variants on local arm64/Apple Silicon): 3, 3.13, 3.12, 3.11, 3.10, 3.9, 3.8, 3-bookworm, 3.13-bookworm, 3.12-bookworm, 3.11-bookworm, 3.10-bookworm, 3.9-bookworm, 3.8-bookworm, 3-bullseye, 3.13-bullseye, 3.12-bullseye, 3.11-bullseye, 3.10-bullseye, 3.9-bullseye, 3.8-bullseye, 3-buster, 3.12-buster, 3.11-buster, 3.10-buster, 3.9-buster, 3.8-buster
 ARG VARIANT=3-bookworm
 FROM python:${VARIANT}
 

--- a/src/python/README.md
+++ b/src/python/README.md
@@ -9,7 +9,7 @@
 | *Categories* | Core, Languages |
 | *Image type* | Dockerfile |
 | *Published image* | mcr.microsoft.com/devcontainers/python |
-| *Available image variants* | 3 / 3-bookworm, 3.8 / 3.8-bookworm, 3.9 / 3.9-bookworm, 3.10 / 3.10-bookworm, 3.11-bookworm / 3.11, 3.12-bookworm / 3.12, 3-bullseye, 3.8-bullseye, 3.9-bullseye, 3.10-bullseye, 3.11-bullseye, 12-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/python/tags/list)) |
+| *Available image variants* | 3 / 3-bookworm, 3.8 / 3.8-bookworm, 3.9 / 3.9-bookworm, 3.10 / 3.10-bookworm, 3.11-bookworm / 3.11, 3.12-bookworm / 3.12, 3.13-bookworm / 3.13, 3-bullseye, 3.8-bullseye, 3.9-bullseye, 3.10-bullseye, 3.11-bullseye, 3.12-bullseye, 3.13-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/python/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bookworm`, and `bullseye` variants |
 | *Container Host OS Support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -29,6 +29,7 @@ You can directly reference [pre-built](https://containers.dev/implementors/refer
 - `mcr.microsoft.com/devcontainers/python:3.10` (or `3.10-bookworm`, `3.10-bullseye` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/python:3.11` (or `3.11-bookworm`, `3.11-bullseye` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/python:3.12` (or `3.12-bookworm`, `3.12-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/python:3.13` (or `3.13-bookworm`, `3.13-bullseye` to pin to an OS version)
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 

--- a/src/python/manifest.json
+++ b/src/python/manifest.json
@@ -1,11 +1,13 @@
 {
 	"version": "1.1.16",
 	"variants": [
+		"3.13-bookworm",
 		"3.12-bookworm",
 		"3.11-bookworm",
 		"3.10-bookworm",
 		"3.9-bookworm",
 		"3.8-bookworm",
+		"3.13-bullseye",
 		"3.12-bullseye",
 		"3.11-bullseye",
 		"3.10-bullseye",
@@ -13,9 +15,13 @@
 		"3.8-bullseye"
 	],
 	"build": {
-		"latest": "3.12-bookworm",
+		"latest": "3.13-bookworm",
 		"rootDistro": "debian",
 		"architectures": {
+			"3.13-bookworm": [
+				"linux/amd64",
+				"linux/arm64"
+			],
 			"3.12-bookworm": [
 				"linux/amd64",
 				"linux/arm64"
@@ -33,6 +39,10 @@
 				"linux/arm64"
 			],
 			"3.8-bookworm": [
+				"linux/amd64",
+				"linux/arm64"
+			],
+			"3.13-bullseye": [
 				"linux/amd64",
 				"linux/arm64"
 			],
@@ -61,11 +71,14 @@
 			"python:${VERSION}-${VARIANT}"
 		],
 		"variantTags": {
-			"3.12-bookworm": [
-				"python:${VERSION}-3.12",
+			"3.13-bookworm": [
+				"python:${VERSION}-3.13",
 				"python:${VERSION}-3",
 				"python:${VERSION}-3-bookworm",
 				"python:${VERSION}-bookworm"
+			],
+			"3.12-bookworm": [
+				"python:${VERSION}-3.12"
 			],
 			"3.11-bookworm": [
 				"python:${VERSION}-3.11"
@@ -79,7 +92,7 @@
 			"3.8-bookworm": [
 				"python:${VERSION}-3.8"
 			],
-			"3.12-bullseye": [
+			"3.13-bullseye": [
 				"python:${VERSION}-3-bullseye",
 				"python:${VERSION}-bullseye"
 			]


### PR DESCRIPTION
**Devcontainer name**
* Python

**Description**
* This pr adds `3.13` latest python version to the supported versions list in python image

**_Changelog_**
* Changes are there in `manifest.json`, `Dockerfile` and `readme.md` file to add support to latest `3.13` python version 

**Checklist**
- [x] Checked that applied changed work as expected