### PR TITLE
[GO]- EOL v1.22 changes

### DIFF
--- a/src/go/README.md
+++ b/src/go/README.md
@@ -10,7 +10,7 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/go |
-| *Available image variants* | 1 / 1-bookworm, 1.24 / 1.24-bookworm, 1.23 / 1.23-bookworm, 1.22 / 1.22-bookworm, 1-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/go/tags/list)) |
+| *Available image variants* | 1 / 1-bookworm, 1.24 / 1.24-bookworm, 1.23 / 1.23-bookworm, 1-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/go/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bookworm`, and `bullseye` variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -26,7 +26,6 @@ You can directly reference pre-built versions of `Dockerfile` by using the `imag
 - `mcr.microsoft.com/devcontainers/go:1` (or `1-bookworm`, `1-bullseye` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/go:1.24` (or `1.24-bookworm`, `1.24-bullseye` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/go:1.23` (or `1.23-bookworm`, `1.23-bullseye` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/go:1.22` (or `1.22-bookworm`, `1.22-bullseye` to pin to an OS version)
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 

--- a/src/go/README.md
+++ b/src/go/README.md
@@ -10,7 +10,7 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/go |
-| *Available image variants* | 1 / 1-bookworm, 1.24 / 1.24-bookworm, 1.23 / 1.23-bookworm, 1.22 / 1.22-bookworm, 1-bullseye, 1.22-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/go/tags/list)) |
+| *Available image variants* | 1 / 1-bookworm, 1.24 / 1.24-bookworm, 1.23 / 1.23-bookworm, 1.22 / 1.22-bookworm, 1-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/go/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bookworm`, and `bullseye` variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |

--- a/src/go/manifest.json
+++ b/src/go/manifest.json
@@ -5,8 +5,7 @@
     "1.23-bookworm",
     "1.22-bookworm",
     "1.24-bullseye",
-    "1.23-bullseye",
-    "1.22-bullseye"
+    "1.23-bullseye"
   ],
   "build": {
     "latest": "1.24-bookworm",

--- a/src/go/manifest.json
+++ b/src/go/manifest.json
@@ -3,7 +3,6 @@
   "variants": [
     "1.24-bookworm",
     "1.23-bookworm",
-    "1.22-bookworm",
     "1.24-bullseye",
     "1.23-bullseye"
   ],
@@ -22,19 +21,11 @@
         "linux/amd64",
         "linux/arm64"
       ],
-      "1.22-bookworm": [
-        "linux/amd64",
-        "linux/arm64"
-      ],
       "1.24-bullseye": [
         "linux/amd64",
         "linux/arm64"
       ],
       "1.23-bullseye": [
-        "linux/amd64",
-        "linux/arm64"
-      ],
-      "1.22-bullseye": [
         "linux/amd64",
         "linux/arm64"
       ]
@@ -51,9 +42,6 @@
         "go:${VERSION}-1",
         "go:${VERSION}-1-bookworm",
         "go:${VERSION}-bookworm"
-      ],
-      "1.22-bookworm": [
-        "go:${VERSION}-1.22"
       ],
       "1.24-bullseye": [
         "go:${VERSION}-1-bullseye",


### PR DESCRIPTION
Devcontainer Image

Go

Description of changes

changes corresponding to Go v1.22 EOL

changelog

Amended files to reflect Go v1.22 EOL
Checklist

 Checked that applied changes work as expected