### PR TITLE
Security updates for GHSA-58pv-8j8x-9vj2: jaraco.context and GHSA-8rrh-rw8j-w5fx: wheel 

### DIFF
--- a/src/python/manifest.json
+++ b/src/python/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "3.0.8",
+	"version": "3.0.9",
 	"variants": [
 		"3.14-trixie",
 		"3.13-trixie",

--- a/src/python/test-project/test.sh
+++ b/src/python/test-project/test.sh
@@ -51,5 +51,13 @@ check-version-ge "setuptools-requirement" "${setuptools_version}" "78.1.1"
 gitpython_version=$(python -c "import git; print(git.__version__)")
 check-version-ge "gitpython-requirement" "${gitpython_version}" "3.1.41"
 
+# GHSA-58pv-8j8x-9vj2: jaraco.context
+jaraco.context_version=$(python -c "import jaraco.context; print(jaraco.context.__version__)")
+check-version-ge "jaraco-context-requirement" "${jaraco.context_version}" "6.1.0"
+
+# GHSA-8rrh-rw8j-w5fx: wheel
+wheel_version=$(python -c "import wheel; print(wheel.__version__)")
+check-version-ge "wheel-requirement" "${wheel_version}" "0.46.2"
+
 # Report result
 reportResults

--- a/src/python/test-project/test.sh
+++ b/src/python/test-project/test.sh
@@ -51,5 +51,13 @@ check-version-ge "setuptools-requirement" "${setuptools_version}" "78.1.1"
 gitpython_version=$(python -c "import git; print(git.__version__)")
 check-version-ge "gitpython-requirement" "${gitpython_version}" "3.1.41"
 
+# GHSA-58pv-8j8x-9vj2: jaraco.context
+jaraco_version=$(python -c "import jaraco.context; print(jaraco.context.__version__)")
+check-version-ge "jaraco-context-requirement" "${jaraco.context_version}" "6.1.0"
+
+# GHSA-8rrh-rw8j-w5fx: wheel
+wheel_version=$(python -c "import wheel; print(wheel.__version__)")
+check-version-ge "wheel-requirement" "${wheel_version}" "0.46.2"
+
 # Report result
 reportResults

--- a/src/python/test-project/test.sh
+++ b/src/python/test-project/test.sh
@@ -52,8 +52,8 @@ gitpython_version=$(python -c "import git; print(git.__version__)")
 check-version-ge "gitpython-requirement" "${gitpython_version}" "3.1.41"
 
 # GHSA-58pv-8j8x-9vj2: jaraco.context
-jaraco_version=$(python -c "import jaraco.context; print(jaraco.context.__version__)")
-check-version-ge "jaraco-context-requirement" "${jaraco.context_version}" "6.1.0"
+jaraco_context_version=$(python -c "import jaraco.context; print(jaraco.context.__version__)")
+check-version-ge "jaraco-context-requirement" "${jaraco_context_version}" "6.1.0"
 
 # GHSA-8rrh-rw8j-w5fx: wheel
 wheel_version=$(python -c "import wheel; print(wheel.__version__)")


### PR DESCRIPTION
Update packages to the required versions. 