### PR TITLE
[jekyll] - Fix for vulnerability issue CVE-2024-46901

### DIFF
--- a/src/jekyll/.devcontainer/Dockerfile
+++ b/src/jekyll/.devcontainer/Dockerfile
@@ -25,6 +25,32 @@ RUN chown -R "vscode:rvm" "/usr/local/rvm/" \
 
 COPY post-create.sh /usr/local/post-create.sh
 
+# Fixing vulnerability issue CVE-2024-46901 by upgrading svn to 1.14.5. Ref https://subversion.apache.org/security/CVE-2024-46901-advisory.txt
+RUN set -eux; \
+    URL="https://archive.apache.org/dist/subversion/subversion-1.14.5.tar.gz"; \
+    TMP="/tmp"; \
+    TARBALL="subversion-1.14.5.tar.gz"; \
+    SRCDIR="subversion-1.14.5"; \
+    if wget -q -O "${TMP}/${TARBALL}" "${URL}"; then \
+      echo "Downloaded ${TARBALL} — building..."; \
+      apt-get remove -y subversion libsvn1 || true; \
+      cd "${TMP}"; \
+      tar -xzf "${TARBALL}"; \
+      cd "${SRCDIR}"; \
+      apt-get update -y; \
+      apt-get install -y --no-install-recommends build-essential autoconf libtool pkg-config libapr1-dev libaprutil1-dev liblz4-dev libutf8proc-dev; \
+      ./configure --with-lz4=internal --prefix=/usr; \
+      make -j"$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)"; \
+      make install; \
+      cd /; \
+      rm -rf "${TMP:?}/${SRCDIR}" "${TMP:?}/${TARBALL}"; \
+      apt-get purge -y --auto-remove build-essential autoconf libtool pkg-config; \
+      rm -rf /var/lib/apt/lists/*; \
+      echo "Subversion built and installed (build deps removed)"; \
+    else \
+      echo "Downloading svn source failed, skipping Subversion build"; \
+    fi    
+
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 #     && apt-get -y install --no-install-recommends <your-package-list-here>

--- a/src/jekyll/manifest.json
+++ b/src/jekyll/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.1.18",
+	"version": "2.1.19",
 	"variants": [
 		"3.3-bookworm",
 		"3.3-bullseye"

--- a/src/jekyll/test-project/test.sh
+++ b/src/jekyll/test-project/test.sh
@@ -21,6 +21,10 @@ check "git-location" sh -c "which git | grep /usr/local/bin/git"
 git_version=$(git --version)
 check-version-ge "git-requirement" "${git_version}" "git version 2.40.1"
 
+# Testing vulnerability issue CVE-2024-46901 fix by upgrading svn to 1.14.5.
+svn_version=$(svn --version --quiet)
+check-version-ge "svn-requirement" "${svn_version}" "1.14.5"
+
 check "set-git-config-user-name" sh -c "sudo git config --system user.name devcontainers"
 check "gitconfig-file-location" sh -c "ls /etc/gitconfig"
 check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcontainers'"


### PR DESCRIPTION
Ref: https://github.com/devcontainers/internal/issues/293

**Devcontainer Image:**

- Jekyll

**Description of changes:** 

- Aims to fix [CVE-2024-46901](https://subversion.apache.org/security/CVE-2024-46901-advisory.txt) by installing svn `1.14.5` version from source. Its not available as a library package in Debian yet.

**Changelog:**

- Change in Dockerfile to install the svn package from source.
- Change in test script to validate the svn version

**Checklist:**
- [x] All checks are passed. 