### PR TITLE
[universal]- Remove test for setuptools thats no more default bundled in python

### DIFF
--- a/src/universal/test-project/test.sh
+++ b/src/universal/test-project/test.sh
@@ -172,7 +172,6 @@ check "php-version-on-path-is-8.1.30" php --version | grep 8.1.30
 ls -la /home/codespace
 
 ## Python - current
-checkPythonPackageVersion "python" "setuptools" "78.1.1"
 checkPythonPackageVersion "python" "requests" "2.31.0"
 
 ## Conda Python


### PR DESCRIPTION
## [universal]- Remove test for setuptools thats no more default bundled in python

### Summary
Remove the `setuptools-requirement` check from the `universal` smoke test. `setuptools` is no longer pre-installed for the standalone Python, matching upstream, so the assertion is stale.

### Background
Python upstream stopped bundling `setuptools` as of 3.12+ (no longer installed by `ensurepip`/`venv`). The image's default Python (`3.14.2`) ships without it, so the `setuptools-requirement` check fails with `PackageNotFoundError`. No manual install exists in the image (none is added in `install.sh`).

### Decision : drop support
We keep the standalone Python aligned with upstream rather than re-adding `setuptools`:
- **Upstream alignment** :Python deliberately removed it; modern builds fetch it on demand (PEP 517).
- **Already available** : present via conda (`82.0.1`) and pulled by `pip` on demand for the standalone interpreter.
- **Image size** : avoid re-introducing upstream-removed packages to an already-large image.

### Changes
- Remove the `setuptools-requirement` assertion from `test-project/test.sh`.
- **No `manifest.json` bump** ,this is a test-only change; the image build content is unchanged.

### Impact
- Smoke test passes; other checks unaffected.
- `setuptools` remains available via conda and `pip` on demand.
-  Users requiring setup tools either need to use the conda env that has setup tools bundled, or manually import it themselves inside python env.