### PR TITLE
Dev container - Image Naming convention changes

### DIFF
--- a/src/base-alpine/README.md
+++ b/src/base-alpine/README.md
@@ -9,7 +9,7 @@
 | *Categories* | Core, Other |
 | *Image type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/base:alpine |
-| *Available image variants* | alpine-3.22, alpine-3.21, alpine-3.20, alpine-3.19 ([full list](https://mcr.microsoft.com/v2/devcontainers/base/tags/list)) |
+| *Available image variants* | alpine3.22, alpine3.21, alpine3.20, alpine3.19 ([full list](https://mcr.microsoft.com/v2/devcontainers/base/tags/list)) |
 | *Published image architecture(s)* | x86-64, aarch64/arm64 |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Alpine Linux |
@@ -22,19 +22,19 @@ See **[history](history)** for information on the contents of published images.
 You can also directly reference pre-built versions of `.devcontainer/Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
 
 - `mcr.microsoft.com/devcontainers/base:alpine` (latest)
-- `mcr.microsoft.com/devcontainers/base:alpine-3.22`
-- `mcr.microsoft.com/devcontainers/base:alpine-3.21`
-- `mcr.microsoft.com/devcontainers/base:alpine-3.20`
-- `mcr.microsoft.com/devcontainers/base:alpine-3.19`
+- `mcr.microsoft.com/devcontainers/base:alpine3.22`
+- `mcr.microsoft.com/devcontainers/base:alpine3.21`
+- `mcr.microsoft.com/devcontainers/base:alpine3.20`
+- `mcr.microsoft.com/devcontainers/base:alpine3.19`
 
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/devcontainers/base:0-alpine`
-- `mcr.microsoft.com/devcontainers/base:0.209-alpine`
-- `mcr.microsoft.com/devcontainers/base:0.209.0-alpine`
+- `mcr.microsoft.com/devcontainers/base:1-alpine`
+- `mcr.microsoft.com/devcontainers/base:1.1-alpine`
+- `mcr.microsoft.com/devcontainers/base:1.1.0-alpine`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/base/tags/list).
 

--- a/src/base-alpine/manifest.json
+++ b/src/base-alpine/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "1.0.2",
+	"version": "1.1.0",
 	"variants": [
 		"3.22",
 		"3.21",		
@@ -14,7 +14,6 @@
 			"linux/arm64"
 		],
 		"tags": [
-			"base:${VERSION}-alpine-${VARIANT}",
 			"base:${VERSION}-alpine${VARIANT}"
 		],
 		"variantTags": {

--- a/src/base-debian/README.md
+++ b/src/base-debian/README.md
@@ -22,17 +22,17 @@ See **[history](history)** for information on the contents of published images.
 You can directly reference pre-built versions of `Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
 
 - `mcr.microsoft.com/devcontainers/base:debian` (latest)
-- `mcr.microsoft.com/devcontainers/base:trixie` (or `debian-13`)
-- `mcr.microsoft.com/devcontainers/base:bookworm` (or `debian-12`)
-- `mcr.microsoft.com/devcontainers/base:bullseye` (or `debian-11`)
+- `mcr.microsoft.com/devcontainers/base:trixie` (or `debian13`)
+- `mcr.microsoft.com/devcontainers/base:bookworm` (or `debian12`)
+- `mcr.microsoft.com/devcontainers/base:bullseye` (or `debian11`)
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/devcontainers/base:1-trixie`
-- `mcr.microsoft.com/devcontainers/base:1.0-trixie`
-- `mcr.microsoft.com/devcontainers/base:1.0.0-trixie`
+- `mcr.microsoft.com/devcontainers/base:2-trixie`
+- `mcr.microsoft.com/devcontainers/base:2.1-trixie`
+- `mcr.microsoft.com/devcontainers/base:2.1.0-trixie`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/base/tags/list).
 

--- a/src/base-debian/manifest.json
+++ b/src/base-debian/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.0.2",
+	"version": "2.1.0",
 	"variants": [
 		"trixie",
 		"bookworm",
@@ -27,17 +27,14 @@
 		],
 		"variantTags": {
 			"trixie": [
-				"base:${VERSION}-debian-13",
 				"base:${VERSION}-debian13",
 				"base:${VERSION}-debian",
 				"base:${VERSION}"
 			],
 			"bookworm": [
-				"base:${VERSION}-debian-12",
 				"base:${VERSION}-debian12"
 			],
 			"bullseye": [
-				"base:${VERSION}-debian-11",
 				"base:${VERSION}-debian11"
 			]
 		}

--- a/src/base-ubuntu/README.md
+++ b/src/base-ubuntu/README.md
@@ -9,8 +9,8 @@
 | *Categories* | Core, Other |
 | *Image type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/base:ubuntu |
-| *Available image variants* | ubuntu-24.04 / noble, ubuntu-22.04 / jammy ([full list](https://mcr.microsoft.com/v2/devcontainers/base/tags/list)) |
-| *Published image architecture(s)* | x86-64, aarch64/arm64 for `ubuntu-22.04` (`jammy`) and `ubuntu-24.04` (`noble`) variants |
+| *Available image variants* | ubuntu24.04 / noble, ubuntu22.04 / jammy ([full list](https://mcr.microsoft.com/v2/devcontainers/base/tags/list)) |
+| *Published image architecture(s)* | x86-64, aarch64/arm64 for `ubuntu22.04` (`jammy`) and `ubuntu24.04` (`noble`) variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Ubuntu |
 | *Languages, platforms* | Any |
@@ -22,16 +22,16 @@ See **[history](history)** for information on the contents of published images.
 You can directly reference pre-built versions of `Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
 
 - `mcr.microsoft.com/devcontainers/base:ubuntu` (latest LTS release)
-- `mcr.microsoft.com/devcontainers/base:ubuntu-24.04` (or `noble`)
-- `mcr.microsoft.com/devcontainers/base:ubuntu-22.04` (or `jammy`)
+- `mcr.microsoft.com/devcontainers/base:ubuntu24.04` (or `noble`)
+- `mcr.microsoft.com/devcontainers/base:ubuntu22.04` (or `jammy`)
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/devcontainers/base:2-jammy`
-- `mcr.microsoft.com/devcontainers/base:2.0-jammy`
-- `mcr.microsoft.com/devcontainers/base:2.0.0-jammy`
+- `mcr.microsoft.com/devcontainers/base:2.1-jammy`
+- `mcr.microsoft.com/devcontainers/base:2.1.0-jammy`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/base/tags/list).
 

--- a/src/base-ubuntu/manifest.json
+++ b/src/base-ubuntu/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.0.5",
+	"version": "2.1.0",
 	"variants": [
 		"noble",
 		"jammy"
@@ -22,12 +22,10 @@
 		],
 		"variantTags": {
 			"noble": [
-				"base:${VERSION}-ubuntu-24.04",
 				"base:${VERSION}-ubuntu24.04",
 				"base:${VERSION}-ubuntu"
 			],
 			"jammy": [
-				"base:${VERSION}-ubuntu-22.04",
 				"base:${VERSION}-ubuntu22.04"
 			]
 		}

--- a/src/cpp/.devcontainer/Dockerfile
+++ b/src/cpp/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG VARIANT=debian-13
+ARG VARIANT=debian13
 FROM mcr.microsoft.com/devcontainers/base:${VARIANT}
 USER root
 

--- a/src/cpp/README.md
+++ b/src/cpp/README.md
@@ -9,8 +9,8 @@
 | *Categories* | Core, Languages |
 | *Image type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/cpp |
-| *Available image variants* | debian-13, debian-12, ubuntu-24.04, ubuntu-22.04 ([full list](https://mcr.microsoft.com/v2/devcontainers/cpp/tags/list)) |
-| *Published image architecture(s)* | x86-64, aarch64/arm64 for `debian-12`, `ubuntu-24.04` and `ubuntu-22.04` variants |
+| *Available image variants* | debian13, debian12, ubuntu24.04, ubuntu22.04 ([full list](https://mcr.microsoft.com/v2/devcontainers/cpp/tags/list)) |
+| *Published image architecture(s)* | x86-64, aarch64/arm64 for `debian13`, `debian12`, `ubuntu24.04` and `ubuntu22.04` variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian, Ubuntu |
 | *Languages, platforms* | C++ |
@@ -23,21 +23,21 @@ You can directly reference pre-built versions of `Dockerfile` by using the `imag
 
 - `mcr.microsoft.com/devcontainers/cpp` (latest Debian GA)
 - `mcr.microsoft.com/devcontainers/cpp:debian` (latest Debian GA)
-- `mcr.microsoft.com/devcontainers/cpp:debian-13` (or `trixie`)
-- `mcr.microsoft.com/devcontainers/cpp:debian-12` (or `bookworm`)
+- `mcr.microsoft.com/devcontainers/cpp:debian13` (or `trixie`)
+- `mcr.microsoft.com/devcontainers/cpp:debian12` (or `bookworm`)
 - `mcr.microsoft.com/devcontainers/cpp:ubuntu` (latest Ubuntu LTS)
-- `mcr.microsoft.com/devcontainers/cpp:ubuntu-24.04` (or `noble`)
-- `mcr.microsoft.com/devcontainers/cpp:ubuntu-22.04` (or `jammy`)
+- `mcr.microsoft.com/devcontainers/cpp:ubuntu24.04` (or `noble`)
+- `mcr.microsoft.com/devcontainers/cpp:ubuntu22.04` (or `jammy`)
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 - `mcr.microsoft.com/devcontainers/cpp:2-trixie`
-- `mcr.microsoft.com/devcontainers/cpp:2.0-trixie`
-- `mcr.microsoft.com/devcontainers/cpp:2.0.0-trixie`
+- `mcr.microsoft.com/devcontainers/cpp:2.1-trixie`
+- `mcr.microsoft.com/devcontainers/cpp:2.1.0-trixie`
 - `mcr.microsoft.com/devcontainers/cpp:2-bookworm`
-- `mcr.microsoft.com/devcontainers/cpp:2.0-bookworm`
-- `mcr.microsoft.com/devcontainers/cpp:2.0.0-bookworm`
+- `mcr.microsoft.com/devcontainers/cpp:2.1-bookworm`
+- `mcr.microsoft.com/devcontainers/cpp:2.1.0-bookworm`
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `0-debian-12`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 

--- a/src/cpp/manifest.json
+++ b/src/cpp/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.0.1",
+	"version": "2.1.0",
 	"variants": [
 		"trixie",
 		"bookworm",
@@ -38,22 +38,18 @@
 		],
 		"variantTags": {
 			"trixie": [
-				"cpp:${VERSION}-debian-13",
 				"cpp:${VERSION}-debian13",
 				"cpp:${VERSION}-debian",
 				"cpp:${VERSION}"
 			],
 			"bookworm": [
-				"cpp:${VERSION}-debian-12",
 				"cpp:${VERSION}-debian12"
 			],
 			"noble": [
-				"cpp:${VERSION}-ubuntu-24.04",
 				"cpp:${VERSION}-ubuntu24.04",
 				"cpp:${VERSION}-ubuntu"
 			],
 			"jammy": [
-				"cpp:${VERSION}-ubuntu-22.04",
 				"cpp:${VERSION}-ubuntu22.04"
 			]
 		}


### PR DESCRIPTION
**Ref:** https://github.com/devcontainers/internal/issues/303#issuecomment-3338115653

**Devcontainer Image:**

- base-debian
- base-alpine
- base-ubuntu
- cpp

**Description of changes:** 

- Aims to provide solution for [issue](https://github.com/devcontainers/internal/issues/303#issuecomment-3338115653) by removing image name references having patterns such as `debian-12`, `alpine-3.22`, `ubuntu-24.04` etc.

**Changelog:**

- Changes in manifest.json files to remove image name references mentioned above for base-debian, base-alpine, base-ubuntu and cpp dev container images.
- Version bump.
- Change in readme files.

**Checklist:**
- [x] All checks are passed. 