### PR TITLE
Dotnet image throws warning about stale workloads

### DIFF
--- a/src/dotnet/.devcontainer/Dockerfile
+++ b/src/dotnet/.devcontainer/Dockerfile
@@ -2,13 +2,15 @@ ARG VARIANT=9.0-bookworm-slim
 FROM mcr.microsoft.com/dotnet/sdk:${VARIANT}
 ENV PATH $PATH:/home/vscode/.dotnet:/home/vscode/.dotnet/tools
 
+RUN chmod -R a+w /usr/share/dotnet
+
 ARG VARIANT
 RUN if [ "${VARIANT#*noble}" != "$VARIANT"  ]; then \
-        if id "ubuntu" &>/dev/null; then \
-            echo "Deleting user 'ubuntu'  for $VARIANT" && userdel -f -r ubuntu || echo "Failed to delete ubuntu user for $VARIANT"; \
-        else \
-            echo "User 'ubuntu' does not exist for $VARIANT"; \ 
-        fi; \
+    if id "ubuntu" &>/dev/null; then \
+    echo "Deleting user 'ubuntu'  for $VARIANT" && userdel -f -r ubuntu || echo "Failed to delete ubuntu user for $VARIANT"; \
+    else \
+    echo "User 'ubuntu' does not exist for $VARIANT"; \ 
+    fi; \
     fi
 
 # clear this environment variable so xml docs from NuGet packages are unpackaged. The default dotnet/sdk image sets it to 'skip'.

--- a/src/dotnet/test-project/aspnetapp.csproj
+++ b/src/dotnet/test-project/aspnetapp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <UserSecretsId>31051026529000467138</UserSecretsId>
   </PropertyGroup>
 

--- a/src/dotnet/test-project/test-utils.sh
+++ b/src/dotnet/test-project/test-utils.sh
@@ -172,3 +172,18 @@ fixTestProjectFolderPrivs() {
         fi
     fi
 }
+
+checkBuild()
+{
+    echo -e "\n🧪 Testing dotnet build"
+    build_output=$(dotnet build 2>&1)
+    # Check if the specific error message is present in the output
+    if echo "$build_output" | grep -q "dotnet workload update"; then
+        echoStderr "❌ dotnet build check failed."
+        FAILED+=("dotnet build")
+        return 1 
+    else
+       echo "✅  Passed!"
+       return 0
+    fi
+}

--- a/src/dotnet/test-project/test.sh
+++ b/src/dotnet/test-project/test.sh
@@ -8,6 +8,7 @@ checkCommon
 
 # Image specific tests
 check "dotnet" dotnet --info
+checkBuild
 check "nuget" dotnet restore
 check "msbuild" dotnet msbuild
 sudo rm -rf obj bin


### PR DESCRIPTION
Fixes : https://github.com/devcontainers/images/issues/1303

**Description**:
Dotnet image throws warning when running dotnet build command first time.
 "An issue was encountered verifying workloads. For more information, run "dotnet workload update".
 Issue is reproducable when user is not a root user.
 
 **Changes**:
 Adding write permission to other users to usr/share/dotnet resolves the issue.
 Created a new test case to validate the fix
 
 