### PR TITLE
[Miniconda] - remove stale patches (when higher version is available from upstream)

### DIFF
--- a/src/miniconda/.devcontainer/apply_security_patches.sh
+++ b/src/miniconda/.devcontainer/apply_security_patches.sh
@@ -5,7 +5,7 @@
 
 # define array of packages for pinning to the patched versions
 # vulnerable_packages=( "package1=version1" "package2=version2" "package3=version3" )
-vulnerable_packages=( "tqdm=4.66.4" "requests=2.32.0" "urllib3=2.2.2" "certifi=2024.7.4" "cryptography=43.0.1" )
+vulnerable_packages=( "cryptography=43.0.1" )
 
 # Define the number of rows (based on the length of vulnerable_packages)
 rows=${#vulnerable_packages[@]}


### PR DESCRIPTION
**Dev Container Name**
* Miniconda

**Description**
* to remove stale patch applications since higher or equal versions are available from upstream (continuumio/miniconda3)

**_changelog_**
* Removed the following patch applications in `apply_security_patches.sh` file :
    - `tqdm - 4.66.4` now comes with `v4.66.5` from upstream 
    - `requests - 2.32.0` now comes with `v2.32.3` from upstream
    - `urllib3 - 2.2.2` now comes with `v2.2.3` from upstream
    - `certifi - 2024.7.4` now comes with `v2024.8.30` from upstream

**checklist**
- [x] checked that applied changes work as expected