### PR TITLE
[cpp] - Ubuntu focal EOL for c++ image

### DIFF
--- a/src/cpp/README.md
+++ b/src/cpp/README.md
@@ -9,7 +9,7 @@
 | *Categories* | Core, Languages |
 | *Image type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/cpp |
-| *Available image variants* | debian-12, debian-11, ubuntu-24.04, ubuntu-22.04, ubuntu-20.04 ([full list](https://mcr.microsoft.com/v2/devcontainers/cpp/tags/list)) |
+| *Available image variants* | debian-12, debian-11, ubuntu-24.04, ubuntu-22.04 ([full list](https://mcr.microsoft.com/v2/devcontainers/cpp/tags/list)) |
 | *Published image architecture(s)* | x86-64, aarch64/arm64 for `debian-12`, `debian-11`, `ubuntu-24.04` and `ubuntu-22.04` variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian, Ubuntu |
@@ -28,7 +28,6 @@ You can directly reference pre-built versions of `Dockerfile` by using the `imag
 - `mcr.microsoft.com/devcontainers/cpp:ubuntu` (latest Ubuntu LTS)
 - `mcr.microsoft.com/devcontainers/cpp:ubuntu-24.04` (or `noble`)
 - `mcr.microsoft.com/devcontainers/cpp:ubuntu-22.04` (or `jammy`)
-- `mcr.microsoft.com/devcontainers/cpp:ubuntu-20.04` (or `focal`)
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 

--- a/src/cpp/manifest.json
+++ b/src/cpp/manifest.json
@@ -1,11 +1,10 @@
 {
-	"version": "1.2.10",
+	"version": "1.2.11",
 	"variants": [
 		"bookworm",
 		"bullseye",
 		"noble",
-		"jammy",
-		"focal"
+		"jammy"
 	],
 	"build": {
 		"latest": "bookworm",
@@ -13,8 +12,7 @@
 			"bookworm": "base-debian",
 			"bullseye": "base-debian",
 			"noble": "base-ubuntu",
-			"jammy": "base-ubuntu",
-			"focal": "base-ubuntu"
+			"jammy": "base-ubuntu"
 		},
 		"rootDistro": "debian",
 		"architectures": {
@@ -33,9 +31,6 @@
 			"jammy": [
 				"linux/amd64",
 				"linux/arm64"
-			],
-			"focal": [
-				"linux/amd64"
 			]
 		},
 		"tags": [
@@ -55,16 +50,12 @@
 			],
 			"noble": [
 				"cpp:${VERSION}-ubuntu-24.04",
-				"cpp:${VERSION}-ubuntu24.04"
+				"cpp:${VERSION}-ubuntu24.04",
+				"cpp:${VERSION}-ubuntu"
 			],
 			"jammy": [
 				"cpp:${VERSION}-ubuntu-22.04",
 				"cpp:${VERSION}-ubuntu22.04"
-			],
-			"focal": [
-				"cpp:${VERSION}-ubuntu-20.04",
-				"cpp:${VERSION}-ubuntu20.04",
-				"cpp:${VERSION}-ubuntu"
 			]
 		}
 	},

--- a/src/cpp/manifest.json
+++ b/src/cpp/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "1.2.11",
+	"version": "1.2.10",
 	"variants": [
 		"bookworm",
 		"bullseye",


### PR DESCRIPTION
**Ref:** #90 , [#261](https://github.com/devcontainers/internal/issues/261)

**Description:** The ubuntu focal is going out of support from May 31, 2025. So removing the ubuntu focal from the cpp image list.

**Changelog:** The following changes have been made.
- Removed ubuntu focal from the manifest.json.
- Removed from readme file.

**Checklist:**
- [x] All checks are passed.