### PR TITLE
Manual bump up node feature version to solve yarn issue

### DIFF
--- a/src/anaconda/.devcontainer/devcontainer-lock.json
+++ b/src/anaconda/.devcontainer/devcontainer-lock.json
@@ -6,9 +6,9 @@
       "integrity": "sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251"
     },
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "1.6.4",
-      "resolved": "ghcr.io/devcontainers/features/node@sha256:cc6660d1a249c181d802e02596de6000bf68722a425ed8378afe90f8cf188952",
-      "integrity": "sha256:cc6660d1a249c181d802e02596de6000bf68722a425ed8378afe90f8cf188952"
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
     }
   }
 }

--- a/src/dotnet/.devcontainer/devcontainer-lock.json
+++ b/src/dotnet/.devcontainer/devcontainer-lock.json
@@ -11,9 +11,9 @@
       "integrity": "sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251"
     },
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "1.6.4",
-      "resolved": "ghcr.io/devcontainers/features/node@sha256:cc6660d1a249c181d802e02596de6000bf68722a425ed8378afe90f8cf188952",
-      "integrity": "sha256:cc6660d1a249c181d802e02596de6000bf68722a425ed8378afe90f8cf188952"
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
     }
   }
 }

--- a/src/dotnet/test-project/test.sh
+++ b/src/dotnet/test-project/test.sh
@@ -12,7 +12,8 @@ checkBuild
 check "nuget" dotnet restore
 check "msbuild" dotnet msbuild
 sudo rm -rf obj bin
-check "nvm" bash -c ". /usr/local/share/nvm/nvm.sh && nvm install 10"
+check "nvm" bash -c ". /usr/local/share/nvm/nvm.sh && nvm install 24"
+check "corepack" bash -c ". /usr/local/share/nvm/nvm.sh && corepack enable"
 check "nvm-node" bash -c ". /usr/local/share/nvm/nvm.sh && node --version"
 check "yarn" bash -c ". /usr/local/share/nvm/nvm.sh && yarn --version"
 

--- a/src/go/.devcontainer/devcontainer-lock.json
+++ b/src/go/.devcontainer/devcontainer-lock.json
@@ -16,9 +16,9 @@
       "integrity": "sha256:c93a15310238e947d7f336463c1b9cc989ebc165c5ab6dccc03d75530eaced82"
     },
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "1.6.4",
-      "resolved": "ghcr.io/devcontainers/features/node@sha256:cc6660d1a249c181d802e02596de6000bf68722a425ed8378afe90f8cf188952",
-      "integrity": "sha256:cc6660d1a249c181d802e02596de6000bf68722a425ed8378afe90f8cf188952"
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
     }
   }
 }

--- a/src/go/test-project/test.sh
+++ b/src/go/test-project/test.sh
@@ -8,7 +8,8 @@ checkCommon
 
 # Image specific tests
 check "go" go version
-check "nvm" bash -c ". /usr/local/share/nvm/nvm.sh && nvm install 10"
+check "nvm" bash -c ". /usr/local/share/nvm/nvm.sh && nvm install 24"
+check "corepack" bash -c ". /usr/local/share/nvm/nvm.sh && corepack enable"
 check "nvm-node" bash -c ". /usr/local/share/nvm/nvm.sh && node --version"
 check "yarn" bash -c ". /usr/local/share/nvm/nvm.sh && yarn --version"
 

--- a/src/java-8/.devcontainer/devcontainer-lock.json
+++ b/src/java-8/.devcontainer/devcontainer-lock.json
@@ -11,9 +11,9 @@
       "integrity": "sha256:df67d6ff6e9cdd858207ae9e92a99ddb88384b789f79eecd6f873216e951d286"
     },
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "1.6.4",
-      "resolved": "ghcr.io/devcontainers/features/node@sha256:cc6660d1a249c181d802e02596de6000bf68722a425ed8378afe90f8cf188952",
-      "integrity": "sha256:cc6660d1a249c181d802e02596de6000bf68722a425ed8378afe90f8cf188952"
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
     }
   }
 }

--- a/src/java/.devcontainer/devcontainer-lock.json
+++ b/src/java/.devcontainer/devcontainer-lock.json
@@ -11,9 +11,9 @@
       "integrity": "sha256:df67d6ff6e9cdd858207ae9e92a99ddb88384b789f79eecd6f873216e951d286"
     },
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "1.6.4",
-      "resolved": "ghcr.io/devcontainers/features/node@sha256:cc6660d1a249c181d802e02596de6000bf68722a425ed8378afe90f8cf188952",
-      "integrity": "sha256:cc6660d1a249c181d802e02596de6000bf68722a425ed8378afe90f8cf188952"
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
     }
   }
 }

