### PR TITLE
docs: update javascript-node semantic version

### DIFF
--- a/src/javascript-node/README.md
+++ b/src/javascript-node/README.md
@@ -28,11 +28,11 @@ Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/devcontainers/javascript-node:2-24` (or `2-24-bookworm`, `2-24-bullseye`)
-- `mcr.microsoft.com/devcontainers/javascript-node:2.0-24` (or `2.0-24-bookworm`, `2.0-24-bullseye`)
-- `mcr.microsoft.com/devcontainers/javascript-node:2.0.0-24` (or `2.0.0-24-bookworm`, `2.0.0-24-bullseye`)
+- `mcr.microsoft.com/devcontainers/javascript-node:3-24` (or `3-24-bookworm`, `3-24-bullseye`)
+- `mcr.microsoft.com/devcontainers/javascript-node:3.0-24` (or `3.0-24-bookworm`, `3.0-24-bullseye`)
+- `mcr.microsoft.com/devcontainers/javascript-node:3.0.0-24` (or `3.0.0-24-bookworm`, `3.0.0-24-bullseye`)
 
-However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `2-24`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
+However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `3-24`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 
 Beyond Node.js and `git`, this image / `Dockerfile` includes `eslint`, `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `node` user with `sudo` access, and a set of common dependencies for development. [Node Version Manager](https://github.com/nvm-sh/nvm) (`nvm`) is also included in case you need to use a different version of Node.js than the one included in the image.
 


### PR DESCRIPTION
## Summary

Update JavaScript-Node README to reference the new `3.x` semantic version tags instead of `2.x`

Documentation:
- Update example tags in README from `2-24` variants to `3-24` variants
- Adjust security patching note to reference `3-24` as the latest supported version

## Why?

At #1423, I updated the 3.0.0 version in [manaifest.json](https://github.com/devcontainers/images/blob/main/src/javascript-node/manifest.json).

https://github.com/devcontainers/images/blob/f4b0fee4365a03146c58c756c1a4c7b0762681ae/src/javascript-node/manifest.json#L1-L10

However, I forget to match the [README.md](https://github.com/devcontainers/images/blob/main/src/javascript-node/README.md).