### PR TITLE
Bump up javascript-node image version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "image": "mcr.microsoft.com/devcontainers/javascript-node:0-18",
+    "image": "mcr.microsoft.com/devcontainers/javascript-node:3-22",
     "features": {
         "ghcr.io/devcontainers/features/docker-in-docker:2": {},
         "ghcr.io/devcontainers/features/azure-cli:1": {}


### PR DESCRIPTION
**Devcontainer Image:**
Javascript-node 

**Description of changes**:
bumping up the javascript-node version to  the updated release. 
ref [1391](https://github.com/devcontainers/images/pull/1391) 

**Change log:**
Updated devcontainer.json to the latest lts version. 
**Checklist:**
changes works as expected 