### PR TITLE
[universal] - Update conda feature and remove obsolete openssl 1.1 installation logic 

### DIFF
--- a/src/universal/.devcontainer/Dockerfile
+++ b/src/universal/.devcontainer/Dockerfile
@@ -15,6 +15,27 @@ COPY first-run-notice.txt /tmp/scripts/
 
 ENV LANG="C.UTF-8"
 
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Switch apt sources to HTTPS and add retry/timeout settings
+# Bootstrap: install ca-certificates with temporary cert verification bypass,
+# then switch to fully verified HTTPS for all subsequent apt operations
+RUN printf 'Acquire::https::Verify-Peer "false";\nAcquire::Retries "5";\nAcquire::ForceIPv4 "true";\n' \
+        > /etc/apt/apt.conf.d/99-bootstrap \
+    && if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then \
+        sed -i 's|http://archive.ubuntu.com|https://archive.ubuntu.com|g; s|http://security.ubuntu.com|https://security.ubuntu.com|g' \
+            /etc/apt/sources.list.d/ubuntu.sources; \
+    elif [ -f /etc/apt/sources.list ]; then \
+        sed -i 's|http://archive.ubuntu.com|https://archive.ubuntu.com|g; s|http://security.ubuntu.com|https://security.ubuntu.com|g' \
+            /etc/apt/sources.list; \
+    fi \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -f /etc/apt/apt.conf.d/99-bootstrap \
+    && printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\nAcquire::ForceIPv4 "true";\n' \
+        > /etc/apt/apt.conf.d/80-network-retries \
+    && rm -rf /var/lib/apt/lists/*
+
 #Merging the mutiple layers to reduce the size of the image slightly
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     # Restore man command
@@ -60,14 +81,10 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
         curl \
         gettext \
         inotify-tools \
