### PR TITLE
Adding bubblewrap and socat as these are dependencies for sandboxing.

### DIFF
--- a/src/universal/.devcontainer/Dockerfile
+++ b/src/universal/.devcontainer/Dockerfile
@@ -60,6 +60,8 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
         curl \
         gettext \
         inotify-tools \
+        bubblewrap \
+        socat \
     && rm -rf /var/lib/apt/lists/* \
     # This is the folder containing 'links' to benv and build script generator
     && apt-get update \

--- a/src/universal/.devcontainer/Dockerfile
+++ b/src/universal/.devcontainer/Dockerfile
@@ -60,8 +60,6 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
         curl \
         gettext \
         inotify-tools \
-        bubblewrap \
-        socat \
     && rm -rf /var/lib/apt/lists/* \
     # This is the folder containing 'links' to benv and build script generator
     && apt-get update \

--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -9,6 +9,9 @@
             "userUid": "1000",
             "userGid": "1000"
         },
+        "ghcr.io/devcontainers-extra/features/apt-packages:1": {
+            "packages": "bubblewrap, socat"
+        },
         "ghcr.io/devcontainers/features/dotnet:2": {
             "version": "10.0",
             "dotnetRuntimeVersions": "9.0", 
@@ -80,6 +83,7 @@
     },
     "overrideFeatureInstallOrder": [
         "ghcr.io/devcontainers/features/common-utils",
+        "ghcr.io/devcontainers-extra/features/apt-packages",
         "ghcr.io/devcontainers/features/git",
         "ghcr.io/devcontainers/features/dotnet",
         "ghcr.io/devcontainers/features/hugo",

--- a/src/universal/manifest.json
+++ b/src/universal/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "6.0.3",
+	"version": "6.0.4",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/src/universal/test-project/test-utils.sh
+++ b/src/universal/test-project/test-utils.sh
@@ -131,7 +131,9 @@ checkCommon()
         locales \
         gettext \
         sudo \
-        inotify-tools"
+        inotify-tools \
+        bubblewrap \
+        socat"
 
     # Actual tests
     checkOSPackages "common-os-packages" ${PACKAGE_LIST}


### PR DESCRIPTION
For sandboxing in vscode, bubblewrap and socat are dependency packages needed to be available.