### PR TITLE
[anaconda] - Pinning transformers library to `4.53.0`

### DIFF
--- a/src/anaconda/.devcontainer/apply_security_patches.sh
+++ b/src/anaconda/.devcontainer/apply_security_patches.sh
@@ -26,7 +26,7 @@ done
 
 # Add an array for packages that should always pin to the provided version, 
 # even if higher version is available in conda channel
-pin_to_required_version=("jupyter_core" "cryptography" "protobuf")
+pin_to_required_version=("jupyter_core" "cryptography" "protobuf" "transformers")
 # Function to check if a package is in the pin_to_required_version array
 function is_pin_to_required_version() {
     local pkg="$1"

--- a/src/anaconda/manifest.json
+++ b/src/anaconda/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "1.3.3",
+	"version": "1.3.4",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",


### PR DESCRIPTION
**Devcontainer Image:**

- anaconda

**Description of changes:** 

- The `transformers` package has a new update available in the conda channel to `4.57.1` but this version is [downgrading](https://github.com/devcontainers/images/actions/runs/19586015317/job/56094960705#step:3:1524) `cookiecutter` package to vulnerable version `1.7.3`, see [CVE-2022-24065](https://nvd.nist.gov/vuln/detail/CVE-2022-24065). So pinning `transformers` package to the earlier available and minimum required version `4.53.0` as part of this PR.

**Changelog:**

- Change in apply_security_patches.sh to pin `transformers` package to `4.53.0`
- Version bump

**Checklist:**
- [x] All checks are passed. 