### PR TITLE
[ruby] - Add support for debian trixie(13)

### DIFF
--- a/src/ruby/.devcontainer/Dockerfile
+++ b/src/ruby/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.4, 3.3, 3.2, 3-bookworm, 3.4-bookworm, 3.3-bookworm, 3.2-bookworm, 3-bullseye, 3.4-bullseye, 3.3-bullseye, 3.2-bullseye, 3-buster, 3.2-buster
-ARG VARIANT=3-bookworm
+ARG VARIANT=3-trixie
 FROM ruby:${VARIANT}
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/src/ruby/.devcontainer/devcontainer-lock.json
+++ b/src/ruby/.devcontainer/devcontainer-lock.json
@@ -1,9 +1,9 @@
 {
   "features": {
     "ghcr.io/devcontainers/features/common-utils:2": {
-      "version": "2.5.3",
-      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:3cf7ca93154faf9bdb128f3009cf1d1a91750ec97cc52082cf5d4edef5451f85",
-      "integrity": "sha256:3cf7ca93154faf9bdb128f3009cf1d1a91750ec97cc52082cf5d4edef5451f85"
+      "version": "2.5.4",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:00fd45550f578d9d515044d9e2226e908dbc3d7aa6fcb9dee4d8bdb60be114cf",
+      "integrity": "sha256:00fd45550f578d9d515044d9e2226e908dbc3d7aa6fcb9dee4d8bdb60be114cf"
     },
     "ghcr.io/devcontainers/features/git:1": {
       "version": "1.3.4",
@@ -16,9 +16,9 @@
       "integrity": "sha256:3c35dff2aedeaeb86f03e10c265c29b56a1b3609324d83d6e901dbb6032543a4"
     },
     "ghcr.io/devcontainers/features/ruby:1": {
-      "version": "1.3.1",
-      "resolved": "ghcr.io/devcontainers/features/ruby@sha256:810d7c68f9393ebe9aaa0ec51ed7172c1ef7e3a73d8bb7c6ebf2b220e183480f",
-      "integrity": "sha256:810d7c68f9393ebe9aaa0ec51ed7172c1ef7e3a73d8bb7c6ebf2b220e183480f"
+      "version": "1.3.2",
+      "resolved": "ghcr.io/devcontainers/features/ruby@sha256:1c9bbde293ba6f21449a58be34a358ffa2b3846f31cb3146409b26ab3f13e1a2",
+      "integrity": "sha256:1c9bbde293ba6f21449a58be34a358ffa2b3846f31cb3146409b26ab3f13e1a2"
     }
   }
 }

--- a/src/ruby/README.md
+++ b/src/ruby/README.md
@@ -9,7 +9,7 @@
 | *Categories* | Core, Languages |
 | *Image type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/ruby |
-| *Available image variants* | 3 / 3-bookworm, 3.4 / 3.4-bookworm, 3.3 / 3.3-bookworm, 3.2 / 3.2-bookworm, 3-bullseye, 3.4-bullseye, 3.3-bullseye, 3.2-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/ruby/tags/list)) |
+| *Available image variants* | 3 / 3-trixie, 3.4 / 3.4-trixie, 3.3 / 3.3-trixie, 3.2 / 3.2-trixie, 3-bookworm, 3.4-bookworm, 3.3-bookworm, 3.2-bookworm, 3-bullseye, 3.4-bullseye, 3.3-bullseye, 3.2-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/ruby/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bookworm` , and `bullseye` variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -22,20 +22,20 @@ See **[history](history)** for information on the contents of published images.
 You can directly reference pre-built versions of `Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
 
 - `mcr.microsoft.com/devcontainers/ruby`     (latest)
