### PR TITLE
[Ruby]- EOL v3.1 changes

### DIFF
--- a/src/ruby/.devcontainer/Dockerfile
+++ b/src/ruby/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.4, 3.3, 3.2, 3.1, 3-bookworm, 3.4-bookworm, 3.3-bookworm, 3.2-bookworm, 3.1-bookworm, 3-bullseye, 3.4-bullseye, 3.3-bullseye, 3.2-bullseye, 3.1-bullseye, 3-buster, 3.2-buster 3.1-buster
+# [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.4, 3.3, 3.2, 3-bookworm, 3.4-bookworm, 3.3-bookworm, 3.2-bookworm, 3-bullseye, 3.4-bullseye, 3.3-bullseye, 3.2-bullseye, 3-buster, 3.2-buster
 ARG VARIANT=3-bookworm
 FROM ruby:${VARIANT}
 

--- a/src/ruby/README.md
+++ b/src/ruby/README.md
@@ -32,8 +32,8 @@ Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/devcontainers/ruby:1-3`     (or `1-3-bookworm`, `1-3-bullseye` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/ruby:1.3-3`   (or `1.0-3-bookworm`, `1.0-3-bullseye` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/ruby:1.3.0-3` (or `1.0.0-3-bookworm`, `1.0.0-3-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/ruby:1.3-3`   (or `1.3-3-bookworm`, `1.3-3-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/ruby:1.3.0-3` (or `1.3.0-3-bookworm`, `1.3.0-3-bullseye` to pin to an OS version)
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `1-3.2`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 

--- a/src/ruby/README.md
+++ b/src/ruby/README.md
@@ -9,7 +9,7 @@
 | *Categories* | Core, Languages |
 | *Image type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/ruby |
-| *Available image variants* | 3 / 3-bookworm, 3.4 / 3.4-bookworm, 3.3 / 3.3-bookworm, 3.2 / 3.2-bookworm, 3.1 / 3.1-bookworm, 3-bullseye, 3.4-bullseye, 3.3-bullseye, 3.2-bullseye, 3.1-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/ruby/tags/list)) |
+| *Available image variants* | 3 / 3-bookworm, 3.4 / 3.4-bookworm, 3.3 / 3.3-bookworm, 3.2 / 3.2-bookworm, 3-bullseye, 3.4-bullseye, 3.3-bullseye, 3.2-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/ruby/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bookworm` , and `bullseye` variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -26,15 +26,14 @@ You can directly reference pre-built versions of `Dockerfile` by using the `imag
 - `mcr.microsoft.com/devcontainers/ruby:3.4` (or `3.4-bookworm`, `3.4-bullseye` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/ruby:3.3` (or `3.3-bookworm`, `3.3-bullseye` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/ruby:3.2` (or `3.2-bookworm`, `3.2-bullseye` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/ruby:3.1` (or `3.1-bookworm`, `3.1-bullseye` to pin to an OS version)
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/devcontainers/ruby:1-3`     (or `1-3-bookworm`, `1-3-bullseye` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/ruby:1.0-3`   (or `1.0-3-bookworm`, `1.0-3-bullseye` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/ruby:1.0.0-3` (or `1.0.0-3-bookworm`, `1.0.0-3-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/ruby:1.3-3`   (or `1.0-3-bookworm`, `1.0-3-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/ruby:1.3.0-3` (or `1.0.0-3-bookworm`, `1.0.0-3-bullseye` to pin to an OS version)
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `1-3.2`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 

--- a/src/ruby/manifest.json
+++ b/src/ruby/manifest.json
@@ -1,14 +1,12 @@
 {
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"variants": [
 		"3.4-bookworm",		
 		"3.3-bookworm",
 		"3.2-bookworm",
-		"3.1-bookworm",
 		"3.4-bullseye",		
 		"3.3-bullseye",
-		"3.2-bullseye",
-		"3.1-bullseye"
+		"3.2-bullseye"
 	],
 	"build": {
 		"latest": "3.4-bookworm",
@@ -26,10 +24,6 @@
 				"linux/amd64",
 				"linux/arm64"
 			],
-			"3.1-bookworm": [
-				"linux/amd64",
-				"linux/arm64"
-			],
 			"3.4-bullseye": [
 				"linux/amd64",
 				"linux/arm64"
@@ -39,10 +33,6 @@
 				"linux/arm64"
 			],
 			"3.2-bullseye": [
-				"linux/amd64",
-				"linux/arm64"
-			],
-			"3.1-bullseye": [
 				"linux/amd64",
 				"linux/arm64"
 			]
@@ -62,9 +52,6 @@
 			],			
 			"3.2-bookworm": [
 				"ruby:${VERSION}-3.2"
-			],
-			"3.1-bookworm": [
-				"ruby:${VERSION}-3.1"
 			],
 			"3.4-bullseye": [
 				"ruby:${VERSION}-3-bullseye",


### PR DESCRIPTION
**Ref:** #90 

**Devcontainer Image:**

- Ruby

**Description of changes:**

- Changes corresponding to Ruby v3.1 EOL

**Changelog:**

- Change in manifest.json & readme files to remove ruby 3.1 references

**Checklist:**

- Checked that applied changes work as expected