### PR TITLE
Assign `ubuntu` tag to the latest LTS release

### DIFF
--- a/src/base-ubuntu/manifest.json
+++ b/src/base-ubuntu/manifest.json
@@ -27,12 +27,12 @@
 		"variantTags": {
 			"noble": [
 				"base:${VERSION}-ubuntu-24.04",
-				"base:${VERSION}-ubuntu24.04"
+				"base:${VERSION}-ubuntu24.04",
+				"base:${VERSION}-ubuntu"
 			],
 			"jammy": [
 				"base:${VERSION}-ubuntu-22.04",
 				"base:${VERSION}-ubuntu22.04",
-				"base:${VERSION}-ubuntu"
 			],
 			"focal": [
 				"base:${VERSION}-ubuntu-20.04",


### PR DESCRIPTION
The documentation says that that the tag `ubuntu` should target the latest LTS release of ubuntu.

This PR fixes that, currently `ubuntu` is assigned to `22.04` instead of `24.04`