### PR TITLE
Debian: Support debian 13 (trixie)

### DIFF
--- a/src/base-debian/.devcontainer/Dockerfile
+++ b/src/base-debian/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Debian version (use bullseye on local arm64/Apple Silicon): bookworm, bullseye, buster
-ARG VARIANT="bookworm"
+# [Choice] Debian version (use bullseye on local arm64/Apple Silicon): trixie, bookworm, bullseye, buster
+ARG VARIANT="trixie"
 FROM buildpack-deps:${VARIANT}-curl
 
 # [Optional] Uncomment this section to install additional OS packages.

--- a/src/base-debian/README.md
+++ b/src/base-debian/README.md
@@ -9,8 +9,8 @@
 | *Categories* | Core, Other |
 | *Image type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/base:debian |
-| *Available image variants* | bookworm, bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/base/tags/list)) |
-| *Published image architecture(s)* | x86-64, aarch64/arm64 for `bookworm`, and `bullseye` variant |
+| *Available image variants* | trixie, bookworm, bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/base/tags/list)) |
+| *Published image architecture(s)* | x86-64, aarch64/arm64 for `trixie`, `bookworm`, and `bullseye` variant |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
 | *Languages, platforms* | Any |
@@ -22,6 +22,7 @@ See **[history](history)** for information on the contents of published images.
 You can directly reference pre-built versions of `Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
 
 - `mcr.microsoft.com/devcontainers/base:debian` (latest)
+- `mcr.microsoft.com/devcontainers/base:trixie` (or `debian-13`)
 - `mcr.microsoft.com/devcontainers/base:bookworm` (or `debian-12`)
 - `mcr.microsoft.com/devcontainers/base:bullseye` (or `debian-11`)
 
@@ -29,9 +30,9 @@ Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/devcontainers/base:1-bookworm`
-- `mcr.microsoft.com/devcontainers/base:1.0-bookworm`
-- `mcr.microsoft.com/devcontainers/base:1.0.0-bookworm`
+- `mcr.microsoft.com/devcontainers/base:1-trixie`
+- `mcr.microsoft.com/devcontainers/base:1.0-trixie`
+- `mcr.microsoft.com/devcontainers/base:1.0.0-trixie`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/base/tags/list).
 

--- a/src/base-debian/manifest.json
+++ b/src/base-debian/manifest.json
@@ -1,13 +1,18 @@
 {
-	"version": "1.0.25",
+	"version": "2.0.0",
 	"variants": [
+		"trixie",
 		"bookworm",
 		"bullseye"
 	],
 	"build": {
-		"latest": "bookworm",
+		"latest": "trixie",
 		"rootDistro": "debian",
 		"architectures": {
+			"trixie": [
+				"linux/amd64",
+				"linux/arm64"
+			],
 			"bookworm": [
 				"linux/amd64",
 				"linux/arm64"
@@ -21,11 +26,15 @@
 			"base:${VERSION}-${VARIANT}"
 		],
 		"variantTags": {
-			"bookworm": [
-				"base:${VERSION}-debian-12",
-				"base:${VERSION}-debian12",
+			"trixie": [
+				"base:${VERSION}-debian-13",
+				"base:${VERSION}-debian13",
 				"base:${VERSION}-debian",
 				"base:${VERSION}"
+			],
+			"bookworm": [
+				"base:${VERSION}-debian-12",
+				"base:${VERSION}-debian12"
 			],
 			"bullseye": [
 				"base:${VERSION}-debian-11",


### PR DESCRIPTION
https://www.debian.org/News/2025/20250809 🥳 