-    && rm -rf /var/lib/apt/lists/* \
-    # This is the folder containing 'links' to benv and build script generator
-    && apt-get update \
-    && apt-get upgrade -y \
+    # Add universe repo
     && add-apt-repository universe \
-    && rm -rf /var/lib/apt/lists/* \
-    # Verify expected build and debug tools are present
     && apt-get update \
+    # Verify expected build and debug tools are present
     && apt-get -y install build-essential cmake cppcheck valgrind clang lldb llvm gdb python3-dev \
     # Install tools and shells not in common script
     && apt-get install -yq vim vim-doc xtail software-properties-common libsecret-1-dev \
@@ -83,20 +100,6 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && printf "if type code-insiders > /dev/null 2>&1; and not type code > /dev/null 2>&1\n  alias code=code-insiders\nend" >> /etc/fish/conf.d/code_alias.fish \   
     # Remove scripts now that we're done with them
     && apt-get clean -y && rm -rf /tmp/scripts
-
-# Install libssl1.1 for oryx compatibility based on architecture
-RUN ARCH=$(uname -m) && \
-    if [ "$ARCH" = "x86_64" ] || [ "$ARCH" = "amd64" ]; then \
-        curl -fsSL -o libssl1.1_1.1.0g-2ubuntu4_amd64.deb http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb && \
-        dpkg -i libssl1.1_1.1.0g-2ubuntu4_amd64.deb && \
-        rm libssl1.1_1.1.0g-2ubuntu4_amd64.deb; \
-    elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then \
-        curl -fsSL -o libssl1.1_1.1.1f-1ubuntu2_arm64.deb http://ports.ubuntu.com/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_arm64.deb && \
-        dpkg -i libssl1.1_1.1.1f-1ubuntu2_arm64.deb && \
-        rm libssl1.1_1.1.1f-1ubuntu2_arm64.deb; \
-    else \
-        echo "Unsupported architecture: $ARCH" && exit 1; \
-    fi
 
 # Default to bash shell (other shells available at /usr/bin/fish and /usr/bin/zsh)
 ENV SHELL=/bin/bash \

--- a/src/universal/.devcontainer/Dockerfile
+++ b/src/universal/.devcontainer/Dockerfile
@@ -15,27 +15,6 @@ COPY first-run-notice.txt /tmp/scripts/
 
 ENV LANG="C.UTF-8"
 
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Switch apt sources to HTTPS and add retry/timeout settings
-# Bootstrap: install ca-certificates with temporary cert verification bypass,
-# then switch to fully verified HTTPS for all subsequent apt operations
-RUN printf 'Acquire::https::Verify-Peer "false";\nAcquire::Retries "5";\nAcquire::ForceIPv4 "true";\n' \
-        > /etc/apt/apt.conf.d/99-bootstrap \
-    && if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then \
-        sed -i 's|http://archive.ubuntu.com|https://archive.ubuntu.com|g; s|http://security.ubuntu.com|https://security.ubuntu.com|g' \
-            /etc/apt/sources.list.d/ubuntu.sources; \
-    elif [ -f /etc/apt/sources.list ]; then \
-        sed -i 's|http://archive.ubuntu.com|https://archive.ubuntu.com|g; s|http://security.ubuntu.com|https://security.ubuntu.com|g' \
-            /etc/apt/sources.list; \
-    fi \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates \
-    && rm -f /etc/apt/apt.conf.d/99-bootstrap \
-    && printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\nAcquire::ForceIPv4 "true";\n' \
-        > /etc/apt/apt.conf.d/80-network-retries \
-    && rm -rf /var/lib/apt/lists/*
-
 #Merging the mutiple layers to reduce the size of the image slightly
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     # Restore man command
@@ -81,10 +60,14 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
         curl \
         gettext \
         inotify-tools \
-    # Add universe repo
-    && add-apt-repository universe \
+    && rm -rf /var/lib/apt/lists/* \
+    # This is the folder containing 'links' to benv and build script generator
     && apt-get update \
+    && apt-get upgrade -y \
+    && add-apt-repository universe \
+    && rm -rf /var/lib/apt/lists/* \
     # Verify expected build and debug tools are present
+    && apt-get update \
     && apt-get -y install build-essential cmake cppcheck valgrind clang lldb llvm gdb python3-dev \
     # Install tools and shells not in common script
     && apt-get install -yq vim vim-doc xtail software-properties-common libsecret-1-dev \

--- a/src/universal/.devcontainer/devcontainer-lock.json
+++ b/src/universal/.devcontainer/devcontainer-lock.json
@@ -5,10 +5,10 @@
       "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:dbf431d6b42d55cde50fa1df75c7f7c3999a90cde6d73f7a7071174b3c3d0cc4",
       "integrity": "sha256:dbf431d6b42d55cde50fa1df75c7f7c3999a90cde6d73f7a7071174b3c3d0cc4"
     },
-    "ghcr.io/devcontainers/features/conda:1": {
-      "version": "1.2.5",
-      "resolved": "ghcr.io/devcontainers/features/conda@sha256:d189cf17997854b28c7ffbab5db70f9b7d70332d97dfbf44447e48e958a03c8b",
-      "integrity": "sha256:d189cf17997854b28c7ffbab5db70f9b7d70332d97dfbf44447e48e958a03c8b"
+    "ghcr.io/devcontainers/features/conda:2": {
+      "version": "2.0.1",
+      "resolved": "ghcr.io/devcontainers/features/conda@sha256:f5f3e5b96a33a90377eba3be0fdba7aef6a128b5702571e1f586b2c9e0083840",
+      "integrity": "sha256:f5f3e5b96a33a90377eba3be0fdba7aef6a128b5702571e1f586b2c9e0083840"
     },
     "ghcr.io/devcontainers/features/copilot-cli:1": {
       "version": "1.0.0",
@@ -51,9 +51,9 @@
       "integrity": "sha256:15465c956810aa164c9644b6df5ca36f6cac3e7a86b7dcc474a1fb830b21c509"
     },
     "ghcr.io/devcontainers/features/java:1": {
-      "version": "1.7.2",
-      "resolved": "ghcr.io/devcontainers/features/java@sha256:e75d274ac969b29a59ba6f34c2d098f6a52144d0ec027ef326b724ea4b8b7b4e",
-      "integrity": "sha256:e75d274ac969b29a59ba6f34c2d098f6a52144d0ec027ef326b724ea4b8b7b4e"
+      "version": "1.8.0",
+      "resolved": "ghcr.io/devcontainers/features/java@sha256:9663ce0219ff85786e87901ce5f0a59f488edd5f99b46015192cda48468b233a",
+      "integrity": "sha256:9663ce0219ff85786e87901ce5f0a59f488edd5f99b46015192cda48468b233a"
     },
     "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
       "version": "1.3.1",

--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -34,7 +34,7 @@
             "additionalVersions": "8.4.15",
             "installComposer": "true"
         },
-        "ghcr.io/devcontainers/features/conda:1": {
+        "ghcr.io/devcontainers/features/conda:2": {
             "version": "latest"
         },
         "ghcr.io/devcontainers/features/ruby:1": {

--- a/src/universal/.devcontainer/local-features/patch-conda/install.sh
+++ b/src/universal/.devcontainer/local-features/patch-conda/install.sh
@@ -20,6 +20,8 @@ chmod +x /etc/profile.d/00-restore-env.sh
 
 export DEBIAN_FRONTEND=noninteractive
 
+CONDA_DIR="/opt/conda"
+
 sudo_if() {
     COMMAND="$*"
     if [ "$(id -u)" -eq 0 ] && [ "$USERNAME" != "root" ]; then
@@ -51,22 +53,14 @@ sudo_if /opt/conda/bin/python3 -m pip install --upgrade pip
 # Temporary: Upgrade python packages due to security vulnerabilities
 # They are installed by the conda feature and Conda distribution does not have the patches
 
+if ! "${CONDA_DIR}/bin/conda" tos --help > /dev/null 2>&1; then
+    echo "not fullfilled"
+fi
+
 # https://github.com/advisories/GHSA-r6ph-v2qm-q3c2
 update_conda_package pyopenssl "26.0.0"
 
 update_conda_package cryptography "46.0.5"
-
-# https://github.com/advisories/GHSA-9hjg-9r4m-mvj7
-update_conda_package requests "2.32.4"
-
-# https://github.com/advisories/GHSA-5rjg-fvgr-3xxf
-update_conda_package setuptools "78.1.1"
-
-# https://github.com/advisories/GHSA-g7vv-2v7x-gj9p
-update_python_package /opt/conda/bin/python3 tqdm "4.66.3"
-
-# https://github.com/advisories/GHSA-38jv-5279-wg99
-update_conda_package urllib3 "2.6.3"
 
 # https://nvd.nist.gov/vuln/detail/CVE-2025-6176
 update_conda_package brotli "1.2.0"

--- a/src/universal/.devcontainer/local-features/patch-conda/install.sh
+++ b/src/universal/.devcontainer/local-features/patch-conda/install.sh
@@ -20,8 +20,6 @@ chmod +x /etc/profile.d/00-restore-env.sh
 
 export DEBIAN_FRONTEND=noninteractive
 
-CONDA_DIR="/opt/conda"
-
 sudo_if() {
     COMMAND="$*"
     if [ "$(id -u)" -eq 0 ] && [ "$USERNAME" != "root" ]; then
@@ -52,10 +50,6 @@ sudo_if /opt/conda/bin/python3 -m pip install --upgrade pip
 
 # Temporary: Upgrade python packages due to security vulnerabilities
 # They are installed by the conda feature and Conda distribution does not have the patches
-
-if ! "${CONDA_DIR}/bin/conda" tos --help > /dev/null 2>&1; then
-    echo "not fullfilled"
-fi
 
 # https://github.com/advisories/GHSA-r6ph-v2qm-q3c2
 update_conda_package pyopenssl "26.0.0"

--- a/src/universal/manifest.json
+++ b/src/universal/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "6.0.1",
+	"version": "6.0.2",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",


### PR DESCRIPTION
**Changelog:** The following files are changed.

- Update conda feature reference in devcontainer.json and devcontainer-lock.json to solve universal image build issue.
- Remove obsolete openssl 1.1 installation logic from Dockerfile which is not needed any longer as Oryx has already been updated.
- Version bump.
- Remove unwanted python library installation steps using conda as the libraries are already updated with the conda upgrade.

**Checklist:**
- [x] All checks are passed. 
