### PR TITLE
[rust] - Build failure due to non-existing rust dependency. Correction by changing the feature reference

### DIFF
--- a/src/rust/.devcontainer/devcontainer.json
+++ b/src/rust/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
             "userGid": "1000",
             "upgradePackages": "true"
         },
-        "ghcr.io/devcontainers/features/rust:1": "latest",
+        "ghcr.io/devcontainers/features/rust:latest": "latest",
 	"ghcr.io/devcontainers/features/git:1": {
             "version": "latest",
             "ppa": "false"

--- a/src/rust/.devcontainer/devcontainer.json
+++ b/src/rust/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
             "userGid": "1000",
             "upgradePackages": "true"
         },
-        "ghcr.io/devcontainers/features/rust:1.3": "latest",
+        "ghcr.io/devcontainers/features/rust:latest": "latest",
 	"ghcr.io/devcontainers/features/git:1": {
             "version": "latest",
             "ppa": "false"

--- a/src/rust/.devcontainer/devcontainer.json
+++ b/src/rust/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
             "userGid": "1000",
             "upgradePackages": "true"
         },
-        "ghcr.io/devcontainers/features/rust:1": "latest",
+        "ghcr.io/devcontainers/features/rust:1.3": "latest",
 	"ghcr.io/devcontainers/features/git:1": {
             "version": "latest",
             "ppa": "false"

--- a/src/rust/.devcontainer/devcontainer.json
+++ b/src/rust/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
             "userGid": "1000",
             "upgradePackages": "true"
         },
-        "ghcr.io/devcontainers/features/rust:latest": "latest",
+        "ghcr.io/devcontainers/features/rust:1": "latest",
 	"ghcr.io/devcontainers/features/git:1": {
             "version": "latest",
             "ppa": "false"

--- a/src/rust/.devcontainer/devcontainer.json
+++ b/src/rust/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
             "userGid": "1000",
             "upgradePackages": "true"
         },
-        "ghcr.io/devcontainers/features/rust:1.3": "latest",
+        "ghcr.io/devcontainers/features/rust:1": "latest",
 	"ghcr.io/devcontainers/features/git:1": {
             "version": "latest",
             "ppa": "false"

--- a/src/rust/.devcontainer/devcontainer.json
+++ b/src/rust/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
             "userGid": "1000",
             "upgradePackages": "true"
         },
-        "ghcr.io/devcontainers/features/rust:latest": "latest",
+        "ghcr.io/devcontainers/features/rust:1.3": "latest",
 	"ghcr.io/devcontainers/features/git:1": {
             "version": "latest",
             "ppa": "false"

--- a/src/rust/manifest.json
+++ b/src/rust/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "1.0.23",
+	"version": "1.0.24",
 	"variants": [
 		"bookworm",
 		"bullseye"


### PR DESCRIPTION
**Ref#** [#266](https://github.com/devcontainers/internal/issues/266)

**Description:** Changing the rust feature OCI tag to [ghcr.io/devcontainers/features/rust:latest](http://ghcr.io/devcontainers/features/rust:latest) in the devcontainer.json for rust image 