### PR TITLE
Release issue in dev build, version history checking failing for miniconda image in the Build and Push dev workflow

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,10 @@
 {
-    "image": "mcr.microsoft.com/devcontainers/javascript-node:0-18",
+    "image": "mcr.microsoft.com/devcontainers/base:dev-ubuntu-24.04",
     "features": {
+        "ghcr.io/devcontainers/features/node:1": {
+            "version": "20",
+            "additionalVersions": "18"
+        },        
         "ghcr.io/devcontainers/features/docker-in-docker:2": {},
         "ghcr.io/devcontainers/features/azure-cli:1": {}
     },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,6 @@
 {
-    "image": "mcr.microsoft.com/devcontainers/base:dev-ubuntu-24.04",
+    "image": "mcr.microsoft.com/devcontainers/javascript-node:0-18",
     "features": {
-        "ghcr.io/devcontainers/features/node:1": {
-            "version": "20",
-            "additionalVersions": "18"
-        },        
         "ghcr.io/devcontainers/features/docker-in-docker:2": {},
         "ghcr.io/devcontainers/features/azure-cli:1": {}
     },

--- a/build/src/utils/image-content-extractor.js
+++ b/build/src/utils/image-content-extractor.js
@@ -284,7 +284,7 @@ function getUserName(imageId) {
 }
 
 async function getPipVersionLookup(imageTagOrContainerName, imageId) {
-    const packageVersionListOutput = await getCommandOutputFromContainer(imageTagOrContainerName, 'pip list --disable-pip-version-check --no-python-version-warning --format json', false, getUserName(imageId));
+    const packageVersionListOutput = await getCommandOutputFromContainer(imageTagOrContainerName, 'pip list --disable-pip-version-check --format json', false, getUserName(imageId));
 
     const packageVersionList = JSON.parse(packageVersionListOutput);
 


### PR DESCRIPTION
**Ref#** https://github.com/devcontainers/internal/issues/254 , [pypa/pip#13154](https://github.com/pypa/pip/issues/13154)

**Description:** Version history checking failing for miniconda image in the Build and Push dev workflow

**Root Cause:** This is failing in version history for miniconda image because its running `pip list` with `--no-python-version-warning` & `--format json` options which would get the list of installed python packages in json format but its getting generated with a warning message as `--no-python-version-warning` option will be deprecated in pip 25.1 version & due to the warning message the output of the `pip list` didn't get generated as a well-formed json & hence the json parsing error appeared. PFB the sample payload which is getting generated.

```
base) root ➜ / $ set -e && echo ~~~BEGIN~~~ && pip list --disable-pip-version-check --no-python-version-warning --format json && echo && echo ~~~END~~~
~~~BEGIN~~~
DEPRECATION: --no-python-version-warning is deprecated. pip 25.1 will enforce this behaviour change. A possible replacement is to remove the flag as it's a no-op. Discussion can be found at https://github.com/pypa/pip/issues/13154
[{"name": "anaconda-anon-usage", "version": "0.5.0"}, {"name": "annotated-types", "version": "0.6.0"}, {"name": "archspec", "version": "0.2.3"}, {"name": "boltons", "version": "24.1.0"}, {"name": "Brotli", "version": "1.0.9"}, {"name": "certifi", "version": "2025.1.31"}, {"name": "cffi", "version": "1.17.1"}, {"name": "charset-normalizer", "version": "3.3.2"}, {"name": "conda", "version": "25.1.1"}, {"name": "conda-anaconda-telemetry", "version": "0.1.2"}, {"name": "conda-anaconda-tos", "version": "0.1.2"}, {"name": "conda-content-trust", "version": "0.2.0"}, {"name": "conda-libmamba-solver", "version": "25.1.1"}, {"name": "conda-package-handling", "version": "2.4.0"}, {"name": "conda_package_streaming", "version": "0.11.0"}, {"name": "cryptography", "version": "43.0.3"}, {"name": "distro", "version": "1.9.0"}, {"name": "frozendict", "version": "2.4.2"}, {"name": "idna", "version": "3.7"}, {"name": "jsonpatch", "version": "1.33"}, {"name": "jsonpointer", "version": "2.1"}, {"name": "libmambapy", "version": "2.0.5"}, {"name": "markdown-it-py", "version": "2.2.0"}, {"name": "mdurl", "version": "0.1.0"}, {"name": "menuinst", "version": "2.2.0"}, {"name": "packaging", "version": "24.2"}, {"name": "pip", "version": "25.0"}, {"name": "platformdirs", "version": "3.10.0"}, {"name": "pluggy", "version": "1.5.0"}, {"name": "pycosat", "version": "0.6.6"}, {"name": "pycparser", "version": "2.21"}, {"name": "pydantic", "version": "2.10.3"}, {"name": "pydantic_core", "version": "2.27.1"}, {"name": "Pygments", "version": "2.15.1"}, {"name": "PySocks", "version": "1.7.1"}, {"name": "requests", "version": "2.32.3"}, {"name": "rich", "version": "13.9.4"}, {"name": "ruamel.yaml", "version": "0.18.6"}, {"name": "ruamel.yaml.clib", "version": "0.2.8"}, {"name": "setuptools", "version": "75.8.0"}, {"name": "tqdm", "version": "4.67.1"}, {"name": "truststore", "version": "0.10.0"}, {"name": "typing_extensions", "version": "4.12.2"}, {"name": "urllib3", "version": "2.3.0"}, {"name": "wheel", "version": "0.45.1"}, {"name": "zstandard", "version": "0.23.0"}]

~~~END~~~
``` 

**Changelog:** Changes done in ./build/src/utils/image-content-extractor.js file to remove `--no-python-version-warning` option from the pip list command in `getPipVersionLookup` function as this option is a no-op in Python 3 versions.

**Checklist:**

- Checked that applied changes work as expected. 
- There is no existing test suite available for this build node app /build/vscdc unlike cli repo. 
- I tested this in codespace by launching `vscdc info` directly from launch.json for all images variants in the images repository. 
- Adding the test captures from debug console below in comments for miniconda, anaconda, python & universal images where python package check is applicable.