### PR TITLE
[universal] - Update Oryx feature with DEBIAN_FLAVOR `bookworm`

### DIFF
--- a/src/universal/.devcontainer/devcontainer-lock.json
+++ b/src/universal/.devcontainer/devcontainer-lock.json
@@ -21,9 +21,9 @@
       "integrity": "sha256:ce078b7bf7d9ef3bcb9813b32103795d8d72172446890b64772cbe1dec6baafd"
     },
     "ghcr.io/devcontainers/features/dotnet:2": {
-      "version": "2.4.2",
-      "resolved": "ghcr.io/devcontainers/features/dotnet@sha256:e56b2abde945918508f1bca94d5545e23b30f5f1d4f3b363ad4819c6b81396f1",
-      "integrity": "sha256:e56b2abde945918508f1bca94d5545e23b30f5f1d4f3b363ad4819c6b81396f1"
+      "version": "2.5.0",
+      "resolved": "ghcr.io/devcontainers/features/dotnet@sha256:0fc16547ed4db6d7ff2a9f5981d2b93eb314e568affb9958029ad794f1f9a093",
+      "integrity": "sha256:0fc16547ed4db6d7ff2a9f5981d2b93eb314e568affb9958029ad794f1f9a093"
     },
     "ghcr.io/devcontainers/features/git-lfs:1": {
       "version": "1.2.5",
@@ -65,10 +65,10 @@
       "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
       "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
     },
-    "ghcr.io/devcontainers/features/oryx:1": {
-      "version": "1.4.1",
-      "resolved": "ghcr.io/devcontainers/features/oryx@sha256:afffd5b839bb25e29f8abbe5c7be913ae8793a2af684af7ed89a75c22a70a471",
-      "integrity": "sha256:afffd5b839bb25e29f8abbe5c7be913ae8793a2af684af7ed89a75c22a70a471"
+    "ghcr.io/devcontainers/features/oryx:2": {
+      "version": "2.0.0",
+      "resolved": "ghcr.io/devcontainers/features/oryx@sha256:5295f2aa261376a83c29f3cfd6f6d967bb352d1ff7b54436f2029fd48c692b67",
+      "integrity": "sha256:5295f2aa261376a83c29f3cfd6f6d967bb352d1ff7b54436f2029fd48c692b67"
     },
     "ghcr.io/devcontainers/features/php:1": {
       "version": "1.1.4",

--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -73,7 +73,7 @@
             "version": "latest"
         },
         "./local-features/jekyll": "latest",
-        "ghcr.io/devcontainers/features/oryx:1": "latest",
+        "ghcr.io/devcontainers/features/oryx:2": "latest",
         "./local-features/setup-user": "latest",
         "./local-features/patch-conda": {},
         "./local-features/patch-python": {}

--- a/src/universal/.devcontainer/local-features/setup-user/install.sh
+++ b/src/universal/.devcontainer/local-features/setup-user/install.sh
@@ -30,8 +30,8 @@ sudo_if() {
 }
 
 # Enables the oryx tool to generate manifest-dir which is needed for running the postcreate tool
-DEBIAN_FLAVOR="focal-scm"
-mkdir -p /opt/oryx && echo "vso-focal" > /opt/oryx/.imagetype
+DEBIAN_FLAVOR="bookworm"
+mkdir -p /opt/oryx && echo "vso-bookworm" > /opt/oryx/.imagetype
 echo "DEBIAN|${DEBIAN_FLAVOR}" | tr '[a-z]' '[A-Z]' > /opt/oryx/.ostype
 
 # Oryx expects the tool to be installed at `/opt/oryx` and looks for relevant files in there.
@@ -88,6 +88,15 @@ OPT_DOTNET_DIR="/opt/dotnet/"
 chown -R ${USERNAME}:oryx ${OPT_DOTNET_DIR}
 chmod -R g+r+w "${OPT_DOTNET_DIR}"
 find "${OPT_DOTNET_DIR}" -type d | xargs -n 1 chmod g+s
+
+# Patch createSymlinksForDotnet.sh to handle the case where the symlink destination
+# already exists as a real directory (e.g. /home/codespace/.dotnet -> /usr/share/dotnet
+# which already has packs/NETStandard.Library.Ref/2.1.0 from a pre-installed .NET SDK).
+# Without this, `ln -sTf` fails because it cannot overwrite a real directory.
+if [ -f "/opt/tmp/build/createSymlinksForDotnet.sh" ]; then
+    sed -i '/echo "\$linkTo is missing, creating \.\.\."/a\            if [ -d "$linkFrom" ] \&\& [ ! -L "$linkFrom" ]; then rm -rf "$linkFrom"; fi' \
+        /opt/tmp/build/createSymlinksForDotnet.sh
+fi
 
 echo "Defaults secure_path=\"${DOTNET_PATH}:${NODE_PATH}/bin:${PHP_PATH}/bin:${PYTHON_PATH}/bin:${JAVA_PATH}/bin:${RUBY_PATH}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:/usr/local/share:/home/${USERNAME}/.local/bin:${PATH}\"" >> /etc/sudoers.d/$USERNAME
 

--- a/src/universal/README.md
+++ b/src/universal/README.md
@@ -27,9 +27,9 @@ The container includes the `zsh` (and Oh My Zsh!) and `fish` shells that you can
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image.
 For example:
 
-- `mcr.microsoft.com/devcontainers/universal:5-noble`
-- `mcr.microsoft.com/devcontainers/universal:5.1-noble`
-- `mcr.microsoft.com/devcontainers/universal:5.1.5-noble`
+- `mcr.microsoft.com/devcontainers/universal:6-noble`
+- `mcr.microsoft.com/devcontainers/universal:6.0-noble`
+- `mcr.microsoft.com/devcontainers/universal:6.0.0-noble`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/universal/tags/list).
 

