### PR TITLE
[anaconda] - Fix to stick to transformers version 4.49.0

### DIFF
--- a/src/anaconda/manifest.json
+++ b/src/anaconda/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "1.2.3",
+	"version": "1.2.4",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",


### PR DESCRIPTION
Ref# [#267](https://github.com/devcontainers/internal/issues/267)

**Description:** This change is to create the ability to pin extra python packages to specific versions provided as input instead of looking for higher version.

**Changelog:** The following changes have been made.
- Change done in `images/src/anaconda/.devcontainer/apply_security_patches.sh` introduce an array `pin_to_required_version` which should consist of package names for which the install should stick to the given version in `vulnerable_packages` array instead of looking for higher version.
- Version bump.

**Checklist:**
- [x] All checks are passed.