--- a/src/java/test-project/test.sh
+++ b/src/java/test-project/test.sh
@@ -17,7 +17,8 @@ rm -rf mv maven-wrapper-maven-wrapper-0.5.5
 check "java" java -version
 check "build-and-test-jar" ./mvnw -q package
 check "test-project" java -jar target/my-app-1.0-SNAPSHOT.jar
-check "nvm" bash -c ". /usr/local/share/nvm/nvm.sh && nvm install 10"
+check "nvm" bash -c ". /usr/local/share/nvm/nvm.sh && nvm install 24"
+check "corepack" bash -c ". /usr/local/share/nvm/nvm.sh && corepack enable"
 check "nvm-node" bash -c ". /usr/local/share/nvm/nvm.sh && node --version"
 check "yarn" bash -c ". /usr/local/share/nvm/nvm.sh && yarn --version"
 

--- a/src/javascript-node/.devcontainer/devcontainer-lock.json
+++ b/src/javascript-node/.devcontainer/devcontainer-lock.json
@@ -11,9 +11,9 @@
       "integrity": "sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251"
     },
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "1.6.4",
-      "resolved": "ghcr.io/devcontainers/features/node@sha256:cc6660d1a249c181d802e02596de6000bf68722a425ed8378afe90f8cf188952",
-      "integrity": "sha256:cc6660d1a249c181d802e02596de6000bf68722a425ed8378afe90f8cf188952"
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
     }
   }
 }

--- a/src/jekyll/.devcontainer/devcontainer-lock.json
+++ b/src/jekyll/.devcontainer/devcontainer-lock.json
@@ -6,9 +6,9 @@
       "integrity": "sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251"
     },
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "1.6.4",
-      "resolved": "ghcr.io/devcontainers/features/node@sha256:cc6660d1a249c181d802e02596de6000bf68722a425ed8378afe90f8cf188952",
-      "integrity": "sha256:cc6660d1a249c181d802e02596de6000bf68722a425ed8378afe90f8cf188952"
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
     }
   }
 }

--- a/src/miniconda/.devcontainer/devcontainer-lock.json
+++ b/src/miniconda/.devcontainer/devcontainer-lock.json
@@ -6,9 +6,9 @@
       "integrity": "sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251"
     },
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "1.6.4",
-      "resolved": "ghcr.io/devcontainers/features/node@sha256:cc6660d1a249c181d802e02596de6000bf68722a425ed8378afe90f8cf188952",
-      "integrity": "sha256:cc6660d1a249c181d802e02596de6000bf68722a425ed8378afe90f8cf188952"
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
     },
     "ghcr.io/devcontainers/features/python:1": {
       "version": "1.8.0",

--- a/src/php/.devcontainer/devcontainer-lock.json
+++ b/src/php/.devcontainer/devcontainer-lock.json
@@ -11,9 +11,9 @@
       "integrity": "sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251"
     },
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "1.6.4",
-      "resolved": "ghcr.io/devcontainers/features/node@sha256:cc6660d1a249c181d802e02596de6000bf68722a425ed8378afe90f8cf188952",
-      "integrity": "sha256:cc6660d1a249c181d802e02596de6000bf68722a425ed8378afe90f8cf188952"
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
     }
   }
 }

--- a/src/php/test-project/test.sh
+++ b/src/php/test-project/test.sh
@@ -10,7 +10,8 @@ checkCommon
 check "php" php --version
 check "apache2ctl" which apache2ctl
 
-check "nvm" bash -c ". /usr/local/share/nvm/nvm.sh && nvm install 10"
+check "nvm" bash -c ". /usr/local/share/nvm/nvm.sh && nvm install 24"
+check "corepack" bash -c ". /usr/local/share/nvm/nvm.sh && corepack enable"
 check "nvm-node" bash -c ". /usr/local/share/nvm/nvm.sh && node --version"
 check "yarn" bash -c ". /usr/local/share/nvm/nvm.sh && yarn --version"
 

