### PR TITLE
[anaconda]- Security update for pyasn1 (GHSA-jr27-m4p2-rc6r) and ujson (GHSA-wgvc-ghv9-3pmm)

### DIFF
--- a/src/anaconda/.devcontainer/apply_security_patches.sh
+++ b/src/anaconda/.devcontainer/apply_security_patches.sh
@@ -2,9 +2,12 @@
 
 # vulnerabilities:
 # werkzeug - [GHSA-f9vj-2wh5-fj8j] 
+# pyasn1 - [GHSA-jr27-m4p2-rc6r]
+# ujson - [GHSA-wgvc-ghv9-3pmm]
 
 patched_package_versions=( "mistune=3.0.1" "aiohttp=3.10.11" "cryptography=44.0.1" "h11=0.16.0" "jinja2=3.1.6" "jupyter_core=5.8.1" "protobuf=6.33.5" "requests=2.32.4" "setuptools=78.1.1" "transformers=4.53.0" "urllib3=2.5.0" "werkzeug=3.1.5" "jupyter-lsp=2.2.2" "scrapy=2.14.2"
-                      "zipp=3.19.1" "tornado=6.5.5" "jupyterlab=4.4.8" "imagecodecs=2024.9.22" "fonttools=4.60.2" "pyarrow=17.0.0" "brotli=1.2.0" "filelock=3.20.1" "bokeh=3.8.2" "distributed=2026.1.0" "wheel=0.46.2" "nltk=3.9.3" "black=26.3.1" "pyjwt=2.12.0" "pillow=12.1.1" "pyopenssl=26.0.0" "nbconvert=7.17.1" "markdown=3.8.1" "python-dotenv=1.2.2" "lxml=6.1.0")
+                      "zipp=3.19.1" "tornado=6.5.5" "jupyterlab=4.4.8" "imagecodecs=2024.9.22" "fonttools=4.60.2" "pyarrow=17.0.0" "brotli=1.2.0" "filelock=3.20.1" "bokeh=3.8.2" "distributed=2026.1.0" "wheel=0.46.2" "nltk=3.9.3" "black=26.3.1" "pyjwt=2.12.0" "pillow=12.1.1" "pyopenssl=26.0.0" "nbconvert=7.17.1" "markdown=3.8.1" "python-dotenv=1.2.2" "lxml=6.1.0"
+                      "pyasn1=0.6.3" "ujson=5.12.0")
 
 # Define the number of rows (based on the length of patched_package_versions)
 rows=${#patched_package_versions[@]}

--- a/src/anaconda/README.md
+++ b/src/anaconda/README.md
@@ -30,7 +30,7 @@ You can decide how often you want updates by referencing a [semantic version](ht
 
 - `mcr.microsoft.com/devcontainers/anaconda:1-3`
 - `mcr.microsoft.com/devcontainers/anaconda:1.3-3`
-- `mcr.microsoft.com/devcontainers/anaconda:1.3.18-3`
+- `mcr.microsoft.com/devcontainers/anaconda:1.3.19-3`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/anaconda/tags/list).
 

--- a/src/anaconda/manifest.json
+++ b/src/anaconda/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "1.3.18",
+	"version": "1.3.19",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -82,6 +82,8 @@ checkCondaPackageVersion "streamlit" "1.37.0"
 checkCondaPackageVersion "nltk" "3.9.3"
 checkCondaPackageVersion "markdown" "3.8.1"
 checkCondaPackageVersion "python-dotenv" "1.2.2"
+checkCondaPackageVersion "pyasn1" "0.6.3"
+checkCondaPackageVersion "ujson" "5.12.0"
 
 check "conda-update-conda" bash -c "conda update -y conda"
 check "conda-install-tensorflow" bash -c "conda create --name test-env -c conda-forge --yes tensorflow"

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -68,6 +68,8 @@ checkPythonPackageVersion "bokeh" "3.8.2"
 checkPythonPackageVersion "pyjwt" "2.12.0"
 checkPythonPackageVersion "python-dotenv" "1.2.2"
 checkPythonPackageVersion "lxml" "6.1.0"
+checkPythonPackageVersion "pyasn1" "0.6.3"
+checkPythonPackageVersion "ujson" "5.12.0"
 
 checkCondaPackageVersion "pyopenssl" "26.0.0"
 checkCondaPackageVersion "requests" "2.32.4"


### PR DESCRIPTION

GHSA ID | Vulnerability ID | Action | Package | Installed Version | Required Version | Language | Install Path/ Note | Image Digest
-- | -- | -- | -- | -- | -- | -- | -- | --
Python (Pip) Security Update for pyasn1 (GHSA-jr27-m4p2-rc6r) | 5009279 | Y | pyasn1 | 0.4.8 | 0.6.3 | Python | opt/conda/lib/python3.12/site-packages/pyasn1-0.4.8.dist-info/METADATA | sha256:f313bf1984a76b908816b252239059ec74964558f8a8709f5033692c5247fdf4
Python (Pip) Security Update for ujson (GHSA-wgvc-ghv9-3pmm) | 5009346 | Y | ujson | 5.10.0 | 5.12.0 | Python | opt/conda/lib/python3.12/site-packages/ujson-5.10.0.dist-info/METADATA | sha256:f313bf1984a76b908816b252239059ec74964558f8a8709f5033692c5247fdf4

