### PR TITLE
[universal] - Fixing multiple image vulnerability issues

### DIFF
--- a/src/universal/.devcontainer/devcontainer-lock.json
+++ b/src/universal/.devcontainer/devcontainer-lock.json
@@ -16,14 +16,14 @@
       "integrity": "sha256:905c3bd16f12b57e4e68319838799f51d5540982a8911a68f1605f3562838c8b"
     },
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
-      "version": "2.13.0",
-      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:ac0a882e936ba6275d7f4ed5ebfc09e4ddca8cbcaeaad18b412beacddeb2fa91",
-      "integrity": "sha256:ac0a882e936ba6275d7f4ed5ebfc09e4ddca8cbcaeaad18b412beacddeb2fa91"
+      "version": "2.14.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:445e84b0c213225bfdae977a72b4125f65e38eadcd49616dae04f1af24aa122d",
+      "integrity": "sha256:445e84b0c213225bfdae977a72b4125f65e38eadcd49616dae04f1af24aa122d"
     },
     "ghcr.io/devcontainers/features/dotnet:2": {
-      "version": "2.4.1",
-      "resolved": "ghcr.io/devcontainers/features/dotnet@sha256:ee5dfbe74a949dd2b93688e9194a0afa6668096cc43a2da66f7dda137dae9968",
-      "integrity": "sha256:ee5dfbe74a949dd2b93688e9194a0afa6668096cc43a2da66f7dda137dae9968"
+      "version": "2.4.2",
+      "resolved": "ghcr.io/devcontainers/features/dotnet@sha256:e56b2abde945918508f1bca94d5545e23b30f5f1d4f3b363ad4819c6b81396f1",
+      "integrity": "sha256:e56b2abde945918508f1bca94d5545e23b30f5f1d4f3b363ad4819c6b81396f1"
     },
     "ghcr.io/devcontainers/features/git-lfs:1": {
       "version": "1.2.5",

--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -75,7 +75,8 @@
         "./local-features/jekyll": "latest",
         "ghcr.io/devcontainers/features/oryx:1": "latest",
         "./local-features/setup-user": "latest",
-        "./local-features/patch-conda": {}
+        "./local-features/patch-conda": {},
+		"./local-features/patch-python": {}
     },
     "overrideFeatureInstallOrder": [
         "ghcr.io/devcontainers/features/common-utils",
@@ -87,6 +88,7 @@
         "ghcr.io/devcontainers/features/conda",
         "./local-features/patch-conda",
         "ghcr.io/devcontainers/features/python",
+		"./local-features/patch-python",
         "ghcr.io/devcontainers/features/php",
         "ghcr.io/devcontainers/features/ruby",
         "ghcr.io/devcontainers/features/java",

--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -76,7 +76,7 @@
         "ghcr.io/devcontainers/features/oryx:1": "latest",
         "./local-features/setup-user": "latest",
         "./local-features/patch-conda": {},
-		"./local-features/patch-python": {}
+        "./local-features/patch-python": {}
     },
     "overrideFeatureInstallOrder": [
         "ghcr.io/devcontainers/features/common-utils",
@@ -88,7 +88,7 @@
         "ghcr.io/devcontainers/features/conda",
         "./local-features/patch-conda",
         "ghcr.io/devcontainers/features/python",
-		"./local-features/patch-python",
+        "./local-features/patch-python",
         "ghcr.io/devcontainers/features/php",
         "ghcr.io/devcontainers/features/ruby",
         "ghcr.io/devcontainers/features/java",

--- a/src/universal/.devcontainer/local-features/patch-conda/install.sh
+++ b/src/universal/.devcontainer/local-features/patch-conda/install.sh
@@ -49,7 +49,7 @@ update_conda_package() {
 sudo_if /opt/conda/bin/python3 -m pip install --upgrade pip
 
 # Temporary: Upgrade python packages due to security vulnerabilities
-# They are installed by the conda feature and Conda distribution does not have the patches.
+# They are installed by the conda feature and Conda distribution does not have the patches
 
 # https://github.com/advisories/GHSA-79v4-65xg-pq4g
 update_python_package /opt/conda/bin/python3 cryptography "44.0.1"

--- a/src/universal/.devcontainer/local-features/patch-conda/install.sh
+++ b/src/universal/.devcontainer/local-features/patch-conda/install.sh
@@ -51,7 +51,7 @@ sudo_if /opt/conda/bin/python3 -m pip install --upgrade pip
 # Temporary: Upgrade python packages due to security vulnerabilities
 # They are installed by the conda feature and Conda distribution does not have the patches.
 
-# https://github.com/advisories/GHSA-h4gh-qq45-vh27
+# https://github.com/advisories/GHSA-79v4-65xg-pq4g
 update_python_package /opt/conda/bin/python3 cryptography "44.0.1"
 
 update_conda_package pyopenssl "25.0.0"

--- a/src/universal/.devcontainer/local-features/patch-conda/install.sh
+++ b/src/universal/.devcontainer/local-features/patch-conda/install.sh
@@ -52,12 +52,9 @@ sudo_if /opt/conda/bin/python3 -m pip install --upgrade pip
 # They are installed by the conda feature and Conda distribution does not have the patches.
 
 # https://github.com/advisories/GHSA-h4gh-qq45-vh27
-update_python_package /opt/conda/bin/python3 cryptography "43.0.1"
+update_python_package /opt/conda/bin/python3 cryptography "44.0.1"
 
 update_conda_package pyopenssl "25.0.0"
-
-# https://github.com/advisories/GHSA-pq67-6m6q-mj2v
-update_conda_package urllib3 "2.5.0"
 
 # https://github.com/advisories/GHSA-9hjg-9r4m-mvj7
 update_conda_package requests "2.32.4"
@@ -67,3 +64,9 @@ update_conda_package setuptools "78.1.1"
 
 # https://github.com/advisories/GHSA-g7vv-2v7x-gj9p
 update_python_package /opt/conda/bin/python3 tqdm "4.66.3"
+
+# https://github.com/advisories/GHSA-38jv-5279-wg99
+update_conda_package urllib3 "2.6.3"
+
+# https://nvd.nist.gov/vuln/detail/CVE-2025-6176
+update_conda_package brotli "1.2.0"

--- a/src/universal/.devcontainer/local-features/patch-python/install.sh
+++ b/src/universal/.devcontainer/local-features/patch-python/install.sh
@@ -38,8 +38,9 @@ update_package() {
     sudo_if "$PYTHON_PATH -m pip install --upgrade --no-cache-dir $PACKAGE==$VERSION"
     sudo_if "$PYTHON_PATH -m pip show --no-python-version-warning $PACKAGE"
 }
-
+# Updating pip version for python 3.11. Must be removed when pinned version 3.11 is updated to a different python version.
 sudo_if /usr/local/python/3.11.*/bin/python -m pip install --upgrade pip
 
 # https://github.com/advisories/GHSA-5rjg-fvgr-3xxf
+# Updating setuptools version for python 3.11. Must be removed when pinned version 3.11 is updated to a different python version.
 update_package /usr/local/python/3.11.*/bin/python setuptools "78.1.1"

--- a/src/universal/.devcontainer/local-features/patch-python/install.sh
+++ b/src/universal/.devcontainer/local-features/patch-python/install.sh
@@ -38,3 +38,8 @@ update_package() {
     sudo_if "$PYTHON_PATH -m pip install --upgrade --no-cache-dir $PACKAGE==$VERSION"
     sudo_if "$PYTHON_PATH -m pip show --no-python-version-warning $PACKAGE"
 }
+
+sudo_if /usr/local/python/3.11.*/bin/python -m pip install --upgrade pip
+
+# https://github.com/advisories/GHSA-5rjg-fvgr-3xxf
+update_package /usr/local/python/3.11.*/bin/python setuptools "78.1.1"

--- a/src/universal/README.md
+++ b/src/universal/README.md
@@ -29,7 +29,7 @@ For example:
 
 - `mcr.microsoft.com/devcontainers/universal:5-noble`
 - `mcr.microsoft.com/devcontainers/universal:5.1-noble`
-- `mcr.microsoft.com/devcontainers/universal:5.1.0-noble`
+- `mcr.microsoft.com/devcontainers/universal:5.1.2-noble`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/universal/tags/list).
 

--- a/src/universal/manifest.json
+++ b/src/universal/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "5.1.1",
+	"version": "5.1.2",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -178,15 +178,15 @@ check "java-version-on-path-is-12.0.2" java --version | grep 12.0.2
 ls -la /home/codespace
 
 ## Python - current
-checkPythonPackageVersion "python" "setuptools" "65.5.1"
+checkPythonPackageVersion "/usr/local/python/3.11.*/bin/python" "setuptools" "78.1.1"
 checkPythonPackageVersion "python" "requests" "2.31.0"
-checkPythonPackageVersion "python" "urllib3" "2.5.0"
 
 ## Conda Python
 checkCondaPackageVersion "requests" "2.31.0"
-checkCondaPackageVersion "cryptography" "41.0.4"
+checkCondaPackageVersion "cryptography" "44.0.1"
 checkCondaPackageVersion "pyopenssl" "25.0.0"
-checkCondaPackageVersion "urllib3" "2.5.0"
+checkCondaPackageVersion "urllib3" "2.6.3"
+checkCondaPackageVersion "brotli" "1.2.0"
 
 ## Test Conda
 check "conda-update-conda" bash -c "conda update -y conda"

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -178,8 +178,12 @@ check "java-version-on-path-is-12.0.2" java --version | grep 12.0.2
 ls -la /home/codespace
 
 ## Python - current
-checkPythonPackageVersion "/usr/local/python/3.11.*/bin/python" "setuptools" "78.1.1"
+checkPythonPackageVersion "python" "setuptools" "78.1.1"
 checkPythonPackageVersion "python" "requests" "2.31.0"
+
+## Python -alternative version 3.11. Must be removed when pinned version 3.11 is updated to a different python version.
+checkPythonPackageVersion "/usr/local/python/3.11.*/bin/python" "setuptools" "78.1.1"
+check "pip-version-for-3.11" bash -c "/usr/local/python/3.11.*/bin/python -m pip --version | grep 25.3"
 
 ## Conda Python
 checkCondaPackageVersion "requests" "2.31.0"


### PR DESCRIPTION
Ref# [Issue details](https://github.com/devcontainers/internal/issues/300#issuecomment-3750253957)

 **Dev container name**:
 
 * universal
 
 **Description**:
 
 This PR patches the following vulnerabilities:
 
 * [GHSA-79v4-65xg-pq4g](https://github.com/advisories/GHSA-79v4-65xg-pq4g) - related to the `cryptography` package.
 * [GHSA-4xh5-x5gv-qwph](https://github.com/advisories/GHSA-4xh5-x5gv-qwph) - related to the `pip`.
 * [GHSA-5rjg-fvgr-3xxf](https://github.com/advisories/GHSA-5rjg-fvgr-3xxf) - related to the `setuptools` package.
 * [GHSA-38jv-5279-wg99](https://github.com/advisories/GHSA-38jv-5279-wg99) - related to the `urllib3` package.
 * [CVE-2025-6176](https://nvd.nist.gov/vuln/detail/CVE-2025-6176) - related to the `brotli` package.
 
 
 _Changelog_:
 
 * Updated patch-conda/install.sh
   * Upgraded version for patched python package
     * `cryptography` - _minimum package version has been set to `44.0.1`_
     * `brotli` - _minimum package version has been set to `1.2.0`_
     * `urllib3` - _minimum package version has been set to `2.6.3`_

 * Updated patch-python/install.sh
   * Upgraded version for patched python package
     * `pip` - _upgraded to latest versionn_
     * `setuptools` - _minimum package version has been set to `78.1.1`_
     
 * Added local-feature `patch-python` back in the image build.
 * Small update in test script to test updated versions.
 * Version bump.
 
 **Checklist**:
 
 * [x]   Checked that applied changes work as expected