### PR TITLE
[javascript-node, typescript-node] - Node 18 EOL changes.

### DIFF
--- a/src/javascript-node/README.md
+++ b/src/javascript-node/README.md
@@ -9,7 +9,7 @@
 | *Categories* | Core, Languages |
 | *Image type* | Dockerfile |
 | *Published image* | mcr.microsoft.com/devcontainers/javascript-node |
-| *Available image variants* | 22 / 22-bookworm, 20 / 20-bookworm, 18 / 18-bookworm, 20-bullseye, 18-bullseye, ([full list](https://mcr.microsoft.com/v2/devcontainers/javascript-node/tags/list)) |
+| *Available image variants* | 22 / 22-bookworm, 20 / 20-bookworm, 20-bullseye, ([full list](https://mcr.microsoft.com/v2/devcontainers/javascript-node/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bookworm`, and `bullseye` variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -22,7 +22,6 @@ You can directly reference pre-built versions of `Dockerfile` by using the `imag
 - `mcr.microsoft.com/devcontainers/javascript-node` (latest)
 - `mcr.microsoft.com/devcontainers/javascript-node:22` (or `22-bookworm`, `22-bullseye` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/javascript-node:20` (or `20-bookworm`, `20-bullseye` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/javascript-node:18` (or `18-bookworm`, `18-bullseye` to pin to an OS version)
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
@@ -30,7 +29,7 @@ You can decide how often you want updates by referencing a [semantic version](ht
 
 - `mcr.microsoft.com/devcontainers/typescript-node:1-22` (or `1-22-bookworm`, `1-22-bullseye`)
 - `mcr.microsoft.com/devcontainers/typescript-node:1.1-22` (or `1.1-22-bookworm`, `1.1-22-bullseye`)
-- `mcr.microsoft.com/devcontainers/typescript-node:1.1.0-22` (or `1.1.0-22-bookworm`, `1.1.0-22-bullseye`)
+- `mcr.microsoft.com/devcontainers/typescript-node:1.1.12-22` (or `1.1.12-22-bookworm`, `1.1.12-22-bullseye`)
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `1-1.0`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 

--- a/src/javascript-node/manifest.json
+++ b/src/javascript-node/manifest.json
@@ -1,12 +1,10 @@
 {
-	"version": "1.1.11",
+	"version": "1.1.12",
 	"variants": [
 		"22-bookworm",
 		"20-bookworm",
-		"18-bookworm",
 		"22-bullseye",
-		"20-bullseye",
-		"18-bullseye"
+		"20-bullseye"
 	],
 	"build": {
 		"latest": "22-bookworm",
@@ -20,19 +18,11 @@
 				"linux/amd64",
 				"linux/arm64"
 			],
-			"18-bookworm": [
-				"linux/amd64",
-				"linux/arm64"
-			],
 			"22-bullseye": [
 				"linux/amd64",
 				"linux/arm64"
 			],
 			"20-bullseye": [
-				"linux/amd64",
-				"linux/arm64"
-			],
-			"18-bullseye": [
 				"linux/amd64",
 				"linux/arm64"
 			]
@@ -47,9 +37,6 @@
 			],
 			"20-bookworm": [
 				"javascript-node:${VERSION}-20"
-			],
-			"18-bookworm": [
-				"javascript-node:${VERSION}-18"
 			],
 			"22-bullseye": [
 				"javascript-node:${VERSION}-bullseye"

--- a/src/typescript-node/README.md
+++ b/src/typescript-node/README.md
@@ -9,7 +9,7 @@
 | *Categories* | Core, Languages |
 | *Image type* | Dockerfile |
 | *Published image* | mcr.microsoft.com/devcontainers/typescript-node |
-| *Available image variants* | 22 / 22-bookworm, 20 / 20-bookworm, 18 / 18-bookworm, 22-bullseye, 20-bullseye, 18-bullseye, 20-buster, 18-buster ([full list](https://mcr.microsoft.com/v2/devcontainers/typescript-node/tags/list)) |
+| *Available image variants* | 22 / 22-bookworm, 20 / 20-bookworm, 22-bullseye, 20-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/typescript-node/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bookworm`, and `bullseye` variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -21,8 +21,7 @@ You can directly reference pre-built versions of `Dockerfile` by using the `imag
 
 - `mcr.microsoft.com/devcontainers/typescript-node` (latest)
 - `mcr.microsoft.com/devcontainers/typescript-node:22` (or `22-bookworm`, `22-bullseye` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/typescript-node:20` (or `20-bookworm`, `20-bullseye`, `20-buster` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/typescript-node:18` (or `18-bookworm`, `18-bullseye`, `18-buster` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/typescript-node:20` (or `20-bookworm`, `20-bullseye` to pin to an OS version)
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
@@ -30,7 +29,7 @@ You can decide how often you want updates by referencing a [semantic version](ht
 
 - `mcr.microsoft.com/devcontainers/typescript-node:1-22` (or `1-22-bookworm`, `1-22-bullseye`)
 - `mcr.microsoft.com/devcontainers/typescript-node:1.1-22` (or `1.1-22-bookworm`, `1.1-22-bullseye`)
-- `mcr.microsoft.com/devcontainers/typescript-node:1.1.0-22` (or `1.1.0-20-bookworm`, `1.1.0-20-bullseye`)
+- `mcr.microsoft.com/devcontainers/typescript-node:1.1.0-22` (or `1.1.12-20-bookworm`, `1.1.12-20-bullseye`)
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `1-1.20`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 

--- a/src/typescript-node/manifest.json
+++ b/src/typescript-node/manifest.json
@@ -1,12 +1,10 @@
 {
-	"version": "1.1.11",
+	"version": "1.1.12",
 	"variants": [
 		"22-bookworm",
 		"20-bookworm",
-		"18-bookworm",
 		"22-bullseye",
-		"20-bullseye",
-		"18-bullseye"
+		"20-bullseye"
 	],
 	"build": {
 		"latest": "22-bookworm",
@@ -21,19 +19,11 @@
 				"linux/amd64",
 				"linux/arm64"
 			],
-			"18-bookworm": [
-				"linux/amd64",
-				"linux/arm64"
-			],
 			"22-bullseye": [
 				"linux/amd64",
 				"linux/arm64"
 			],
 			"20-bullseye": [
-				"linux/amd64",
-				"linux/arm64"
-			],
-			"18-bullseye": [
 				"linux/amd64",
 				"linux/arm64"
 			]
@@ -48,9 +38,6 @@
 			],
 			"20-bookworm": [
 				"typescript-node:${VERSION}-20"
-			],
-			"18-bookworm": [
-				"typescript-node:${VERSION}-18"
 			],
 			"22-bullseye": [
 				"typescript-node:${VERSION}-bullseye"


### PR DESCRIPTION
**Ref:** https://github.com/devcontainers/images/issues/90

**Devcontainer Image:**

- javascript-node
- typescript-node

**Description of changes:**

- Changes corresponding to Node 18 EOL effective on 30th Apr 2025, see [here](https://endoflife.date/nodejs)

**Changelog:**

- Change in manifest.json & readme files to remove node 18 references for both `javascript-node` and `typescript-node` images.

**Checklist:**

- Checked that applied changes work as expected