--- a/src/python/.devcontainer/devcontainer-lock.json
+++ b/src/python/.devcontainer/devcontainer-lock.json
@@ -11,9 +11,9 @@
       "integrity": "sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251"
     },
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "1.6.4",
-      "resolved": "ghcr.io/devcontainers/features/node@sha256:cc6660d1a249c181d802e02596de6000bf68722a425ed8378afe90f8cf188952",
-      "integrity": "sha256:cc6660d1a249c181d802e02596de6000bf68722a425ed8378afe90f8cf188952"
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
     },
     "ghcr.io/devcontainers/features/python:1": {
       "version": "1.8.0",

--- a/src/python/test-project/test.sh
+++ b/src/python/test-project/test.sh
@@ -20,7 +20,8 @@ check "bandit" bandit --version
 check "pipenv" pipenv --version
 check "virtualenv" virtualenv --version
 
-check "nvm" bash -c ". /usr/local/share/nvm/nvm.sh && nvm install 10"
+check "nvm" bash -c ". /usr/local/share/nvm/nvm.sh && nvm install 24"
+check "corepack" bash -c ". /usr/local/share/nvm/nvm.sh && corepack enable"
 check "nvm-node" bash -c ". /usr/local/share/nvm/nvm.sh && node --version"
 check "yarn" bash -c ". /usr/local/share/nvm/nvm.sh && yarn --version"
 

--- a/src/ruby/.devcontainer/devcontainer-lock.json
+++ b/src/ruby/.devcontainer/devcontainer-lock.json
@@ -11,9 +11,9 @@
       "integrity": "sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251"
     },
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "1.6.4",
-      "resolved": "ghcr.io/devcontainers/features/node@sha256:cc6660d1a249c181d802e02596de6000bf68722a425ed8378afe90f8cf188952",
-      "integrity": "sha256:cc6660d1a249c181d802e02596de6000bf68722a425ed8378afe90f8cf188952"
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
     },
     "ghcr.io/devcontainers/features/ruby:1": {
       "version": "1.3.2",

--- a/src/ruby/test-project/test.sh
+++ b/src/ruby/test-project/test.sh
@@ -11,7 +11,8 @@ check "ruby" ruby --version
 check "rvm" rvm --version
 check "gem" gem --version
 
-check "nvm" bash -c ". /usr/local/share/nvm/nvm.sh && nvm install 10"
+check "nvm" bash -c ". /usr/local/share/nvm/nvm.sh && nvm install 24"
+check "corepack" bash -c ". /usr/local/share/nvm/nvm.sh && corepack enable"
 check "nvm-node" bash -c ". /usr/local/share/nvm/nvm.sh && node --version"
 check "yarn" bash -c ". /usr/local/share/nvm/nvm.sh && yarn --version"
 

--- a/src/universal/.devcontainer/devcontainer-lock.json
+++ b/src/universal/.devcontainer/devcontainer-lock.json
@@ -36,9 +36,9 @@
       "integrity": "sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251"
     },
     "ghcr.io/devcontainers/features/github-cli:1": {
-      "version": "1.0.15",
-      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:1ad1ec1a806cc9926c84ca5b147427bba03b97e14e91f9df89af83726039ecaf",
-      "integrity": "sha256:1ad1ec1a806cc9926c84ca5b147427bba03b97e14e91f9df89af83726039ecaf"
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
     },
     "ghcr.io/devcontainers/features/go:1": {
       "version": "1.3.2",
@@ -61,9 +61,9 @@
       "integrity": "sha256:2127a072a351ef5e9ccf5f98284163f14b8ddbf505663a30b0f7ec99fbd0d7a8"
     },
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "1.6.4",
-      "resolved": "ghcr.io/devcontainers/features/node@sha256:cc6660d1a249c181d802e02596de6000bf68722a425ed8378afe90f8cf188952",
-      "integrity": "sha256:cc6660d1a249c181d802e02596de6000bf68722a425ed8378afe90f8cf188952"
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
     },
     "ghcr.io/devcontainers/features/oryx:1": {
       "version": "1.4.1",


### PR DESCRIPTION
**Ref:** #1752 

**Description:** 
- Running `devcontainer upgrade` for all image variants to bump up node feature version `1.7.1` to ensure node dev container feature fixes [1](https://github.com/devcontainers/features/pull/1547) and [2](https://github.com/devcontainers/features/pull/1550) are included in dev build.

- Also fixed failing test scripts to activate `yarn` via `corepack` 

**Changelog:**

- Changes in multiple `devcontainer-lock.json` files as well as failing test scripts.

**Checklist:**
- [x] All checks are passed. 
