### PR TITLE
[miniconda] - cryptography - GHSA-79v4-65xg-pq4g

### DIFF
--- a/src/miniconda/.devcontainer/apply_security_patches.sh
+++ b/src/miniconda/.devcontainer/apply_security_patches.sh
@@ -5,7 +5,7 @@
 
 # define array of packages for pinning to the patched versions
 # vulnerable_packages=( "package1=version1" "package2=version2" "package3=version3" )
-vulnerable_packages=()
+vulnerable_packages=( "cryptography=44.0.1" )
 
 # Define the number of rows (based on the length of vulnerable_packages)
 rows=${#vulnerable_packages[@]}

--- a/src/miniconda/manifest.json
+++ b/src/miniconda/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "1.1.2",
+	"version": "1.1.3",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/src/miniconda/test-project/test.sh
+++ b/src/miniconda/test-project/test.sh
@@ -18,12 +18,11 @@ check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcont
 
 check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
-checkPythonPackageVersion "cryptography" "43.0.1"
 checkPythonPackageVersion "setuptools" "65.5.1"
 checkPythonPackageVersion "wheel" "0.38.1"
 checkPythonPackageVersion "urllib3" "2.2.2"
 
-checkCondaPackageVersion "cryptography" "43.0.1"
+checkCondaPackageVersion "cryptography" "44.0.1"
 checkCondaPackageVersion "setuptools" "65.5.1"
 checkCondaPackageVersion "wheel" "0.38.1"
 checkCondaPackageVersion "requests" "2.32.0"

--- a/src/miniconda/test-project/test.sh
+++ b/src/miniconda/test-project/test.sh
@@ -18,6 +18,7 @@ check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcont
 
 check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
+checkPythonPackageVersion "cryptography" "44.0.1"
 checkPythonPackageVersion "setuptools" "65.5.1"
 checkPythonPackageVersion "wheel" "0.38.1"
 checkPythonPackageVersion "urllib3" "2.2.2"


### PR DESCRIPTION
**Dev container name:**

- Miniconda

**Description:**

This PR patches the following vulnerability:

- [GHSA-79v4-65xg-pq4g](https://github.com/advisories/GHSA-79v4-65xg-pq4g) - related to the `cryptography` package;

This vulnerability comes from the coninuumio/miniconda3 image used upstream for the Miniconda devcontainer.

**Changelog:**

- Change in apply_security_patches.sh to pin cryptography version to 44.0.1
- Change in test.sh to update the expected version to 44.0.1

**Checklist:**

- Checked that applied changes work as expected]
