### PR TITLE
 [anaconda] - Fix to stick to cryptography version 43.0.3.

### DIFF
--- a/src/anaconda/.devcontainer/apply_security_patches.sh
+++ b/src/anaconda/.devcontainer/apply_security_patches.sh
@@ -3,7 +3,7 @@
 # vulnerabilities:
 # werkzeug - [GHSA-f9vj-2wh5-fj8j]
 
-vulnerable_packages=( "mistune=3.0.1" "transformers=4.36.0" "cryptography=43.0.1" "jupyter-lsp=2.2.2" "scrapy=2.11.2" \ 
+vulnerable_packages=( "mistune=3.0.1" "transformers=4.36.0" "cryptography=43.0.3" "jupyter-lsp=2.2.2" "scrapy=2.11.2" \ 
                       "zipp=3.19.1" "tornado=6.4.2")
 
 # Define the number of rows (based on the length of vulnerable_packages)
@@ -45,12 +45,12 @@ for ((i=0; i<rows; i++)); do
             CONDA_VERSION="0"
         fi
         GREATER_VERSION_B=$((echo ${REQUIRED_VERSION}; echo ${CONDA_VERSION}) | sort -V | tail -1)
-        if [[ $CONDA_VERSION == $GREATER_VERSION_B ]]; then
+        if [[ $CONDA_VERSION == $GREATER_VERSION_B && ${packages_array[$i,0]} != "cryptography" ]]; then        
             echo -e "Found Version v${CONDA_VERSION} in the Conda channel which is greater than or equal to the required version: v${REQUIRED_VERSION}. \n";
             echo "Installing ${packages_array[$i,0]} from source from conda channel for v${REQUIRED_VERSION}..."
-            conda install "${packages_array[$i,0]}==${CONDA_VERSION}"
-        elif [[ $REQUIRED_VERSION == $GREATER_VERSION_B ]]; then 
-            echo -e "Required version: v${REQUIRED_VERSION} is greater than the version found in the Conda channel v${CONDA_VERSION}. \n";
+            conda install "${packages_array[$i,0]}==${CONDA_VERSION}"        
+        elif [[ $REQUIRED_VERSION == $GREATER_VERSION_B || ${packages_array[$i,0]} == "cryptography" ]]; then 
+            echo -e "Required version: v${REQUIRED_VERSION} is greater than the version found in the Conda channel v${CONDA_VERSION} or its cryptography package. \n";
             echo "Installing ${packages_array[$i,0]} from source from pip package manager for v${REQUIRED_VERSION}..."
             python3 -m pip install --upgrade --no-cache-dir "${packages_array[$i,0]}==${REQUIRED_VERSION}"
         fi


### PR DESCRIPTION
**Ref#** https://github.com/devcontainers/internal/issues/253 

**Description:** In anaconda image cryptography tool has a new release 44.0.1 which is not getting installed due to dependency of pyopenssl (v24.2.1) tool which is expecting cryptography package version to be less than 44.
```
28.27 + conda install cryptography==44.0.1
29.67 Channels:
29.67  - defaults
29.67 Platform: linux-64
29.67 Collecting package metadata (repodata.json): ...working... done
30.08 Solving environment: ...working... warning  libmamba Added empty dependency for problem type SOLVER_RULE_UPDATE
33.88 failed
33.89 
33.89 LibMambaUnsatisfiableError: Encountered problems while solving:
33.89   - package pyopenssl-24.2.1-py312h06a4308_0 requires cryptography >=41.0.5,<44, but none of the providers can be installed
```

**Root Cause:** As the latest cryptography version 44.0.1 is failing to install, the crytopgraphy version is defaulted to 43.0.0 in the anaconda image which is less than the minimum expected version 43.0.1.

**Changelog:** Change done in ./src/anaconda/.devcontainer/apply_security_patches.sh file to change the cryptography required version to 43.0.3 which is currently used version in the production anaconda image & bypassing the logic for cryptography tool which checks if for a tool the required version is lower than the version published in Conda channel, then install the latest version from Conda channel.   

**Checklist:**

- Checked that applied changes work as expected.