### PR TITLE
Updated fix for vulnerability issue CVE-2024-46901

### DIFF
--- a/src/go/.devcontainer/scripts/install-subversion.sh
+++ b/src/go/.devcontainer/scripts/install-subversion.sh
@@ -1,6 +1,20 @@
 #!/bin/bash
 set -eux
 
+REQUIRED="1.14.5"
+
+# Determine current svn version if present
+current=""
+if command -v svn >/dev/null 2>&1; then
+  current="$(svn --version --quiet 2>/dev/null || true)"
+fi
+
+# If current version is >= REQUIRED, skip building
+if [ -n "${current}" ] && dpkg --compare-versions "${current}" ge "${REQUIRED}"; then
+  echo "Subversion ${current} is >= ${REQUIRED}; skipping build."
+  exit 0
+fi
+
 URL="https://archive.apache.org/dist/subversion/subversion-1.14.5.tar.gz"
 TMP="/tmp"
 TARBALL="subversion-1.14.5.tar.gz"

--- a/src/javascript-node/.devcontainer/scripts/install-subversion.sh
+++ b/src/javascript-node/.devcontainer/scripts/install-subversion.sh
@@ -1,6 +1,20 @@
 #!/bin/bash
 set -eux
 
+REQUIRED="1.14.5"
+
+# Determine current svn version if present
+current=""
+if command -v svn >/dev/null 2>&1; then
+  current="$(svn --version --quiet 2>/dev/null || true)"
+fi
+
+# If current version is >= REQUIRED, skip building
+if [ -n "${current}" ] && dpkg --compare-versions "${current}" ge "${REQUIRED}"; then
+  echo "Subversion ${current} is >= ${REQUIRED}; skipping build."
+  exit 0
+fi
+
 URL="https://archive.apache.org/dist/subversion/subversion-1.14.5.tar.gz"
 TMP="/tmp"
 TARBALL="subversion-1.14.5.tar.gz"

--- a/src/jekyll/.devcontainer/scripts/install-subversion.sh
+++ b/src/jekyll/.devcontainer/scripts/install-subversion.sh
@@ -1,6 +1,20 @@
 #!/bin/bash
 set -eux
 
+REQUIRED="1.14.5"
+
+# Determine current svn version if present
+current=""
+if command -v svn >/dev/null 2>&1; then
+  current="$(svn --version --quiet 2>/dev/null || true)"
+fi
+
+# If current version is >= REQUIRED, skip building
+if [ -n "${current}" ] && dpkg --compare-versions "${current}" ge "${REQUIRED}"; then
+  echo "Subversion ${current} is >= ${REQUIRED}; skipping build."
+  exit 0
+fi
+
 URL="https://archive.apache.org/dist/subversion/subversion-1.14.5.tar.gz"
 TMP="/tmp"
 TARBALL="subversion-1.14.5.tar.gz"

--- a/src/python/.devcontainer/scripts/install-subversion.sh
+++ b/src/python/.devcontainer/scripts/install-subversion.sh
@@ -1,6 +1,20 @@
 #!/bin/bash
 set -eux
 
+REQUIRED="1.14.5"
+
+# Determine current svn version if present
+current=""
+if command -v svn >/dev/null 2>&1; then
+  current="$(svn --version --quiet 2>/dev/null || true)"
+fi
+
+# If current version is >= REQUIRED, skip building
+if [ -n "${current}" ] && dpkg --compare-versions "${current}" ge "${REQUIRED}"; then
+  echo "Subversion ${current} is >= ${REQUIRED}; skipping build."
+  exit 0
+fi
+
 URL="https://archive.apache.org/dist/subversion/subversion-1.14.5.tar.gz"
 TMP="/tmp"
 TARBALL="subversion-1.14.5.tar.gz"

--- a/src/ruby/.devcontainer/scripts/install-subversion.sh
+++ b/src/ruby/.devcontainer/scripts/install-subversion.sh
@@ -1,6 +1,20 @@
 #!/bin/bash
 set -eux
 
+REQUIRED="1.14.5"
+
+# Determine current svn version if present
+current=""
+if command -v svn >/dev/null 2>&1; then
+  current="$(svn --version --quiet 2>/dev/null || true)"
+fi
+
+# If current version is >= REQUIRED, skip building
+if [ -n "${current}" ] && dpkg --compare-versions "${current}" ge "${REQUIRED}"; then
+  echo "Subversion ${current} is >= ${REQUIRED}; skipping build."
+  exit 0
+fi
+
 URL="https://archive.apache.org/dist/subversion/subversion-1.14.5.tar.gz"
 TMP="/tmp"
 TARBALL="subversion-1.14.5.tar.gz"

--- a/src/rust/.devcontainer/scripts/install-subversion.sh
+++ b/src/rust/.devcontainer/scripts/install-subversion.sh
@@ -1,6 +1,20 @@
 #!/bin/bash
 set -eux
 
+REQUIRED="1.14.5"
+
+# Determine current svn version if present
+current=""
+if command -v svn >/dev/null 2>&1; then
+  current="$(svn --version --quiet 2>/dev/null || true)"
+fi
+
+# If current version is >= REQUIRED, skip building
+if [ -n "${current}" ] && dpkg --compare-versions "${current}" ge "${REQUIRED}"; then
+  echo "Subversion ${current} is >= ${REQUIRED}; skipping build."
+  exit 0
+fi
+
 URL="https://archive.apache.org/dist/subversion/subversion-1.14.5.tar.gz"
 TMP="/tmp"
 TARBALL="subversion-1.14.5.tar.gz"

--- a/src/typescript-node/.devcontainer/scripts/install-subversion.sh
+++ b/src/typescript-node/.devcontainer/scripts/install-subversion.sh
@@ -1,6 +1,20 @@
 #!/bin/bash
 set -eux
 
+REQUIRED="1.14.5"
+
+# Determine current svn version if present
+current=""
+if command -v svn >/dev/null 2>&1; then
+  current="$(svn --version --quiet 2>/dev/null || true)"
+fi
+
+# If current version is >= REQUIRED, skip building
+if [ -n "${current}" ] && dpkg --compare-versions "${current}" ge "${REQUIRED}"; then
+  echo "Subversion ${current} is >= ${REQUIRED}; skipping build."
+  exit 0
+fi
+
 URL="https://archive.apache.org/dist/subversion/subversion-1.14.5.tar.gz"
 TMP="/tmp"
 TARBALL="subversion-1.14.5.tar.gz"


### PR DESCRIPTION
**Ref:** 

- https://github.com/devcontainers/internal/issues/290 (go)
- https://github.com/devcontainers/internal/issues/297 (ruby)
- https://github.com/devcontainers/internal/issues/293 (jekyll)
- https://github.com/devcontainers/internal/issues/292 (javascript-node)
- https://github.com/devcontainers/internal/issues/296 (python)
- https://github.com/devcontainers/internal/issues/298 (rust)
- https://github.com/devcontainers/internal/issues/299 (typescript-node)

**Devcontainer Image:**

- Go
- Ruby
- Jekyll
- Javascript-node
- Python
- Rust
- Typescript-node

**Description of changes:** 

- Update fix [CVE-2024-46901](https://subversion.apache.org/security/CVE-2024-46901-advisory.txt) by modifying fix done in [PR](https://github.com/devcontainers/images/pull/1506) to try updating `svn` only if the current installed version of the package is less than `1.14.5`. 

**Changelog:**

- Change in install-subversion.sh script to modify the logic such that update `svn` only if the current installed version of the package is less than `1.14.5`.

**Checklist:**
- [x] All checks are passed. 