### PR TITLE
(feat) Update prepare-release.sh to bump patch version in both manifest and README

### DIFF
--- a/src/java/README.md
+++ b/src/java/README.md
@@ -31,11 +31,11 @@ Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/devcontainers/java:2-11` (or `2-11-trixie`, `2-11-bookworm` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/java:2.0-11` (or `2.0-11-trixie`, `2.0-11-bookworm` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/java:2.0.0-11` (or `2.0.0-11-trixie`, `2.0.0-11-bookworm` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/java:3-11` (or `3-11-trixie`, `3-11-bookworm` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/java:3.0-11` (or `3.0-11-trixie`, `3.0-11-bookworm` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/java:3.0.5-11` (or `3.0.0-11-trixie`, `3.0.0-11-bookworm` to pin to an OS version)
 
-However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `2-11`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
+However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `3-11`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/java/tags/list).
 

--- a/src/miniconda/README.md
+++ b/src/miniconda/README.md
@@ -29,8 +29,8 @@ Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/devcontainers/miniconda:1-3`
-- `mcr.microsoft.com/devcontainers/miniconda:1.0-3`
-- `mcr.microsoft.com/devcontainers/miniconda:1.0.0-3`
+- `mcr.microsoft.com/devcontainers/miniconda:1.1-3`
+- `mcr.microsoft.com/devcontainers/miniconda:1.1.0-3`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/miniconda/tags/list).
 


### PR DESCRIPTION
Reduces the manual effort of having to bump patch versions in README files for all images. Tested locally to verify that it works.