### PR TITLE
set xdebug client port to default 9003

### DIFF
--- a/src/php/.devcontainer/Dockerfile
+++ b/src/php/.devcontainer/Dockerfile
@@ -6,7 +6,7 @@ RUN yes | pecl install xdebug \
     && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.mode = debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/xdebug.ini \
-    && echo "xdebug.client_port = 9000" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.client_port = 9003" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && rm -rf /tmp/pear
 
 # Install composer


### PR DESCRIPTION
The default Xdebug port changed between Xdebug v2 to v3 from 9000 to 9003.