### PR TITLE
[anaconda] - imagecodecs - revert back the version to 2023.1.23

### DIFF
--- a/src/anaconda/.devcontainer/apply_security_patches.sh
+++ b/src/anaconda/.devcontainer/apply_security_patches.sh
@@ -4,7 +4,7 @@
 # werkzeug - [GHSA-f9vj-2wh5-fj8j]
 
 vulnerable_packages=( "mistune=3.0.1" "werkzeug=3.0.6" "transformers=4.36.0" "cryptography=43.0.1" "jupyter-lsp=2.2.2" "scrapy=2.11.2" \
-                      "zipp=3.19.1" "imagecodecs=2023.1.23" )
+                      "zipp=3.19.1" )
 
 # Define the number of rows (based on the length of vulnerable_packages)
 rows=${#vulnerable_packages[@]}

--- a/src/anaconda/.devcontainer/apply_security_patches.sh
+++ b/src/anaconda/.devcontainer/apply_security_patches.sh
@@ -4,7 +4,7 @@
 # werkzeug - [GHSA-f9vj-2wh5-fj8j]
 
 vulnerable_packages=( "mistune=3.0.1" "werkzeug=3.0.6" "transformers=4.36.0" "cryptography=43.0.1" "jupyter-lsp=2.2.2" "scrapy=2.11.2" \
-                      "zipp=3.19.1" "imagecodecs=2023.9.18" )
+                      "zipp=3.19.1" "imagecodecs=2023.1.23" )
 
 # Define the number of rows (based on the length of vulnerable_packages)
 rows=${#vulnerable_packages[@]}

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -56,7 +56,6 @@ checkPythonPackageVersion "scrapy" "2.11.2"
 checkPythonPackageVersion "requests" "2.32.2"
 checkPythonPackageVersion "scikit-learn" "1.5.0"
 checkPythonPackageVersion "zipp" "3.19.1"
-checkPythonPackageVersion "imagecodecs" "2023.1.23"
 
 checkCondaPackageVersion "pyopenssl" "24.2.1"
 checkCondaPackageVersion "requests" "2.32.2"

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -56,7 +56,7 @@ checkPythonPackageVersion "scrapy" "2.11.2"
 checkPythonPackageVersion "requests" "2.32.2"
 checkPythonPackageVersion "scikit-learn" "1.5.0"
 checkPythonPackageVersion "zipp" "3.19.1"
-checkPythonPackageVersion "imagecodecs" "2023.9.18"
+checkPythonPackageVersion "imagecodecs" "2023.1.23"
 
 checkCondaPackageVersion "pyopenssl" "24.2.1"
 checkCondaPackageVersion "requests" "2.32.2"


### PR DESCRIPTION
**Devcontainer Image**

- Anaconda

**Description**

- Updating back the imagecodecs version to 2023.1.23 as that is still the latest stable version available for the moment.

**Changelog**

- Removed the imagecodecs version in the array list in apply_security_patches.sh file.
- Changed the test.sh which checks inside the devcontainer for the fix (whether been updated or not to specified versions ) to remove the imagecodecs version.
- By default, the imagecodecs version will be installed with the base package as 2023.1.23  

**Checklist**

- Checked that applied changes work as expected