### PR TITLE
[anaconda]: Security updates for Python Packages: click & idna

### DIFF
--- a/src/anaconda/.devcontainer/apply_security_patches.sh
+++ b/src/anaconda/.devcontainer/apply_security_patches.sh
@@ -10,10 +10,12 @@ python3 -m pip install --upgrade --no-cache-dir "pip==26.1.2" || exit $?
 # twisted - [GHSA-grgv-6hw6-v9g4]
 # gitpython - [GHSA-v87r-6q3f-2j67]
 # mistune - [GHSA-8mp2-v27r-99xp]
+# idna - [GHSA-65pc-fj4g-8rjx]
+# click - [GHSA-47fr-3ffg-hgmw]
 
 patched_package_versions=( "mistune=3.2.1" "aiohttp=3.10.11" "cryptography=44.0.1" "h11=0.16.0" "jinja2=3.1.6" "jupyter_core=5.8.1" "protobuf=6.33.5" "requests=2.32.4" "setuptools=78.1.1" "transformers=4.53.0" "urllib3=2.5.0" "werkzeug=3.1.5" "jupyter-lsp=2.2.2" "scrapy=2.14.2"
                       "zipp=3.19.1" "tornado=6.5.5" "jupyterlab=4.4.8" "imagecodecs=2024.9.22" "fonttools=4.60.2" "pyarrow=17.0.0" "brotli=1.2.0" "filelock=3.20.1" "bokeh=3.8.2" "distributed=2026.1.0" "wheel=0.46.2" "nltk=3.9.3" "black=26.3.1" "pyjwt=2.12.0" "pillow=12.1.1" "pyopenssl=26.0.0" "nbconvert=7.17.1" "markdown=3.8.1" "python-dotenv=1.2.2" "lxml=6.1.0"
-                      "pyasn1=0.6.3" "ujson=5.12.1" "twisted=26.4.0" "gitpython=3.1.50")
+                      "pyasn1=0.6.3" "ujson=5.12.1" "twisted=26.4.0" "gitpython=3.1.50" "click=8.4.2" "idna=3.18")
 
 # Define the number of rows (based on the length of patched_package_versions)
 rows=${#patched_package_versions[@]}

--- a/src/anaconda/README.md
+++ b/src/anaconda/README.md
@@ -30,7 +30,7 @@ You can decide how often you want updates by referencing a [semantic version](ht
 
 - `mcr.microsoft.com/devcontainers/anaconda:1-3`
 - `mcr.microsoft.com/devcontainers/anaconda:1.3-3`
-- `mcr.microsoft.com/devcontainers/anaconda:1.3.22-3`
+- `mcr.microsoft.com/devcontainers/anaconda:1.3.23-3`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/anaconda/tags/list).
 

--- a/src/anaconda/manifest.json
+++ b/src/anaconda/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "1.3.22",
+	"version": "1.3.23",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/src/anaconda/test-project/test.sh
+++ b/src/anaconda/test-project/test.sh
@@ -88,6 +88,8 @@ checkCondaPackageVersion "markdown" "3.8.1"
 checkCondaPackageVersion "python-dotenv" "1.2.2"
 checkCondaPackageVersion "pyasn1" "0.6.3"
 checkCondaPackageVersion "ujson" "5.12.1"
+checkCondaPackageVersion "click" "8.4.2"
+checkCondaPackageVersion "idna" "3.18"
 
 check "conda-update-conda" bash -c "conda update -y conda"
 check "conda-install-tensorflow" bash -c "conda create --name test-env -c conda-forge --yes tensorflow"


### PR DESCRIPTION
| GHSA ID | Vulnerability ID | Action | Package | Installed Version | Required Version | Language | Install Path | Image Digest |
|----------|----------|----------|----------|----------|----------|----------|----------|----------|
Python (Pip) Security Update for click (GHSA-47fr-3ffg-hgmw) | 5012984 | Yes, updated to 8.4.2 | click | 8.1.7 | 8.3.3 | Python | opt/conda/lib/python3.12/site-packages/click-8.1.7.dist-info/METADATA | sha256:7de6f67135f63e32d2357da6d1df7d794a03288beb8b10cb05a470b8cf3eb787 |
Python (Pip) Security Update for idna (GHSA-65pc-fj4g-8rjx) | 5012909 | Yes, updated to 3.18 | idna | 3.7 | 3.15 | Python | opt/conda/lib/python3.12/site-packages/idna-3.7.dist-info/METADATA | sha256:98c49662a023995b8614a70080c6facd7a413b0ca098878b6f36067523438ae2 |