### PR TITLE
[universal] - Update toolings and vulnerability fix

### DIFF
--- a/.github/linters/eslint.config.mjs
+++ b/.github/linters/eslint.config.mjs
@@ -2,7 +2,7 @@ import { defineConfig } from "eslint/config";
 import { FlatCompat } from "@eslint/eslintrc";
 import js from "@eslint/js";
 import globals from "globals";
-import jsoncParser from "jsonc-eslint-parser";
+import * as jsoncParser from "jsonc-eslint-parser";
 
 const compat = new FlatCompat();
 

--- a/.github/linters/eslint.config.mjs
+++ b/.github/linters/eslint.config.mjs
@@ -1,10 +1,7 @@
 import { defineConfig } from "eslint/config";
-import { FlatCompat } from "@eslint/eslintrc";
 import js from "@eslint/js";
 import globals from "globals";
-import * as jsoncParser from "jsonc-eslint-parser";
-
-const compat = new FlatCompat();
+import jsoncPlugin from "eslint-plugin-jsonc";
 
 export default defineConfig([
   js.configs.recommended,
@@ -44,12 +41,5 @@ export default defineConfig([
     },
   },
 
-  ...compat.extends("plugin:jsonc/recommended-with-jsonc"),
-  {
-    files: ["**/*.json"],
-    languageOptions: {
-      parser: jsoncParser,
-      parserOptions: { jsonSyntax: "JSONC" },
-    },
-  },
+  ...jsoncPlugin.configs["flat/recommended-with-jsonc"],
 ]);

--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -23,8 +23,8 @@
         },
         "./local-features/nvs": "latest",
         "ghcr.io/devcontainers/features/python:1": {
-            "version": "3.12.1",
-            "additionalVersions": "3.11.9",
+            "version": "3.14.2",
+            "additionalVersions": "3.13.8",
             "installJupyterlab": "true",
             "configureJupyterlabAllowOrigin": "*",
             "useOryxIfAvailable": "false"
@@ -38,8 +38,8 @@
             "version": "latest"
         },
         "ghcr.io/devcontainers/features/ruby:1": {
-            "version": "3.4.7",
-            "additionalVersions": "3.3.10"
+            "version": "3.4.9",
+            "additionalVersions": "3.3.11"
         },
         "ghcr.io/devcontainers/features/java:1": {
             "version": "25",

--- a/src/universal/.devcontainer/local-features/patch-conda/install.sh
+++ b/src/universal/.devcontainer/local-features/patch-conda/install.sh
@@ -51,10 +51,10 @@ sudo_if /opt/conda/bin/python3 -m pip install --upgrade pip
 # Temporary: Upgrade python packages due to security vulnerabilities
 # They are installed by the conda feature and Conda distribution does not have the patches
 
-# https://github.com/advisories/GHSA-79v4-65xg-pq4g
-update_python_package /opt/conda/bin/python3 cryptography "44.0.1"
+# https://github.com/advisories/GHSA-r6ph-v2qm-q3c2
+update_conda_package pyopenssl "26.0.0"
 
-update_conda_package pyopenssl "25.0.0"
+update_python_package /opt/conda/bin/python3 cryptography "46.0.5"
 
 # https://github.com/advisories/GHSA-9hjg-9r4m-mvj7
 update_conda_package requests "2.32.4"

--- a/src/universal/.devcontainer/local-features/patch-conda/install.sh
+++ b/src/universal/.devcontainer/local-features/patch-conda/install.sh
@@ -54,7 +54,7 @@ sudo_if /opt/conda/bin/python3 -m pip install --upgrade pip
 # https://github.com/advisories/GHSA-r6ph-v2qm-q3c2
 update_conda_package pyopenssl "26.0.0"
 
-update_python_package /opt/conda/bin/python3 cryptography "46.0.5"
+update_conda_package cryptography "46.0.5"
 
 # https://github.com/advisories/GHSA-9hjg-9r4m-mvj7
 update_conda_package requests "2.32.4"

--- a/src/universal/.devcontainer/local-features/patch-python/install.sh
+++ b/src/universal/.devcontainer/local-features/patch-python/install.sh
@@ -38,9 +38,3 @@ update_package() {
     sudo_if "$PYTHON_PATH -m pip install --upgrade --no-cache-dir $PACKAGE==$VERSION"
     sudo_if "$PYTHON_PATH -m pip show --no-python-version-warning $PACKAGE"
 }
-# Updating pip version for python 3.11. Must be removed when pinned version 3.11 is updated to a different python version.
-sudo_if /usr/local/python/3.11.*/bin/python -m pip install --upgrade pip
-
-# https://github.com/advisories/GHSA-5rjg-fvgr-3xxf
-# Updating setuptools version for python 3.11. Must be removed when pinned version 3.11 is updated to a different python version.
-update_package /usr/local/python/3.11.*/bin/python setuptools "78.1.1"

--- a/src/universal/README.md
+++ b/src/universal/README.md
@@ -29,7 +29,7 @@ For example:
 
 - `mcr.microsoft.com/devcontainers/universal:6-noble`
 - `mcr.microsoft.com/devcontainers/universal:6.0-noble`
-- `mcr.microsoft.com/devcontainers/universal:6.0.0-noble`
+- `mcr.microsoft.com/devcontainers/universal:6.0.1-noble`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/universal/tags/list).
 

--- a/src/universal/manifest.json
+++ b/src/universal/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "6.0.0",
+	"version": "6.0.1",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -175,15 +175,10 @@ ls -la /home/codespace
 checkPythonPackageVersion "python" "setuptools" "78.1.1"
 checkPythonPackageVersion "python" "requests" "2.31.0"
 
-## Python -alternative version 3.11. Must be removed when pinned version 3.11 is updated to a different python version.
-checkPythonPackageVersion "/usr/local/python/3.11.*/bin/python" "setuptools" "78.1.1"
-pip_version_3_11=$(/usr/local/python/3.11.*/bin/python -m pip --version)
-check-version-ge "pip-version-for-3.11" "${pip_version_3_11}" "pip 25.3"
-
 ## Conda Python
 checkCondaPackageVersion "requests" "2.31.0"
-checkCondaPackageVersion "cryptography" "44.0.1"
-checkCondaPackageVersion "pyopenssl" "25.0.0"
+checkCondaPackageVersion "cryptography" "46.0.5"
+checkCondaPackageVersion "pyopenssl" "26.0.0"
 checkCondaPackageVersion "urllib3" "2.6.3"
 checkCondaPackageVersion "brotli" "1.2.0"
 


### PR DESCRIPTION
**Changelog:** The following files are changed.

- Updated the versions of python and ruby
- Fix for vulnerability issue [GHSA-r6ph-v2qm-q3c2](https://github.com/advisories/GHSA-r6ph-v2qm-q3c2) for universal image. 
- Tests modified.
- Version bump.
- JSON linter started failing with ESLint error due to update in super-linter@v8 action to ESLint `9.39.2+` where `jsonc-eslint-parser` dropped its default export, breaking the old import `jsoncParser` from `jsonc-eslint-parser`. Using FlatCompat as a workaround then caused a circular structure error. The native flat config avoids both issues. Removed `@eslint/eslintrc (FlatCompat)` and `jsonc-eslint-parser` imports as both are no longer needed. Added direct import of `eslint-plugin-jsonc`, which natively supports ESLint flat config.

**Checklist:**
- [x] All checks are passed. 