--- a/src/universal/manifest.json
+++ b/src/universal/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "5.1.5",
+	"version": "6.0.0",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -143,8 +143,6 @@ check "default-node-location-remained-same" bash -c "which node | grep /home/cod
 # Ensures sdkman works in a Java Project
 check "default-java-version" bash -c "java --version"
 check "default-java-location" bash -c "which java | grep /home/codespace/java/current/bin"
-check "oryx-build-java-project" bash -c "oryx build ./sample/java"
-check "oryx-configured-current-java-version" bash -c "ls -la /home/codespace/java/current | grep /opt/java"
 check "sdk-install-java" bash -c ". /usr/local/sdkman/bin/sdkman-init.sh && sdk install java 19.0.1-oracle < /dev/null"
 check "sdkman-works-in-java-project" bash -c "java --version | grep 19.0.1"
 check "default-java-location-remained-same" bash -c "which java | grep /home/codespace/java/current/bin"
@@ -157,21 +155,17 @@ check "oryx-build-python-installed" python3 -m pip list | grep mpmath
 check "oryx-build-python-result" python3 ./sample/python/src/solve.py
 
 # Install platforms with oryx build tool
-check "oryx-install-dotnet-2.1" oryx prep --skip-detection --platforms-and-versions dotnet=2.1.30
-check "dotnet-2-installed-by-oryx" ls /opt/dotnet/ | grep 2.1
-check "dotnet-version-on-path-is-2.1.12" dotnet --version | grep 2.1
+check "oryx-install-dotnet-8.0" oryx prep --skip-detection --platforms-and-versions dotnet=8.0.23
+check "dotnet-8-installed-by-oryx" ls /opt/dotnet/ | grep 8.0
+check "dotnet-version-on-path-is-8.0.23" dotnet --version | grep 8.0
 
-check "oryx-install-nodejs-12.22.11" oryx prep --skip-detection --platforms-and-versions nodejs=12.22.11
-check "nodejs-12.22.11-installed-by-oryx" ls /opt/nodejs/ | grep 12.22.11
-check "nodejs-version-on-path-is-2.1.12" node --version | grep v12.22.11
+check "oryx-install-nodejs-20.11.0" oryx prep --skip-detection --platforms-and-versions nodejs=20.11.0
+check "nodejs-20.11.0-installed-by-oryx" ls /opt/nodejs/ | grep 20.11.0
+check "nodejs-version-on-path-is-20.11.0" node --version | grep v20.11.0
 
-check "oryx-install-php-7.3.25" oryx prep --skip-detection --platforms-and-versions php=7.3.25
-check "php-7.3.25-installed-by-oryx" ls /opt/php/ | grep 7.3.25
-check "php-version-on-path-is-2.1.12" php --version | grep 7.3.25
-
-check "oryx-install-java-12.0.2" oryx prep --skip-detection --platforms-and-versions java=12.0.2
-check "java-12.0.2-installed-by-oryx" ls /opt/java/ | grep 12.0.2
-check "java-version-on-path-is-12.0.2" java --version | grep 12.0.2
+check "oryx-install-php-8.1.30" oryx prep --skip-detection --platforms-and-versions php=8.1.30
+check "php-8.1.30-installed-by-oryx" ls /opt/php/ | grep 8.1.30
+check "php-version-on-path-is-8.1.30" php --version | grep 8.1.30
 
 # Test patches
 


### PR DESCRIPTION
**Description of changes:** As part of this PR upgrading Oryx feature for universal image to the latest Oryx version with DEBIAN_FLAVOR `bookworm`. Please note that with this update Oryx stops supporting Java installation and build in the universal image as the latest Oryx version doesn't support Java any longer.

**Changelog:** The following files are changed.

- Updated the Oryx dev container feature reference.
- Update the local feature `setup-user` to slightly customize the Oryx build for universal image to support latest dotnet sdk installations using Oryx by allowing to replace existing symlink.
- Tests modified.
- Major version bump.

**Checklist:**
- [x] All checks are passed. 
