### PR TITLE
Fix Yarn GPG key issue in Jekyll Dockerfile

### DIFF
--- a/src/jekyll/.devcontainer/Dockerfile
+++ b/src/jekyll/.devcontainer/Dockerfile
@@ -11,6 +11,12 @@ ENV LANG=en_US.UTF-8 \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US
 
+# Fix Yarn GPG key issue - remove the problematic Yarn repository
+# that has an expired/rotated signing key causing apt-get update to fail
+# See: https://github.com/devcontainers/images/issues/1752
+# Inspired by this PR: https://github.com/dotnet/aspire-devcontainer/pull/7
+RUN rm -f /etc/apt/sources.list.d/yarn.list 2>/dev/null || true
+
 # Install bundler, latest jekyll, and github-pages for older jekyll
 RUN gem update --system
 


### PR DESCRIPTION
My Jekyll-based devcontainers have been failing to build for a month or two (see this [Codespace prebuild log](https://github.com/Rabadash8820/Dansite/actions/runs/23179269576/job/67348504809) for example) due to the Yarn Classic GPG error described in #1752. I'm not really sure why the Jekyll devcontainer is adding the Node feature at all, but if it's going to then I think it should at least remove Yarn Classic since that version is no longer being maintained. This PR accomplishes that by completely removing the Yarn apt repository from the Jekyll devcontainer (inspired by the .NET Aspire team's related PR: dotnet/aspire-devcontainer#7).

I'm not positive if this PR will solve the issue as I wasn't sure how to test it, but hopefully this gets the ball rolling. 👍