-- `mcr.microsoft.com/devcontainers/ruby:3`   (or `3-bookworm`, `3-bullseye` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/ruby:3.4` (or `3.4-bookworm`, `3.4-bullseye` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/ruby:3.3` (or `3.3-bookworm`, `3.3-bullseye` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/ruby:3.2` (or `3.2-bookworm`, `3.2-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/ruby:3`   (or `3-trixie`, `3-bookworm`, `3-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/ruby:3.4` (or `3.4-trixie`, `3.4-bookworm`, `3.4-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/ruby:3.3` (or `3.3-trixie`, `3.3-bookworm`, `3.3-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/ruby:3.2` (or `3.2-trixie`, `3.2-bookworm`, `3.2-bullseye` to pin to an OS version)
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/devcontainers/ruby:1-3`     (or `1-3-bookworm`, `1-3-bullseye` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/ruby:1.4-3`   (or `1.4-3-bookworm`, `1.4-3-bullseye` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/ruby:1.4.5-3` (or `1.4.5-3-bookworm`, `1.4.5-3-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/ruby:2-3`     (or `2-3-trixie`, `2-3-bookworm`, `2-3-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/ruby:2.0-3`   (or `2.0-3-trixie`, `2.0-3-bookworm`, `2.0-3-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/ruby:2.0.0-3` (or `2.0.0-3-trixie`, `2.0.0-3-bookworm`, `2.0.0-3-bullseye` to pin to an OS version)
 
-However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `1-3.4`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
+However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `2-3.4`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/ruby/tags/list).
 

--- a/src/ruby/manifest.json
+++ b/src/ruby/manifest.json
@@ -1,6 +1,9 @@
 {
-	"version": "1.4.5",
+	"version": "2.0.0",
 	"variants": [
+		"3.4-trixie",		
+		"3.3-trixie",
+		"3.2-trixie",		
 		"3.4-bookworm",		
 		"3.3-bookworm",
 		"3.2-bookworm",
@@ -12,6 +15,18 @@
 		"latest": "3.4-bookworm",
 		"rootDistro": "debian",
 		"architectures": {
+			"3.4-trixie": [
+				"linux/amd64",
+				"linux/arm64"
+			],			
+			"3.3-trixie": [
+				"linux/amd64",
+				"linux/arm64"
+			],
+			"3.2-trixie": [
+				"linux/amd64",
+				"linux/arm64"
+			],			
 			"3.4-bookworm": [
 				"linux/amd64",
 				"linux/arm64"
@@ -41,17 +56,27 @@
 			"ruby:${VERSION}-${VARIANT}"
 		],
 		"variantTags": {
-			"3.4-bookworm": [
+			"3.4-trixie": [
 				"ruby:${VERSION}-3",
 				"ruby:${VERSION}-3.4",
+				"ruby:${VERSION}-3-trixie",
+				"ruby:${VERSION}-trixie"
+			],
+			"3.3-trixie": [
+				"ruby:${VERSION}-3.3"
+			],			
+			"3.2-trixie": [
+				"ruby:${VERSION}-3.2"
+			],			
+			"3.4-bookworm": [
 				"ruby:${VERSION}-3-bookworm",
 				"ruby:${VERSION}-bookworm"
 			],
 			"3.3-bookworm": [
-				"ruby:${VERSION}-3.3"
+				"ruby:${VERSION}-3.3-bookworm"
 			],			
 			"3.2-bookworm": [
-				"ruby:${VERSION}-3.2"
+				"ruby:${VERSION}-3.2-bookworm"
 			],
 			"3.4-bullseye": [
 				"ruby:${VERSION}-3-bullseye",


### PR DESCRIPTION
**Ref:** https://github.com/devcontainers/internal/issues/283

**Devcontainer Image:**

- ruby

**Description of changes:** 

- Aims to add support for debian trixie (13)

**Changelog:**

- Change in Dockerfiles to add debian trixie as the default option.
- Change in manifest.json to add debian trixie image variant.
- Change in readme file.
- Update devcontainer-lock.json to update feature references

**Checklist:**
- [x] All checks are passed. 