### PR TITLE
Add linters in images repository

### DIFF
--- a/.github/linters/.hadolint.yaml
+++ b/.github/linters/.hadolint.yaml
@@ -6,8 +6,8 @@ failure-threshold: "error"
 ignored:
   - DL4001 # Ignore wget and curl in same file
   - DL4006 # ignore pipefail as we don't want to add layers
-  - DL3018 # We do pin version in pipfile.lock
-  - DL3013 # We do pin version in pipfile.lock
+  - DL3018 # Allow unpinned OS package versions (see DL3008 note for APT)
+  - DL3013 # Allow unpinned pip package versions; versions are managed outside the Dockerfile
   - DL3003 # Ignore workdir so we don't add layers
   - SC2016 # ignore as its interpreted later
   - DL3044 # Ignore using env in env

--- a/.github/linters/.hadolint.yaml
+++ b/.github/linters/.hadolint.yaml
@@ -1,0 +1,16 @@
+---
+##########################
+## Hadolint config file ##
+##########################
+failure-threshold: "error"
+ignored:
+  - DL4001 # Ignore wget and curl in same file
+  - DL4006 # ignore pipefail as we don't want to add layers
+  - DL3018 # We do pin version in pipfile.lock
+  - DL3013 # We do pin version in pipfile.lock
+  - DL3003 # Ignore workdir so we don't add layers
+  - SC2016 # ignore as its interpreted later
+  - DL3044 # Ignore using env in env
+  - DL3008 # Ignore pinned versions check for APT
+  - SC3020 # Ignore POSIX check of the shorthand redirection(&>)
+  - SC2283 # Remove spaces around = to assign and this is not needed

--- a/.github/linters/.shellcheckrc
+++ b/.github/linters/.shellcheckrc
@@ -1,0 +1,3 @@
+shell=bash
+disable=SC1101,SC1102
+severity=error

--- a/.github/linters/eslint.config.mjs
+++ b/.github/linters/eslint.config.mjs
@@ -1,0 +1,55 @@
+import { defineConfig } from "eslint/config";
+import { FlatCompat } from "@eslint/eslintrc";
+import js from "@eslint/js";
+import globals from "globals";
+import jsoncParser from "jsonc-eslint-parser";
+
+const compat = new FlatCompat();
+
+export default defineConfig([
+  js.configs.recommended,
+
+  {
+    files: ["**/*.js", "**/*.cjs"],
+    languageOptions: {
+      ecmaVersion: 2021,
+      sourceType: "script",
+      globals: {
+        ...globals.node,
+      },
+    },
+    rules: {
+      "no-undef": "error",
+    },
+  },
+
+  {
+    files: ["build/src/prep.js"],
+    languageOptions: {
+      globals: { scriptLibraryPathInRepo: "readonly" },
+    },          
+  },
+
+  {
+    files: ["build/src/push.js"],
+    rules: {
+      "no-useless-escape": "off",
+    },
+  },
+
+  {
+    files: ["build/src/utils/async.js"],
+    rules: {
+      "no-redeclare": ["error", { builtinGlobals: false }],
+    },
+  },
+
+  ...compat.extends("plugin:jsonc/recommended-with-jsonc"),
+  {
+    files: ["**/*.json"],
+    languageOptions: {
+      parser: jsoncParser,
+      parserOptions: { jsonSyntax: "JSONC" },
+    },
+  },
+]);

--- a/.github/workflows/code-linter.yml
+++ b/.github/workflows/code-linter.yml
@@ -18,7 +18,7 @@ jobs:
     
     - uses: super-linter/super-linter/slim@v8
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.PAT }}
         BASH_SEVERITY: error
         VALIDATE_ALL_CODEBASE: true
         DEFAULT_BRANCH: main

--- a/.github/workflows/code-linter.yml
+++ b/.github/workflows/code-linter.yml
@@ -19,6 +19,7 @@ jobs:
     - uses: super-linter/super-linter/slim@v8
       env:
         GITHUB_TOKEN: ${{ secrets.PAT }}
+        ENABLE_GITHUB_PULL_REQUEST_SUMMARY_COMMENT: false
         BASH_SEVERITY: error
         VALIDATE_ALL_CODEBASE: true
         DEFAULT_BRANCH: main

--- a/.github/workflows/code-linter.yml
+++ b/.github/workflows/code-linter.yml
@@ -18,7 +18,7 @@ jobs:
     
     - uses: super-linter/super-linter/slim@v8
       env:
-        GITHUB_TOKEN: ${{ secrets.PAT }}
+        MULTI_STATUS : false
         ENABLE_GITHUB_PULL_REQUEST_SUMMARY_COMMENT: false
         BASH_SEVERITY: error
         VALIDATE_ALL_CODEBASE: true

--- a/.github/workflows/code-linter.yml
+++ b/.github/workflows/code-linter.yml
@@ -1,4 +1,4 @@
-name: JSON and Dockerfile linter
+name: JSON, shell, javascript and Dockerfile linter
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   code-linter-steps:
-    name: JSON and Dockerfile linter
+    name: JSON, shell, javascript and Dockerfile linter
     runs-on: ubuntu-latest
     
     steps:

--- a/.github/workflows/code-linter.yml
+++ b/.github/workflows/code-linter.yml
@@ -1,0 +1,31 @@
+name: JSON and Dockerfile linter
+
+on:
+  push:
+    branches: 
+      - main
+  pull_request:
+
+jobs:
+  code-linter-steps:
+    name: Json and Dockerfile linter
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0    
+    
+    - uses: super-linter/super-linter/slim@v8
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BASH_SEVERITY: error
+        VALIDATE_ALL_CODEBASE: true
+        DEFAULT_BRANCH: main
+        FILTER_REGEX_INCLUDE: '(^|.*/)(src/.*|build/.*\.js|Dockerfile)$'
+        FILTER_REGEX_EXCLUDE: '(^|.*/)src/.*/test-project(/.*)?$'
+        VALIDATE_DOCKERFILE_HADOLINT: true
+        VALIDATE_JAVASCRIPT_ES: true
+        VALIDATE_JSON: true
+        VALIDATE_BASH: true
+        

--- a/.github/workflows/code-linter.yml
+++ b/.github/workflows/code-linter.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   code-linter-steps:
-    name: Json and Dockerfile linter
+    name: JSON and Dockerfile linter
     runs-on: ubuntu-latest
     
     steps:

--- a/build/src/prep.js
+++ b/build/src/prep.js
@@ -7,7 +7,6 @@ const path = require('path');
 const asyncUtils = require('./utils/async');
 const configUtils = require('./utils/config');
 const handlebars = require('handlebars');
-const mkdirp = require('mkdirp');
 const scriptSHA = {};
 
 const assetsPath = path.join(__dirname, '..', 'assets');


### PR DESCRIPTION
**Description of changes:** As part of this PR adding linters for the following type of files.
- Bash shell scripts excluding the test scripts.
- Dockerfile syntaxes using hadolint
- The source javascript files in build/src location used by the `build/vscdc` component.
- JSON files with JSON and JSONC syntaxes

**Changelog:** The following files are changed.

- Added a new workflow for code linter process
- Added linter configuration files under `.github/linters` location.
- Removed unused import from prep.js for `build/vscdc` component. 

**Checklist:**
- [x] All checks are passed. 
     