### PR TITLE
[miniconda]- security update for cryptography (GHSA-m959-cc7f-wv43) 

### DIFF
--- a/src/miniconda/.devcontainer/apply_security_patches.sh
+++ b/src/miniconda/.devcontainer/apply_security_patches.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # vulnerablities 
-# cryptography - [GHSA-h4gh-qq45-vh27]
+# cryptography - [GHSA-m959-cc7f-wv43]
 
 # define array of packages for pinning to the patched versions
 # patched_package_versions=( "package1=version1" "package2=version2" "package3=version3" )

--- a/src/miniconda/.devcontainer/apply_security_patches.sh
+++ b/src/miniconda/.devcontainer/apply_security_patches.sh
@@ -5,10 +5,10 @@
 
 # define array of packages for pinning to the patched versions
 # vulnerable_packages=( "package1=version1" "package2=version2" "package3=version3" )
-vulnerable_packages=( "cryptography=44.0.1" "requests=2.32.4" "urllib3=2.5.0" )
+patched_package_versions=( "cryptography=46.0.6" "requests=2.32.4" "urllib3=2.5.0")
 
-# Define the number of rows (based on the length of vulnerable_packages)
-rows=${#vulnerable_packages[@]}
+# Define the number of rows (based on the length of patched_package_versions)
+rows=${#patched_package_versions[@]}
 
 if [ $rows -gt 0 ]; then
     # Define the number of columns
@@ -17,8 +17,8 @@ if [ $rows -gt 0 ]; then
     declare -A packages_array
     # Fill the 2D array
     for ((i=0; i<rows; i++)); do
-        # Split each element of vulnerable_packages by the '=' sign
-        IFS='=' read -ra parts <<< "${vulnerable_packages[$i]}"
+        # Split each element of patched_package_versions by the '=' sign
+        IFS='=' read -ra parts <<< "${patched_package_versions[$i]}"
         # Assign the parts to the 2D array
         packages_array[$i,0]=${parts[0]}
         packages_array[$i,1]=${parts[1]}

--- a/src/miniconda/.devcontainer/apply_security_patches.sh
+++ b/src/miniconda/.devcontainer/apply_security_patches.sh
@@ -4,7 +4,7 @@
 # cryptography - [GHSA-h4gh-qq45-vh27]
 
 # define array of packages for pinning to the patched versions
-# vulnerable_packages=( "package1=version1" "package2=version2" "package3=version3" )
+# patched_package_versions=( "package1=version1" "package2=version2" "package3=version3" )
 patched_package_versions=( "cryptography=46.0.6" "requests=2.32.4" "urllib3=2.5.0")
 
 # Define the number of rows (based on the length of patched_package_versions)

--- a/src/miniconda/README.md
+++ b/src/miniconda/README.md
@@ -30,7 +30,7 @@ You can decide how often you want updates by referencing a [semantic version](ht
 
 - `mcr.microsoft.com/devcontainers/miniconda:1-3`
 - `mcr.microsoft.com/devcontainers/miniconda:1.2-3`
-- `mcr.microsoft.com/devcontainers/miniconda:1.2.4-3`
+- `mcr.microsoft.com/devcontainers/miniconda:1.2.5-3`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/miniconda/tags/list).
 

--- a/src/miniconda/manifest.json
+++ b/src/miniconda/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "1.2.4",
+	"version": "1.2.5",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/src/miniconda/test-project/test.sh
+++ b/src/miniconda/test-project/test.sh
@@ -18,12 +18,12 @@ check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcont
 
 check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
 
-checkPythonPackageVersion "cryptography" "44.0.1"
+checkPythonPackageVersion "cryptography" "46.0.6"
 checkPythonPackageVersion "setuptools" "65.5.1"
 checkPythonPackageVersion "wheel" "0.38.1"
 checkPythonPackageVersion "urllib3" "2.5.0"
 
-checkCondaPackageVersion "cryptography" "44.0.1"
+checkCondaPackageVersion "cryptography" "46.0.6"
 checkCondaPackageVersion "setuptools" "65.5.1"
 checkCondaPackageVersion "wheel" "0.38.1"
 checkCondaPackageVersion "requests" "2.32.4"


### PR DESCRIPTION
Update cryptography package version to 46.0.6 and increment manifest version to 1.2.5

GHSA ID | Vulnerability ID | Action | Package | Installed Version | Required Version | Language | Install Path/ Note | Image Digest
-- | -- | -- | -- | -- | -- | -- | -- | --
Python (Pip) Security Update for cryptography (GHSA-m959-cc7f-wv43) | 5010145 | Y | cryptography | 46.0.5 | 46.0.6 | Python | opt/conda/lib/python3.13/site-packages/cryptography-46.0.5.dist-info/METADATA | sha256:da12786874c65d67f7ce12d0f9c9dc4158665a99a31f8af3777d589e6edc9a12