### PR TITLE
[Monthly release] v0.4.16

### DIFF
--- a/src/base-ubuntu/manifest.json
+++ b/src/base-ubuntu/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "1.2.6",
+	"version": "1.2.8",
 	"variants": [
 		"noble",
 		"jammy"

--- a/src/base-ubuntu/manifest.json
+++ b/src/base-ubuntu/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "1.2.8",
+	"version": "2.0.0",
 	"variants": [
 		"noble",
 		"jammy"

--- a/src/cpp/manifest.json
+++ b/src/cpp/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "1.2.12",
+	"version": "2.0.0",
 	"variants": [
 		"bookworm",
 		"bullseye",

--- a/src/cpp/manifest.json
+++ b/src/cpp/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "1.2.10",
+	"version": "1.2.12",
 	"variants": [
 		"bookworm",
 		"bullseye",

--- a/src/universal/manifest.json
+++ b/src/universal/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/src/universal/manifest.json
+++ b/src/universal/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "3.0.1",
+	"version": "3.0.0",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",


### PR DESCRIPTION
📆 Monthly release for all the images. This release focuses on upgrading those depending on Ubuntu 20.04, which reaches official end of support on May 31st.

Changelog:

- [[cpp] - Ubuntu focal EOL for c++ image](https://github.com/devcontainers/images/pull/1416)
- [[base-ubuntu] - Ubuntu focal EOL for base image](https://github.com/devcontainers/images/pull/1415)
- [[universal] - Image change ubuntu focal EOL](#1404)