### PR TITLE
[anaconda]- Update vulnerable packages and increment version to 1.3.8

### DIFF
--- a/src/anaconda/.devcontainer/apply_security_patches.sh
+++ b/src/anaconda/.devcontainer/apply_security_patches.sh
@@ -4,7 +4,7 @@
 # werkzeug - [GHSA-f9vj-2wh5-fj8j] 
 
 vulnerable_packages=( "mistune=3.0.1" "aiohttp=3.10.11" "cryptography=44.0.1" "h11=0.16.0" "jinja2=3.1.6" "jupyter_core=5.8.1" "protobuf=5.29.5" "requests=2.32.4" "setuptools=78.1.1" "transformers=4.53.0" "urllib3=2.5.0" "Werkzeug=3.0.6" "jupyter-lsp=2.2.2" "scrapy=2.11.2" \ 
-                      "zipp=3.19.1" "tornado=6.4.2" "jupyterlab=4.4.8" "imagecodecs=2024.9.22")
+                      "zipp=3.19.1" "tornado=6.4.2" "jupyterlab=4.4.8" "imagecodecs=2024.9.22" "fonttools=4.60.2")
 
 # Define the number of rows (based on the length of vulnerable_packages)
 rows=${#vulnerable_packages[@]}

--- a/src/anaconda/manifest.json
+++ b/src/anaconda/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "1.3.7",
+	"version": "1.3.8",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -60,6 +60,7 @@ checkPythonPackageVersion "requests" "2.32.4"
 checkPythonPackageVersion "scikit-learn" "1.5.0"
 checkPythonPackageVersion "zipp" "3.19.1"
 checkPythonPackageVersion "imagecodecs" "2023.9.18"
+checkPythonPackageVersion "fonttools" "4.60.2"
 
 checkCondaPackageVersion "pyopenssl" "24.2.1"
 checkCondaPackageVersion "requests" "2.32.4"


### PR DESCRIPTION
Devcontainer image

anaconda 

Changes 
Adding the vulnerable package "fonttools" to the list 

Updating the version of vulnerable package to 4.60.2

Changes to the apply_security_patches, test.sh and  manifest.json files 

Checklist 
Applied changes worked as expected
