### PR TITLE
[php] - Add support for debian trixie(13)

### DIFF
--- a/src/php/.devcontainer/Dockerfile
+++ b/src/php/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG VARIANT=8.4-apache-bookworm
+ARG VARIANT=8.4-apache-trixie
 FROM php:${VARIANT}
 
 # Install xdebug

--- a/src/php/README.md
+++ b/src/php/README.md
@@ -9,7 +9,7 @@
 | *Categories* | Languages |
 | *Image type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/php |
-| *Available image variants* | 8 / 8-bookworm, 8.4 / 8.4-bookworm, 8.3 / 8.3-bookworm, 8.2 / 8.2-bookworm, 8-bullseye, 8.4-bullseye,,8.3-bullseye, 8.2-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/php/tags/list)) |
+| *Available image variants* | 8 / 8-trixie, 8.4 / 8.4-trixie, 8.3 / 8.3-trixie, 8.2 / 8.2-trixie, 8-bookworm, 8.4-bookworm, 8.3-bookworm, 8.2-bookworm, 8-bullseye, 8.4-bullseye,,8.3-bullseye, 8.2-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/php/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bookworm`, and `bullseye` variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -22,18 +22,18 @@ See **[history](history)** for information on the contents of published images.
 You can directly reference pre-built versions of `Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own `Dockerfile` with one of the following:
 
 - `mcr.microsoft.com/devcontainers/php` (latest)
-- `mcr.microsoft.com/devcontainers/php:8` (or `8-bookworm`, `8-bullseye` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/php:8.4` (or `8.4-bookworm`, `8.4-bullseye` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/php:8.3` (or `8.3-bookworm`, `8.3-bullseye` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/php:8.2` (or `8.2-bookworm`, `8.2-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/php:8` (or `8-trixie`, `8-bookworm`, `8-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/php:8.4` (or `8.4-trixie`, `8.4-bookworm`, `8.4-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/php:8.3` (or `8.3-trixie`, `8.3-bookworm`, `8.3-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/php:8.2` (or `8.2-trixie`, `8.2-bookworm`, `8.2-bullseye` to pin to an OS version)
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/devcontainers/php:1-8` (or `1-8-bookworm`, `1-8-bullseye`)
-- `mcr.microsoft.com/devcontainers/php:1.0-8` (or `1.0-8-bookworm`, `1.0-8-bullseye`)
-- `mcr.microsoft.com/devcontainers/php:1.0.3-8` (or `1.0.3-8-bookworm`, `1.0.3-8-bullseye`)
+- `mcr.microsoft.com/devcontainers/php:2-8` (or `2-8-bookworm`, `2-8-bullseye`)
+- `mcr.microsoft.com/devcontainers/php:2.0-8` (or `2.0-8-bookworm`, `2.0-8-bullseye`)
+- `mcr.microsoft.com/devcontainers/php:2.0.0-8` (or `2.0.0-8-bookworm`, `2.0.0-8-bullseye`)
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `1-8`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 

--- a/src/php/README.md
+++ b/src/php/README.md
@@ -35,7 +35,7 @@ You can decide how often you want updates by referencing a [semantic version](ht
 - `mcr.microsoft.com/devcontainers/php:2.0-8` (or `2.0-8-bookworm`, `2.0-8-bullseye`)
 - `mcr.microsoft.com/devcontainers/php:2.0.0-8` (or `2.0.0-8-bookworm`, `2.0.0-8-bullseye`)
 
-However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `1-8`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
+However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `2-8`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/php/tags/list).
 

--- a/src/php/manifest.json
+++ b/src/php/manifest.json
@@ -77,11 +77,9 @@
 				"php:${VERSION}-bookworm"
 			],
 			"8.3-apache-bookworm": [
-				"php:${VERSION}-8.3",
 				"php:${VERSION}-8.3-bookworm"
 			],			
 			"8.2-apache-bookworm": [
-				"php:${VERSION}-8.2",
 				"php:${VERSION}-8.2-bookworm"
 			],
 			"8.4-apache-bullseye": [

--- a/src/php/manifest.json
+++ b/src/php/manifest.json
@@ -1,6 +1,9 @@
 {
-	"version": "1.3.5",
+	"version": "2.0.0",
 	"variants": [
+        "8.4-apache-trixie",
+        "8.3-apache-trixie",
+        "8.2-apache-trixie",
 		"8.4-apache-bookworm",
 		"8.3-apache-bookworm",
 		"8.2-apache-bookworm",
@@ -9,9 +12,21 @@
 		"8.2-apache-bullseye"
 	],
 	"build": {
-		"latest": "8.4-apache-bookworm",
+		"latest": "8.4-apache-trixie",
 		"rootDistro": "debian",
 		"architectures": {
+			"8.4-apache-trixie": [
+				"linux/amd64",
+				"linux/arm64"
+			],			
+			"8.3-apache-trixie": [
+				"linux/amd64",
+				"linux/arm64"
+			],
+			"8.2-apache-trixie": [
+				"linux/amd64",
+				"linux/arm64"
+			],			
 			"8.4-apache-bookworm": [
 				"linux/amd64",
 				"linux/arm64"
@@ -41,9 +56,22 @@
 			"php:${VERSION}-${VARIANT}"
 		],
 		"variantTags": {
-			"8.4-apache-bookworm": [
+			"8.4-apache-trixie": [
 				"php:${VERSION}-8",
 				"php:${VERSION}-8.4",
+				"php:${VERSION}-8-trixie",
+				"php:${VERSION}-8.4-trixie",
+				"php:${VERSION}-trixie"
+			],
+			"8.3-apache-trixie": [
+				"php:${VERSION}-8.3",
+				"php:${VERSION}-8.3-trixie"
+			],			
+			"8.2-apache-trixie": [
+				"php:${VERSION}-8.2",
+				"php:${VERSION}-8.2-trixie"
+			],			
+			"8.4-apache-bookworm": [
 				"php:${VERSION}-8-bookworm",
 				"php:${VERSION}-8.4-bookworm",
 				"php:${VERSION}-bookworm"


### PR DESCRIPTION
**Ref:** https://github.com/devcontainers/internal/issues/283

**Devcontainer Image:**

- php

**Description of changes:** 

- Aims to add support for debian trixie (13)

**Changelog:**

- Change in Dockerfiles to add debian trixie as the default option.
- Change in manifest.json to add debian trixie image variant.
- Change in readme file.

**Checklist:**
- [x] All checks are passed. 