### PR TITLE
[python] - Rework -  Security updates for GHSA-58pv-8j8x-9vj2: jaraco.context and GHSA-8rrh-rw8j-w5fx: wheel

### DIFF
--- a/src/python/.devcontainer/Dockerfile
+++ b/src/python/.devcontainer/Dockerfile
@@ -9,10 +9,9 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 # Temporary: Upgrade python packages due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40897 and https://github.com/advisories/GHSA-2mqj-m65w-jghx
 # They are installed by the base image (python) which does not have the patch.
 RUN python3 -m pip install --upgrade \
-    setuptools==78.1.1 \
     gitpython==3.1.50 \
-    jaraco.context==6.1.0 \
-    wheel==0.46.2
+    setuptools==82.0.1 \
+    wheel==0.46.3
 
 # Fixing vulnerability issue by upgrading svn to 1.14.5. Ref https://subversion.apache.org/security/CVE-2024-46901-advisory.txt
 COPY ./scripts/install-subversion.sh /tmp/install-subversion.sh

--- a/src/python/README.md
+++ b/src/python/README.md
@@ -34,9 +34,9 @@ Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/devcontainers/python:3-3.13` (or `3-3.14-trixie`)
-- `mcr.microsoft.com/devcontainers/python:3.1-3.13` (or `3.1-3.13-trixie`)
-- `mcr.microsoft.com/devcontainers/python:3.1.3-3.13` (or `3.1.3-3.13-trixie`)
+- `mcr.microsoft.com/devcontainers/python:3-3.14` (or `3-3.14-trixie`)
+- `mcr.microsoft.com/devcontainers/python:3.1-3.14` (or `3.1-3.14-trixie`)
+- `mcr.microsoft.com/devcontainers/python:3.1.4-3.14` (or `3.1.4-3.14-trixie`)
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `2-3`). 
 You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.

--- a/src/python/manifest.json
+++ b/src/python/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "3.1.3",
+	"version": "3.1.4",
 	"variants": [
 		"3.14-trixie",
 		"3.13-trixie",

--- a/src/python/test-project/test-utils.sh
+++ b/src/python/test-project/test-utils.sh
@@ -56,7 +56,7 @@ checkNoVulnerablePackage() {
     while IFS= read -r dist_info; do
         local name version greater
         name="$(basename "${dist_info}")"
-        version="${name#${PACKAGE_PREFIX}-}"
+        version="${name##*-}"
         version="${version%.dist-info}"
         greater="$( (echo "${version}"; echo "${REQUIRED_VERSION}") | sort -V | tail -1 )"
         if [ "${version}" != "${greater}" ]; then

--- a/src/python/test-project/test-utils.sh
+++ b/src/python/test-project/test-utils.sh
@@ -44,6 +44,36 @@ check-version-ge() {
     fi
 }
 
+# Fails if any copy of a package below the required version is bundled anywhere on
+# the filesystem. These can be vendored inside setuptools/_vendor or other virtual
+# envs (e.g. pipenv), which a top-level importlib.metadata version lookup misses.
+checkNoVulnerablePackage() {
+    LABEL=$1
+    PACKAGE_PREFIX=$2
+    REQUIRED_VERSION=$3
+    echo -e "\n🧪 Testing $LABEL: no '$PACKAGE_PREFIX' < '$REQUIRED_VERSION' on the filesystem"
+    local found_vulnerable=0
+    while IFS= read -r dist_info; do
+        local name version greater
+        name="$(basename "${dist_info}")"
+        version="${name#${PACKAGE_PREFIX}-}"
+        version="${version%.dist-info}"
+        greater="$( (echo "${version}"; echo "${REQUIRED_VERSION}") | sort -V | tail -1 )"
+        if [ "${version}" != "${greater}" ]; then
+            echoStderr "Found vulnerable ${PACKAGE_PREFIX} ${version} at: ${dist_info}"
+            found_vulnerable=1
+        fi
+    done < <(find / -type d -name "${PACKAGE_PREFIX}-*.dist-info" 2>/dev/null)
+    if [ ${found_vulnerable} -eq 0 ]; then
+        echo "✅  Passed!"
+        return 0
+    else
+        echoStderr "❌ $LABEL check failed."
+        FAILED+=("$LABEL")
+        return 1
+    fi
+}
+
 checkMultiple() {
     PASSED=0
     LABEL="$1"

--- a/src/python/test-project/test-utils.sh
+++ b/src/python/test-project/test-utils.sh
@@ -63,7 +63,8 @@ checkNoVulnerablePackage() {
             echoStderr "Found vulnerable ${PACKAGE_PREFIX} ${version} at: ${dist_info}"
             found_vulnerable=1
         fi
-    done < <(find / -type d -name "${PACKAGE_PREFIX}-*.dist-info" 2>/dev/null)
+    done < <(find / -xdev \( -path /proc -o -path /sys -o -path /dev -o -path /run \) -prune -o \
+    -type d -name "${PACKAGE_PREFIX}-*.dist-info" -print 2>/dev/null)
     if [ ${found_vulnerable} -eq 0 ]; then
         echo "✅  Passed!"
         return 0

--- a/src/python/test-project/test.sh
+++ b/src/python/test-project/test.sh
@@ -58,7 +58,7 @@ check-version-ge "wheel-requirement" "${wheel_version}" "0.46.2"
 # Ensure no vulnerable copies are bundled anywhere on the filesystem. These can be
 # vendored inside setuptools/_vendor or other virtual envs (e.g. pipenv), which the
 # importlib.metadata top-level lookup above does not catch.
-checkNoVulnerablePackage "no-vulnerable-jaraco-context" "jaraco_context" "6.1.0"
+checkNoVulnerablePackage "no-vulnerable-jaraco-context" "jaraco[._]context" "6.1.0"
 checkNoVulnerablePackage "no-vulnerable-wheel" "wheel" "0.46.2"
 
 # Report result

--- a/src/python/test-project/test.sh
+++ b/src/python/test-project/test.sh
@@ -47,11 +47,11 @@ check-version-ge "svn-requirement" "${svn_version}" "1.14.5"
 setuptools_version=$(python -c "import setuptools; print(setuptools.__version__)")
 check-version-ge "setuptools-requirement" "${setuptools_version}" "78.1.1"
 
-https://github.com/advisories/GHSA-v87r-6q3f-2j67
+# https://github.com/advisories/GHSA-v87r-6q3f-2j67
 gitpython_version=$(python -c "import git; print(git.__version__)")
 check-version-ge "gitpython-requirement" "${gitpython_version}" "3.1.50"
 
-# GHSA-8rrh-rw8j-w5fx: wheel
+# https://github.com/advisories/GHSA-8rrh-rw8j-w5fx
 wheel_version=$(python -c "from importlib.metadata import version; print(version('wheel'))")
 check-version-ge "wheel-requirement" "${wheel_version}" "0.46.2"
 

--- a/src/python/test-project/test.sh
+++ b/src/python/test-project/test.sh
@@ -51,13 +51,15 @@ https://github.com/advisories/GHSA-v87r-6q3f-2j67
 gitpython_version=$(python -c "import git; print(git.__version__)")
 check-version-ge "gitpython-requirement" "${gitpython_version}" "3.1.50"
 
-# GHSA-58pv-8j8x-9vj2: jaraco.context
-jaraco_context_version=$(python -c "from importlib.metadata import version; print(version('jaraco.context'))")
-check-version-ge "jaraco-context-requirement" "${jaraco_context_version}" "6.1.0"
-
 # GHSA-8rrh-rw8j-w5fx: wheel
 wheel_version=$(python -c "from importlib.metadata import version; print(version('wheel'))")
 check-version-ge "wheel-requirement" "${wheel_version}" "0.46.2"
+
+# Ensure no vulnerable copies are bundled anywhere on the filesystem. These can be
+# vendored inside setuptools/_vendor or other virtual envs (e.g. pipenv), which the
+# importlib.metadata top-level lookup above does not catch.
+checkNoVulnerablePackage "no-vulnerable-jaraco-context" "jaraco_context" "6.1.0"
+checkNoVulnerablePackage "no-vulnerable-wheel" "wheel" "0.46.2"
 
 # Report result
 reportResults


### PR DESCRIPTION
Rework of PR the #1873 as the earlier didn't solve the exact problem reported in specific path as part of the vulnerability issues. The actual problem was linked to `setuptools` and not exactly with `jaraco.context` and `wheel` individually.