### PR TITLE
[anaconda] - remove patches when similar or higher versions are available from upstream

### DIFF
--- a/src/anaconda/.devcontainer/apply_security_patches.sh
+++ b/src/anaconda/.devcontainer/apply_security_patches.sh
@@ -1,14 +1,10 @@
 #!/bin/bash
 
 # vulnerabilities:
-# streamlit - [GHSA-rxff-vr5r-8cj5]
-# notebook, jupyterlab - [GHSA-9q39-rmj3-p4r2]
-# cryptography, pyopenssl - [GHSA-h4gh-qq45-vh27]
-# nltk - [GHSA-cgvx-9447-vcch]
+# werkzeug - [GHSA-f9vj-2wh5-fj8j]
 
-vulnerable_packages=( "pydantic=2.5.3" "joblib=1.3.1" "mistune=3.0.1" "werkzeug=3.0.3" "transformers=4.36.0" "pillow=10.3.0" "aiohttp=3.10.2" "pyopenssl=24.2.1" \
-          "cryptography=43.0.1" "gitpython=3.1.41"  "jupyter-lsp=2.2.2" "idna=3.7" "jinja2=3.1.4" "scrapy=2.11.2" "black=24.4.2" "requests=2.32.2" \
-          "jupyter_server=2.14.1" "tornado=6.4.1" "tqdm=4.66.4" "urllib3=2.2.2" "scikit-learn=1.5.0" "zipp=3.19.1" "streamlit=1.37.0" "notebook=7.2.2" "nltk=3.9" "imagecodecs=2023.9.18" "setuptools=70.0.0" )
+vulnerable_packages=( "mistune=3.0.1" "werkzeug=3.0.6" "transformers=4.36.0" "cryptography=43.0.1" "jupyter-lsp=2.2.2" "scrapy=2.11.2" \
+                      "zipp=3.19.1" "imagecodecs=2023.9.18" )
 
 # Define the number of rows (based on the length of vulnerable_packages)
 rows=${#vulnerable_packages[@]}


### PR DESCRIPTION
**Dev Container name**
* Anaconda

**Description**
* PR provides removal of stale patches (similar or greater versions of such packages are available from upstream i.e. `continuumio/anaconda3`)

**_changelog_**
* Following patches were removed from `apply_security_patches.sh` file within `anaconda`
    - `Pydantic` - `2.5.3` now comes at `2.8.2` from upstream
    - `Joblib` - `1.3.1` now comes at `1.4.2` from upstream
    - `pillow-10.3.0` now comes at `10.4.0` from upstream
    - `aiohttp-3.10.2` now comes with `3.10.5` from upstream
    - `Pyopenssl - 24.2.1` comes with same version from upstream
    - `Gitpython - 3.1.41` comes with `3.1.43` from upstream
    - `Idna -3.7` comes with similar version from upstream
    - `Jinja2-3.1.4` comes with same version from upstream
    - `black-24.4.2` now comes with `24.8.0` from upstream
    - `requests-2.32.2` now comes with `2.32.3` from upstream 
    - `jupyter_server-2.14.1` comes with same version from upstream 
    - `tornado-6.4.1` now comes with same version from upstream
    - "`tqdm-4.66.4` now comes with `4.66.5` version from upstream 
    - `urllib3=2.2.2` comes with `2.2.3` from upstream
    - `scikit-learn-1.5.0` comes with `1.5.1` from upstream 
    - `streamlit1.37.0` comes with `1.37.1` from upstream 
    - `notebook7.2.2` comes with same version from upstream
    - `nltk-3.9` comes with `3.9.1` from upstream
    - `Setuptools-70.0.0` comes with `75.1.0` from upstream already

**checklist**
- [x] checked that applied changes work as expected