### PR TITLE
[universal] - Fix vulnerability issues GHSA-mf9w-mj56-hr94 and GHSA-p423-j2cm-9vmq

### DIFF
--- a/src/universal/.devcontainer/local-features/patch-conda/install.sh
+++ b/src/universal/.devcontainer/local-features/patch-conda/install.sh
@@ -54,7 +54,8 @@ sudo_if /opt/conda/bin/python3 -m pip install --upgrade pip
 # https://github.com/advisories/GHSA-r6ph-v2qm-q3c2
 update_conda_package pyopenssl "26.0.0"
 
-update_conda_package cryptography "46.0.5"
+# https://github.com/advisories/GHSA-p423-j2cm-9vmq
+update_conda_package cryptography "46.0.7"
 
 # https://nvd.nist.gov/vuln/detail/CVE-2025-6176
 update_conda_package brotli "1.2.0"

--- a/src/universal/.devcontainer/local-features/patch-conda/install.sh
+++ b/src/universal/.devcontainer/local-features/patch-conda/install.sh
@@ -59,5 +59,6 @@ update_conda_package cryptography "46.0.5"
 # https://nvd.nist.gov/vuln/detail/CVE-2025-6176
 update_conda_package brotli "1.2.0"
 
+# https://github.com/advisories/GHSA-mf9w-mj56-hr94
 update_python_package /opt/conda/bin/python3 python-dotenv "1.2.2"
 

--- a/src/universal/.devcontainer/local-features/patch-conda/install.sh
+++ b/src/universal/.devcontainer/local-features/patch-conda/install.sh
@@ -58,3 +58,6 @@ update_conda_package cryptography "46.0.5"
 
 # https://nvd.nist.gov/vuln/detail/CVE-2025-6176
 update_conda_package brotli "1.2.0"
+
+update_python_package /opt/conda/bin/python3 python-dotenv "1.2.2"
+

--- a/src/universal/manifest.json
+++ b/src/universal/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "6.0.4",
+	"version": "6.0.5",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -176,8 +176,8 @@ checkPythonPackageVersion "python" "setuptools" "78.1.1"
 checkPythonPackageVersion "python" "requests" "2.31.0"
 
 ## Conda Python
-checkCondaPackageVersion "requests" "2.31.0"
-checkCondaPackageVersion "cryptography" "46.0.5"
+checkCondaPackageVersion "requests" "2.33.0"
+checkCondaPackageVersion "cryptography" "46.0.7"
 checkCondaPackageVersion "pyopenssl" "26.0.0"
 checkCondaPackageVersion "urllib3" "2.6.3"
 checkCondaPackageVersion "brotli" "1.2.0"

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -181,6 +181,7 @@ checkCondaPackageVersion "cryptography" "46.0.5"
 checkCondaPackageVersion "pyopenssl" "26.0.0"
 checkCondaPackageVersion "urllib3" "2.6.3"
 checkCondaPackageVersion "brotli" "1.2.0"
+checkCondaPackageVersion "python-dotenv" "1.2.2"
 
 ## Test Conda
 check "conda-update-conda" bash -c "conda update -c defaults -y conda"

--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -176,7 +176,7 @@ checkPythonPackageVersion "python" "setuptools" "78.1.1"
 checkPythonPackageVersion "python" "requests" "2.31.0"
 
 ## Conda Python
-checkCondaPackageVersion "requests" "2.33.0"
+checkCondaPackageVersion "requests" "2.31.0"
 checkCondaPackageVersion "cryptography" "46.0.7"
 checkCondaPackageVersion "pyopenssl" "26.0.0"
 checkCondaPackageVersion "urllib3" "2.6.3"


### PR DESCRIPTION
GHSA ID | Vulnerability ID | Action | Package | Installed Version | Required Version | Language | Install Path | Image Digest
-- | -- | -- | -- | -- | -- | -- | -- | --
 Python (Pip) Security Update for python-dotenv (GHSA-mf9w-mj56-hr94)| 5011346  |Y| python-dotenv  | 0.21.0  | 1.2.2 | python | opt/conda/lib/python3.13/site-packages/python__dotenv-1.2.1.dist-info/METADATA and opt/conda/pkgs/python-dotenv-1.2.1-py313h06a4308__0/lib/python3.13/site-packages/python__dotenv-1.2.1.dist-info/METADATA | sha256:d4e0d5954535d633a354e99ff41cffc72f65839696e7be1373c00a2efd392269
 Python (Pip) Security Update for cryptography (https://github.com/advisories/GHSA-p423-j2cm-9vmq)| 5010634  |Y| cryptography  | 46.0.5  | 46.0.7 | python | opt/conda/pkgs/cryptography-45.0.7-py313h0a354b3__0/lib/python3.13/site-packages/cryptography-45.0.7.dist-info/METADATA cryptography 46.0.5 46.0.7 Python opt/conda/lib/python3.13/site-packages/cryptography-46.0.5.dist-info/METADATA cryptography 46.0.5 46.0.7 Python opt/conda/pkgs/cryptography-46.0.5 py313h04fe016__1/lib/python3.13/site-packages/cryptography-46.0.5.dist-info/METADATA | sha256:ebf14f951910c62ec544a6f636027b44a485c5e6a5aaeaf0f6d8ae0afee0d125