### PR TITLE
add missing ruby 3 variants

### DIFF
--- a/src/ruby/README.md
+++ b/src/ruby/README.md
@@ -9,7 +9,7 @@
 | *Categories* | Core, Languages |
 | *Image type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/devcontainers/ruby |
-| *Available image variants* | 4 / 4-trixie, 4-bookworm, 3.4 / 3.4-trixie, 3.3 / 3.3-trixie, 3.4-bookworm, 3.3-bookworm, 3.4-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/ruby/tags/list)) |
+| *Available image variants* | 4 / 4-trixie, 4-bookworm, 3 / 3-trixie, 3-bookworm, 3-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/ruby/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `trixie`, `bookworm` , and `bullseye` variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -31,6 +31,7 @@ Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/devcontainers/ruby:3-4`     (or `3-4-trixie`, `3-4-bookworm`, `3-4-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/ruby:3-3`     (or `3-3-trixie`, `3-3-bookworm` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/ruby:3.0-4`   (or `3.0-4-trixie`, `3.0-4-bookworm`, `3.0-4-bullseye` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/ruby:3.0.8-4` (or `3.0.8-4-trixie`, `3.0.8-4-bookworm`, `3.0.8-4-bullseye` to pin to an OS version)
 

--- a/src/ruby/manifest.json
+++ b/src/ruby/manifest.json
@@ -62,7 +62,9 @@
 				"ruby:${VERSION}-bookworm"
 			],
 			"3.4-trixie": [
+				"ruby:${VERSION}-3",
 				"ruby:${VERSION}-3.4",
+				"ruby:${VERSION}-3-trixie",
 				"ruby:${VERSION}-3.4-trixie"
 			],
 			"3.3-trixie": [
@@ -70,12 +72,14 @@
 				"ruby:${VERSION}-3.3-trixie"
 			],			
 			"3.4-bookworm": [
+				"ruby:${VERSION}-3-bookworm",
 				"ruby:${VERSION}-3.4-bookworm"
 			],
 			"3.3-bookworm": [
 				"ruby:${VERSION}-3.3-bookworm"
 			],			
 			"3.4-bullseye": [
+				"ruby:${VERSION}-3-bullseye",
 				"ruby:${VERSION}-3.4-bullseye"
 			],
 			"3.3-bullseye": [

--- a/src/ruby/manifest.json
+++ b/src/ruby/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "3.0.8",
+	"version": "3.0.9",
 	"variants": [
 		"4.0-trixie",
 		"3.4-trixie",		


### PR DESCRIPTION
- fixes #1906

Note that [both ruby 3 & 4 are meant to be supported at least until Mar 2028](https://endoflife.date/ruby) so this PR should be merged.