### PR TITLE
Fix the use of deprecated set-output command

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -31,8 +31,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Get tag name
-      id: get_tag_name  
-      run: echo "::set-output name=tag::$(echo "${{ github.ref }}" | grep -oP 'refs/tags/\K(.+)')"
+      run: echo "TAG=$(echo "${{ github.ref }}" | grep -oP 'refs/tags/\K(.+)')" >> $GITHUB_ENV
 
     - name: Build and push
       id: build_and_push
@@ -57,7 +56,7 @@ jobs:
         npm install -g @devcontainers/cli
         build/vscdc push  --page ${{ matrix.page }} \
                           --pageTotal ${{ matrix.page-total }} \
-                          --release ${{ steps.get_tag_name.outputs.tag }} \
+                          --release ${{ env.TAG }} \
                           --github-repo ${{ github.repository }} \
                           --registry "$REGISTRY" \
                           --registry-path "$REGISTRY_BASE_PATH" \


### PR DESCRIPTION
Related issue: https://github.com/devcontainers/images/issues/881

Replaced the use of the deprecated set-output command with using GitHub Environment variables.