### PR TITLE
[universal] - Toolings update to solve multiple vulnerability issues.

### DIFF
--- a/src/universal/.devcontainer/devcontainer-lock.json
+++ b/src/universal/.devcontainer/devcontainer-lock.json
@@ -15,10 +15,10 @@
       "resolved": "ghcr.io/devcontainers/features/copilot-cli@sha256:e10d091ae7ef9b8d2ed5f601d75f5a090bc04acbac1a26d4cd3c0d5edde4ea10",
       "integrity": "sha256:e10d091ae7ef9b8d2ed5f601d75f5a090bc04acbac1a26d4cd3c0d5edde4ea10"
     },
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {
-      "version": "2.17.0",
-      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:25b9f05705ffba7dbe503230ac76081419306f8c8bc88e0ce78c4ecd99a0c78c",
-      "integrity": "sha256:25b9f05705ffba7dbe503230ac76081419306f8c8bc88e0ce78c4ecd99a0c78c"
+    "ghcr.io/devcontainers/features/docker-in-docker:3": {
+      "version": "3.1.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:62e04ec83d944da4fd2830f68a677d1f5466c0654aea1e4baa30232d16029ac1",
+      "integrity": "sha256:62e04ec83d944da4fd2830f68a677d1f5466c0654aea1e4baa30232d16029ac1"
     },
     "ghcr.io/devcontainers/features/dotnet:2": {
       "version": "2.5.0",
@@ -60,10 +60,10 @@
       "resolved": "ghcr.io/devcontainers/features/kubectl-helm-minikube@sha256:bbe8adf6b37fff8c67412ab0a4579f4c2f30bbaba1d9a5cebd9e38bade54025b",
       "integrity": "sha256:bbe8adf6b37fff8c67412ab0a4579f4c2f30bbaba1d9a5cebd9e38bade54025b"
     },
-    "ghcr.io/devcontainers/features/node:1": {
-      "version": "1.7.1",
-      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
-      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    "ghcr.io/devcontainers/features/node:2": {
+      "version": "2.1.0",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:586c9a6f7dd40bd3ba2cd41e7f2f88dcc31fbe5d1442afcbf07ffbc66b686857",
+      "integrity": "sha256:586c9a6f7dd40bd3ba2cd41e7f2f88dcc31fbe5d1442afcbf07ffbc66b686857"
     },
     "ghcr.io/devcontainers/features/oryx:2": {
       "version": "2.0.0",

--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
         "ghcr.io/devcontainers/features/hugo:1": {
             "version": "latest"
         },
-        "ghcr.io/devcontainers/features/node:1": {
+        "ghcr.io/devcontainers/features/node:2": {
             "version": "24",
             "additionalVersions": "22"
         },
@@ -63,7 +63,7 @@
         "ghcr.io/devcontainers/features/copilot-cli:1": {
             "version": "latest"
         },
-        "ghcr.io/devcontainers/features/docker-in-docker:2": {
+        "ghcr.io/devcontainers/features/docker-in-docker:3": {
             "version": "latest"
         },
         "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {

--- a/src/universal/README.md
+++ b/src/universal/README.md
@@ -29,7 +29,7 @@ For example:
 
 - `mcr.microsoft.com/devcontainers/universal:6-noble`
 - `mcr.microsoft.com/devcontainers/universal:6.0-noble`
-- `mcr.microsoft.com/devcontainers/universal:6.0.6-noble`
+- `mcr.microsoft.com/devcontainers/universal:6.0.7-noble`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/universal/tags/list).
 

--- a/src/universal/manifest.json
+++ b/src/universal/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "6.0.6",
+	"version": "6.0.7",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",


### PR DESCRIPTION
## 🧾 In a Nutshell

This draft pull request updates two Dev Container features used in the `universal` image — **`docker-in-docker`** (v2 → v3) and **`node`** (v1 → v2) — to their latest major versions in order to resolve known vulnerability issues. The lock file and manifest version are also bumped accordingly. Related [feature PR](https://github.com/devcontainers/features/pull/1672).

---

## 📂 Files Changed

### 1. `src/universal/.devcontainer/devcontainer.json` *(+2 / -2)*
Updated feature references to use the new major versions:
- `ghcr.io/devcontainers/features/node:1` → **`node:2`**
- `ghcr.io/devcontainers/features/docker-in-docker:2` → **`docker-in-docker:3`**

### 2. `src/universal/.devcontainer/devcontainer-lock.json` *(+8 / -8)*
Lock file updated to reflect the new resolved SHA digests for both bumped features:

| Feature              | Old Version | New Version | New SHA (short)  |
|----------------------|-------------|-------------|------------------|
| `docker-in-docker`   | `2.17.0`    | `3.1.0`     | `62e04ec83d94…`  |
| `node`               | `1.7.1`     | `2.1.0`     | `586c9a6f7dd4…`  |

### 3. `src/universal/manifest.json` *(+1 / -1)*
Bumped the universal image version:
- `6.0.6` → **`6.0.7`**

---

## 🔐 Security / Vulnerability Context

Both updated features were bumped to new major versions, which typically include:
- **`docker-in-docker:3`** — Addresses vulnerabilities in the bundled Docker toolchain (e.g., `runc`, `containerd`, or `docker-cli` CVEs).
- **`node:2`** — Addresses known Node.js runtime vulnerabilities present in the v1 feature version.

---
