### PR TITLE
chore: support go 1.25

### DIFF
--- a/src/go/.devcontainer/Dockerfile
+++ b/src/go/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG VARIANT=1.24-bookworm
+ARG VARIANT=1.25-bookworm
 FROM golang:${VARIANT}
 
 # [Optional] Uncomment the next line to use go get to install anything else you need

--- a/src/go/README.md
+++ b/src/go/README.md
@@ -10,7 +10,7 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/go |
-| *Available image variants* | 1 / 1-bookworm, 1.24 / 1.24-bookworm, 1.23 / 1.23-bookworm, 1-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/go/tags/list)) |
+| *Available image variants* | 1 / 1-bookworm, 1.25 / 1.25-bookworm, 1.24 / 1.24-bookworm, 1-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/go/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bookworm`, and `bullseye` variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -24,16 +24,16 @@ You can directly reference pre-built versions of `Dockerfile` by using the `imag
 
 - `mcr.microsoft.com/devcontainers/go` (latest)
 - `mcr.microsoft.com/devcontainers/go:1` (or `1-bookworm`, `1-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/go:1.25` (or `1.25-bookworm`, `1.25-bullseye` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/go:1.24` (or `1.24-bookworm`, `1.24-bullseye` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/go:1.23` (or `1.23-bookworm`, `1.23-bullseye` to pin to an OS version)
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/devcontainers/go:1-1.24` (or `1-1.24-bookworm`, `1-1.24-bullseye`)
-- `mcr.microsoft.com/devcontainers/go:1.4-1.24` (or `1.4-1.24-bookworm`, `1.4-1.24-bullseye`)
-- `mcr.microsoft.com/devcontainers/go:1.4.0-1.24` (or `1.4.0-1.24-bookworm`, `1.4.0-1.24-bullseye`)
+- `mcr.microsoft.com/devcontainers/go:1-1.25` (or `1-1.25-bookworm`, `1-1.25-bullseye`)
+- `mcr.microsoft.com/devcontainers/go:1.4-1.25` (or `1.4-1.25-bookworm`, `1.4-1.25-bullseye`)
+- `mcr.microsoft.com/devcontainers/go:1.4.0-1.25` (or `1.4.0-1.25-bookworm`, `1.4.0-1.25-bullseye`)
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `1-1.24`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 

--- a/src/go/manifest.json
+++ b/src/go/manifest.json
@@ -1,53 +1,53 @@
 {
   "version": "1.4.5",
   "variants": [
+    "1.25-bookworm",
     "1.24-bookworm",
-    "1.23-bookworm",
-    "1.24-bullseye",
-    "1.23-bullseye"
+    "1.25-bullseye",
+    "1.24-bullseye"
   ],
   "build": {
-    "latest": "1.24-bookworm",
+    "latest": "1.25-bookworm",
     "rootDistro": "debian",
     "tags": [
       "go:${VERSION}-${VARIANT}"
     ],
     "architectures": {
+      "1.25-bookworm": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
       "1.24-bookworm": [
         "linux/amd64",
         "linux/arm64"
       ],
-      "1.23-bookworm": [
+      "1.25-bullseye": [
         "linux/amd64",
         "linux/arm64"
       ],
       "1.24-bullseye": [
         "linux/amd64",
         "linux/arm64"
-      ],
-      "1.23-bullseye": [
-        "linux/amd64",
-        "linux/arm64"
       ]
     },
     "variantTags": {
+      "1.25-bookworm": [
+        "go:${VERSION}-1.25",
+        "go:${VERSION}-1",
+        "go:${VERSION}-1-bookworm",
+        "go:${VERSION}-bookworm"
+      ],
       "1.24-bookworm": [
         "go:${VERSION}-1.24",
         "go:${VERSION}-1",
         "go:${VERSION}-1-bookworm",
         "go:${VERSION}-bookworm"
       ],
-      "1.23-bookworm": [
-        "go:${VERSION}-1.23",
-        "go:${VERSION}-1",
-        "go:${VERSION}-1-bookworm",
-        "go:${VERSION}-bookworm"
-      ],
-      "1.24-bullseye": [
+      "1.25-bullseye": [
         "go:${VERSION}-1-bullseye",
         "go:${VERSION}-bullseye"
       ],
-      "1.23-bullseye": [
+      "1.24-bullseye": [
         "go:${VERSION}-1-bullseye",
         "go:${VERSION}-bullseye"
       ]


### PR DESCRIPTION
- Add support for go 1.25 as released https://go.dev/doc/go1.25
- EOL go 1.23
