### PR TITLE
[base-ubuntu] - Ubuntu focal EOL for base image

### DIFF
--- a/src/base-ubuntu/README.md
+++ b/src/base-ubuntu/README.md
@@ -9,7 +9,7 @@
 | *Categories* | Core, Other |
 | *Image type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/base:ubuntu |
-| *Available image variants* | ubuntu-24.04 / noble, ubuntu-22.04 / jammy, ubuntu-20.04 / focal ([full list](https://mcr.microsoft.com/v2/devcontainers/base/tags/list)) |
+| *Available image variants* | ubuntu-24.04 / noble, ubuntu-22.04 / jammy ([full list](https://mcr.microsoft.com/v2/devcontainers/base/tags/list)) |
 | *Published image architecture(s)* | x86-64, aarch64/arm64 for `ubuntu-22.04` (`jammy`) and `ubuntu-24.04` (`noble`) variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Ubuntu |
@@ -24,7 +24,6 @@ You can directly reference pre-built versions of `Dockerfile` by using the `imag
 - `mcr.microsoft.com/devcontainers/base:ubuntu` (latest LTS release)
 - `mcr.microsoft.com/devcontainers/base:ubuntu-24.04` (or `noble`)
 - `mcr.microsoft.com/devcontainers/base:ubuntu-22.04` (or `jammy`)
-- `mcr.microsoft.com/devcontainers/base:ubuntu-20.04` (or `focal`)
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 

--- a/src/base-ubuntu/manifest.json
+++ b/src/base-ubuntu/manifest.json
@@ -1,9 +1,8 @@
 {
-	"version": "1.2.6",
+	"version": "1.2.7",
 	"variants": [
 		"noble",
-		"jammy",
-		"focal"
+		"jammy"
 	],
 	"build": {
 		"latest": false,
@@ -16,9 +15,6 @@
 			"jammy": [
 				"linux/amd64",
 				"linux/arm64"
-			],
-			"focal": [
-				"linux/amd64"
 			]
 		},
 		"tags": [
@@ -27,16 +23,12 @@
 		"variantTags": {
 			"noble": [
 				"base:${VERSION}-ubuntu-24.04",
-				"base:${VERSION}-ubuntu24.04"
+				"base:${VERSION}-ubuntu24.04",
+				"base:${VERSION}-ubuntu"
 			],
 			"jammy": [
 				"base:${VERSION}-ubuntu-22.04",
-				"base:${VERSION}-ubuntu22.04",
-				"base:${VERSION}-ubuntu"
-			],
-			"focal": [
-				"base:${VERSION}-ubuntu-20.04",
-				"base:${VERSION}-ubuntu20.04"
+				"base:${VERSION}-ubuntu22.04"
 			]
 		}
 	},


### PR DESCRIPTION
Ref: #90 , [#261](https://github.com/devcontainers/internal/issues/261)

Description: The ubuntu focal is going out of support from May 31, 2025. So removing the ubuntu focal from the base image list.

Changelog: The following changes have been made.
- Removed ubuntu focal from the manifest.json.
- Removed from readme file.

Checklist:
- [x] PR is up-to-date with the main branch
- [x] PR title follows semantic versioning
- [x] PR is linked to an issue
-