### PR TITLE
[typescript]: Remove support for EOL Node 20(all variants)

### DIFF
--- a/src/typescript-node/README.md
+++ b/src/typescript-node/README.md
@@ -31,7 +31,7 @@ You can decide how often you want updates by referencing a [semantic version](ht
 - `mcr.microsoft.com/devcontainers/typescript-node:5.0-24` (or `5.0-24-trixie`,  `5.0-24-bookworm`, `5.0-24-bullseye`)
 - `mcr.microsoft.com/devcontainers/typescript-node:5.0.0-24` (or `5.0.0-24-trixie`, `5.0.0-24-bookworm`, `5.0.0-24-bullseye`)
 
-However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `3-24`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
+However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `5-24`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 
 Beyond TypeScript, Node.js, and `git`, this image / `Dockerfile` includes `eslint`, `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `node` user with `sudo` access, and a set of common dependencies for development. Since `tslint` is [now fully deprecated](https://github.com/palantir/tslint/issues/4534), the image includes `tslint-to-eslint-config` globally to help you migrate.
 

--- a/src/typescript-node/README.md
+++ b/src/typescript-node/README.md
@@ -9,7 +9,7 @@
 | *Categories* | Core, Languages |
 | *Image type* | Dockerfile |
 | *Published image* | mcr.microsoft.com/devcontainers/typescript-node |
-| *Available image variants* | 24 /24-trixie, 22 / 22-trixie, 20 / 20-trixie, 24-bookworm, 22-bookworm, 20-bookworm, 24-bullseye, 22-bullseye, 20-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/typescript-node/tags/list)) |
+| *Available image variants* | 24 /24-trixie, 22 / 22-trixie, 24-bookworm, 22-bookworm, 24-bullseye, 22-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/typescript-node/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bookworm`, and `bullseye` variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -22,15 +22,14 @@ You can directly reference pre-built versions of `Dockerfile` by using the `imag
 - `mcr.microsoft.com/devcontainers/typescript-node` (latest)
 - `mcr.microsoft.com/devcontainers/typescript-node:24` (or `24-trixie`, `24-bookworm`, `24-bullseye` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/typescript-node:22` (or `22-trixie`, `22-bookworm`, `22-bullseye` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/typescript-node:20` (or `20-trixie`, `20-bookworm`, `20-bullseye` to pin to an OS version)
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/devcontainers/typescript-node:4-24` (or `4-24-trixie`, `4-24-bookworm`, `4-24-bullseye`)
-- `mcr.microsoft.com/devcontainers/typescript-node:4.0-24` (or `4.0-24-trixie`,  `4.0-24-bookworm`, `4.0-24-bullseye`)
-- `mcr.microsoft.com/devcontainers/typescript-node:4.0.10-24` (or `4.0.10-24-trixie`, `4.0.10-24-bookworm`, `4.0.10-24-bullseye`)
+- `mcr.microsoft.com/devcontainers/typescript-node:5-24` (or `5-24-trixie`, `5-24-bookworm`, `5-24-bullseye`)
+- `mcr.microsoft.com/devcontainers/typescript-node:5.0-24` (or `5.0-24-trixie`,  `5.0-24-bookworm`, `5.0-24-bullseye`)
+- `mcr.microsoft.com/devcontainers/typescript-node:5.0.0-24` (or `5.0.0-24-trixie`, `5.0.0-24-bookworm`, `5.0.0-24-bullseye`)
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `3-24`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 

--- a/src/typescript-node/manifest.json
+++ b/src/typescript-node/manifest.json
@@ -1,15 +1,12 @@
 {
-	"version": "4.0.10",
+	"version": "5.0.0",
 	"variants": [
 		"24-trixie",
 		"22-trixie",
-		"20-trixie",
 		"24-bookworm",
 		"22-bookworm",
-		"20-bookworm",
 		"24-bullseye",
-		"22-bullseye",
-		"20-bullseye"
+		"22-bullseye"
 	],
 	"build": {
 		"latest": "24-trixie",
@@ -24,10 +21,6 @@
 				"linux/amd64",
 				"linux/arm64"
 			],
-			"20-trixie": [
-				"linux/amd64",
-				"linux/arm64"
-			],	
 			"24-bookworm": [
 				"linux/amd64",
 				"linux/arm64"
@@ -36,19 +29,11 @@
 				"linux/amd64",
 				"linux/arm64"
 			],
-			"20-bookworm": [
-				"linux/amd64",
-				"linux/arm64"
-			],
 			"24-bullseye": [
 				"linux/amd64",
 				"linux/arm64"
 			],
 			"22-bullseye": [
-				"linux/amd64",
-				"linux/arm64"
-			],
-			"20-bullseye": [
 				"linux/amd64",
 				"linux/arm64"
 			]
@@ -63,9 +48,6 @@
 			],
 			"22-trixie": [
 				"typescript-node:${VERSION}-22"
-			],
-			"20-trixie": [
-				"typescript-node:${VERSION}-20"
 			],
 			"24-bookworm": [
 				"typescript-node:${VERSION}-bookworm"


### PR DESCRIPTION
## [typescript-node] Remove support for EOL Node 20 (all variants)

### Summary
Node.js 20 has reached end-of-life, so this PR removes all Node 20 variants from the `typescript-node` image. The supported matrix is now Node 22 and Node 24 across `trixie`, `bookworm`, and `bullseye`.

### Why
Node 20 is no longer in support and should not keep receiving image builds or security patching. Dropping it keeps the published variant matrix aligned with currently supported Node.js releases.

### Changes

**`src/typescript-node/manifest.json`**
- Removed `20-trixie`, `20-bookworm`, and `20-bullseye` from `variants`.
- Removed the matching entries from `build.architectures`.
- Removed the `20-trixie` entry from `build.variantTags` (which produced the floating `:20` tag).
- Bumped `version` from `4.0.10` → `5.0.0`.

**`src/typescript-node/README.md`**
- Updated the *Available image variants* row to drop the Node 20 entries.
- Removed the `:20` pin-to-OS reference bullet.
- Updated the semantic-version examples from `4.x` / `4.0.10` to `5.x` / `5.0.0`.
- Updated the security-patching example reference from `3-24` to `5-24` to match the new major version.

### Version bump (breaking change)
Removing published variants/tags is a breaking change, so this is a **major** bump per the repo's contribution rules: `4.0.10` → `5.0.0`.

### Tags removed
- `typescript-node:20`
- `typescript-node:<version>-20`, `*-20-trixie`, `*-20-bookworm`, `*-20-bullseye`

### Impact
Consumers pinned to any Node 20 tag (`:20`, `*-20`, `*-20-trixie`, `*-20-bookworm`, `*-20-bullseye`) will no longer receive updated images and must migrate to Node 22 or 24, (Default version is unchanged at 24)