### PR TITLE
Jekyll: Pins "jekyll-sass-converter" to unblock build failures 

### DIFF
--- a/src/jekyll/.devcontainer/Dockerfile
+++ b/src/jekyll/.devcontainer/Dockerfile
@@ -16,6 +16,7 @@ RUN gem update --system
 
 # https://github.com/ntkme/sass-embedded-host-ruby/issues/130
 RUN gem install sass-embedded -v 1.62.1
+RUN gem install jekyll-sass-converter -v 3.0.0
 RUN gem install bundler jekyll github-pages
 
 RUN chown -R "vscode:rvm" "/usr/local/rvm/" \


### PR DESCRIPTION
Fixes jekyll build failures: https://github.com/devcontainers/images/actions/runs/13181846294
Ref: https://github.com/devcontainers/images/issues/1297

