### PR TITLE
[Universal Image] - Update pinned tooling's versions - node & python

### DIFF
--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -52,7 +52,7 @@
             "version": "latest"
         },
         "ghcr.io/devcontainers/features/git:1": {
-            "version": "latest",
+            "version": "2.47.0",
             "ppa": "false"
         },
         "ghcr.io/devcontainers/features/git-lfs:1": {

--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -18,13 +18,13 @@
             "version": "latest"
         },
         "ghcr.io/devcontainers/features/node:1": {
-            "version": "20",
-            "additionalVersions": "18"
+            "version": "22",
+            "additionalVersions": "20"
         },
         "./local-features/nvs": "latest",
         "ghcr.io/devcontainers/features/python:1": {
-            "version": "3.12.1",
-            "additionalVersions": "3.11.9",
+            "version": "3.13.0",
+            "additionalVersions": "3.12.1",
             "installJupyterlab": "true",
             "configureJupyterlabAllowOrigin": "*",
             "useOryxIfAvailable": "false"

--- a/src/universal/.devcontainer/local-features/setup-user/install.sh
+++ b/src/universal/.devcontainer/local-features/setup-user/install.sh
@@ -92,8 +92,8 @@ find "${OPT_DIR}" -type d | xargs -n 1 chmod g+s
 echo "Defaults secure_path=\"${DOTNET_PATH}:${NODE_PATH}/bin:${PHP_PATH}/bin:${PYTHON_PATH}/bin:${JAVA_PATH}/bin:${RUBY_PATH}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:/usr/local/share:/home/${USERNAME}/.local/bin:${PATH}\"" >> /etc/sudoers.d/$USERNAME
 
 # Temporary: Due to GHSA-c2qf-rxjj-qqgw
-bash -c ". /usr/local/share/nvm/nvm.sh && nvm use 18"
-bash -c "npm -g install -g npm@9.8.1"
+bash -c ". /usr/local/share/nvm/nvm.sh && nvm use 20"
+bash -c "npm -g install -g npm@10.9.0"
 bash -c ". /usr/local/share/nvm/nvm.sh && nvm use stable"
 
 echo "Done!"

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -94,8 +94,8 @@ count=$(ls /usr/local/share/nvm/versions/node | wc -l)
 expectedCount=2
 checkVersionCount "two versions of node are present" $count $expectedCount
 echo $(echo "node versions" && ls -a /usr/local/share/nvm/versions/node)
-checkBundledNpmVersion "default" "9.8.0"
-checkBundledNpmVersion "18" "9.8.1"
+checkBundledNpmVersion "default" "10.9.0"
+checkBundledNpmVersion "20" "10.8.2"
 
 # PHP
 check "php" php --version


### PR DESCRIPTION
**Devcontainer Name**
* Universal Image

**Description**
* With the release of Node JS v22 and Python v3.13.0 as stable releases, it can be updated as default configuration of Universal image

**_changelog_**
* updated node.js default version to v22 and additional version to v20
* updated python default version to v3.13.0 and additional version to v3.12.1

**checklist**
- [x] checked that applied changes work as expected