### PR TITLE
[cpp] - Update in readme file for additonal changes needed to use vcpkg in manifest mode

### DIFF
--- a/src/cpp/.devcontainer/Dockerfile
+++ b/src/cpp/.devcontainer/Dockerfile
@@ -5,6 +5,9 @@ USER root
 # Install needed packages. Use a separate RUN statement to add your own dependencies.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install build-essential cmake cppcheck valgrind clang lldb llvm gdb \
+    # [Optional] Additional packages required for using vcpkg package manager in manifest mode.
+    # [Optional] Please uncommment if the below line in needed.
+    # && apt-get -y install autoconf automake libtool m4 autoconf-archive \
     && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # Setup ENV vars for vcpkg

--- a/src/cpp/README.md
+++ b/src/cpp/README.md
@@ -59,7 +59,14 @@ To update the available library packages, pull the latest from the git repositor
 cd "${VCPKG_ROOT}"
 git pull --ff-only
 ```
-
+Please install additonal system packages `autoconf automake libtool m4 autoconf-archive` to use vcpkg in manifest
+mode. It can be added in the Dockerfile as following:
+```
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install autoconf automake libtool m4 autoconf-archive \
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+```
+If building the image from source directly please uncomment respective `# && apt-get -y install autoconf automake libtool m4 autoconf-archive \` line in Dockerfile.
 > Note: Please review the [Vcpkg license details](https://github.com/microsoft/vcpkg#license) to better understand its own license and additional license information pertaining to library packages and supported ports.
 
 ## License


### PR DESCRIPTION
**Ref#** [Issue](https://github.com/devcontainers/images/issues/1133)

**Description:** Additional system packages needed to use vcpkg package manager in manifest mode as found while testing & as per feedback from user. Documenting the same as part of this PR.

**Changelog:** Change done in readme file describing the list of packages required & added them as commented lines in Dockefile which can be helpful if building from source directly. 

**Checklist:**

- Checked that applied changes work as expected.