### PR TITLE
Use GitHub App token instead of PAT in release workflows

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -9,7 +9,7 @@ on:
         required: true
 
 permissions:
-  contents: write
+  contents: read
 
 
 jobs:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -7,7 +7,7 @@ on:
         type: string
         description: New version, in the form v0.4.x
         required: true
-        
+
 permissions:
   contents: write
 
@@ -19,18 +19,26 @@ jobs:
       target_branch: rel/${{github.event.inputs.version}}
       version: ${{github.event.inputs.version}}
     steps:
+      - name: Generate a token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.DEVCONTAINERS_REPO_AUTOMATION_ID }}
+          private-key: ${{ secrets.DEVCONTAINERS_REPO_AUTOMATION_PRIVATE_KEY }}
       - uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: Install devcontainers CLI
         run: npm i -g @devcontainers/cli
-      - name: Update manifest files 
+      - name: Update manifest files
         run: ./build/prepare-release.sh
       - name: Push manifest updates
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config --global user.email github-actions@github.com
           git config --global user.name github-actions
@@ -40,7 +48,7 @@ jobs:
           git push origin $target_branch
       - name: Create pull request
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh api \
                 --method POST \
@@ -50,5 +58,3 @@ jobs:
               -f body="" \
               -f head="$target_branch" \
               -f base='main'
-
- 

--- a/.github/workflows/version-history.yml
+++ b/.github/workflows/version-history.yml
@@ -31,8 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: publishing
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     steps:
 
       - name: Generate a token

--- a/.github/workflows/version-history.yml
+++ b/.github/workflows/version-history.yml
@@ -35,86 +35,95 @@ jobs:
       pull-requests: write
     steps:
 
-    - name: Free more space
-      id: free_space 
-      run: |
-        set -e
-        # Ensure enough space is available for build
-        sudo apt-get autoremove -y
-        sudo apt-get clean -y
-        sudo rm -rf /usr/share/dotnet
+      - name: Generate a token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.DEVCONTAINERS_REPO_AUTOMATION_ID }}
+          private-key: ${{ secrets.DEVCONTAINERS_REPO_AUTOMATION_PRIVATE_KEY }}
 
-    - name: Checkout
-      id: checkout
-      uses: actions/checkout@v6
+      - name: Free more space
+        id: free_space 
+        run: |
+          set -e
+          # Ensure enough space is available for build
+          sudo apt-get autoremove -y
+          sudo apt-get clean -y
+          sudo rm -rf /usr/share/dotnet
 
-    - name: Get image info
-      id: Get_image_info
-      env:
-        REGISTRY: ${{ secrets.REGISTRY }}
-        REGISTRY_BASE_PATH: ${{ secrets.REGISTRY_BASE_PATH }}
-        STUB_REGISTRY: ${{ secrets.STUB_REGISTRY }}
-        STUB_REGISTRY_BASE_PATH: ${{ secrets.STUB_REGISTRY_BASE_PATH }}
-        TOKEN_NAME: ${{ secrets.TOKEN_NAME }}
-        PASSWORD: ${{ secrets.PASSWORD }}
-      run: |
-        set -e
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
-        # ACR login
-        ACR_REGISTRY_NAME=$(echo "$REGISTRY" | grep -oP '(.+)(?=\.azurecr\.io)')
-        az acr login --name $ACR_REGISTRY_NAME --username $TOKEN_NAME --password $PASSWORD
+      - name: Get image info
+        id: Get_image_info
+        env:
+          REGISTRY: ${{ secrets.REGISTRY }}
+          REGISTRY_BASE_PATH: ${{ secrets.REGISTRY_BASE_PATH }}
+          STUB_REGISTRY: ${{ secrets.STUB_REGISTRY }}
+          STUB_REGISTRY_BASE_PATH: ${{ secrets.STUB_REGISTRY_BASE_PATH }}
+          TOKEN_NAME: ${{ secrets.TOKEN_NAME }}
+          PASSWORD: ${{ secrets.PASSWORD }}
+        run: |
+          set -e
 
-        # This is required to set yarn 4.9.4 as the global yarn version in the runner is 1.22.22
-        sudo corepack enable
-        sudo corepack prepare yarn@4.9.4 --activate
-        yarn install
-        RELEASE_STRING=$(echo "${{ inputs.release }}" | grep -oP 'refs/(heads|tags)/\K(.+)')
-        OVERWRITE_STRING=$(if [ "${{ inputs.overwrite }}" = "false" ]; then echo '--no-overwrite'; else echo '--overwrite'; fi)
-        CG_STRING=$(if [ ${{ inputs.cg }} = "false" ]; then echo '--no-cg'; else echo '--cg'; fi)
+          # ACR login
+          ACR_REGISTRY_NAME=$(echo "$REGISTRY" | grep -oP '(.+)(?=\.azurecr\.io)')
+          az acr login --name $ACR_REGISTRY_NAME --username $TOKEN_NAME --password $PASSWORD
 
-        # Pull images and update cgmanifest.json
-        build/vscdc info  --no-build \
-                          --markdown \
-                          --prune \
-                          --release "$RELEASE_STRING" \
-                          --registry "$REGISTRY" \
-                          --registry-path "$REGISTRY_BASE_PATH" \
-                          --stub-registry "$STUB_REGISTRY" \
-                          --stub-registry-path "$STUB_REGISTRY_BASE_PATH" \
-                          --output-path "$GITHUB_WORKSPACE" \
-                          "$OVERWRITE_STRING" \
-                          "$CG_STRING"
+          # This is required to set yarn 4.9.4 as the global yarn version in the runner is 1.22.22
+          sudo corepack enable
+          sudo corepack prepare yarn@4.9.4 --activate
+          yarn install
+          RELEASE_STRING=$(echo "${{ inputs.release }}" | grep -oP 'refs/(heads|tags)/\K(.+)')
+          OVERWRITE_STRING=$(if [ "${{ inputs.overwrite }}" = "false" ]; then echo '--no-overwrite'; else echo '--overwrite'; fi)
+          CG_STRING=$(if [ ${{ inputs.cg }} = "false" ]; then echo '--no-cg'; else echo '--cg'; fi)
 
-    - name: Create PR with updated image information
-      id: push_image_info
-      env:
-        GITHUB_TOKEN: ${{ secrets.PAT }}
-      run: |
-        set -e
+          # Pull images and update cgmanifest.json
+          build/vscdc info  --no-build \
+                            --markdown \
+                            --prune \
+                            --release "$RELEASE_STRING" \
+                            --registry "$REGISTRY" \
+                            --registry-path "$REGISTRY_BASE_PATH" \
+                            --stub-registry "$STUB_REGISTRY" \
+                            --stub-registry-path "$STUB_REGISTRY_BASE_PATH" \
+                            --output-path "$GITHUB_WORKSPACE" \
+                            "$OVERWRITE_STRING" \
+                            "$CG_STRING"
 
-        # Configure git and Push updates
+      - name: Create PR with updated image information
+        id: push_image_info
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -e
 
-        git config --global user.email github-actions@github.com
-        git config --global user.name github-actions
-        git config pull.rebase false
+          # Configure git and Push updates
 
-        branch=automated-update-for-image-history-$GITHUB_RUN_ID
-        git checkout -b $branch
-        message='Automated update for image history'
+          git config --global user.email github-actions@github.com
+          git config --global user.name github-actions
+          git config pull.rebase false
 
-        # Add / update and commit
-        git add -A
-        git commit -m "$message" || export NO_UPDATES=true
+          branch=automated-update-for-image-history-$GITHUB_RUN_ID
+          git checkout -b $branch
+          message='Automated update for image history'
 
-        # Push (unless disabled for testing)
-        if [ "$NO_UPDATES" != "true" ] && [ "${{ inputs.push }}" = "true" ]; then
-            git push origin "$branch"
-            gh api \
-                --method POST \
-                -H "Accept: application/vnd.github+json" \
-                /repos/${GITHUB_REPOSITORY}/pulls \
-                -f title="$message" \
-              -f body="$message" \
-              -f head="$branch" \
-              -f base='main'
-        fi
+          # Add / update and commit
+          git add -A
+          git commit -m "$message" || export NO_UPDATES=true
+
+          # Push (unless disabled for testing)
+          if [ "$NO_UPDATES" != "true" ] && [ "${{ inputs.push }}" = "true" ]; then
+              git push origin "$branch"
+              gh api \
+                  --method POST \
+                  -H "Accept: application/vnd.github+json" \
+                  /repos/${GITHUB_REPOSITORY}/pulls \
+                  -f title="$message" \
+                -f body="$message" \
+                -f head="$branch" \
+                -f base='main'
+          fi


### PR DESCRIPTION
## Use the `devcontainers-repos-automation` GitHub App token instead of a PAT

### What
Replaces the fine-grained PAT (`secrets.PAT`) in the release-automation workflows with a short-lived GitHub App installation token minted at runtime via `actions/create-github-app-token`.

Affected workflows:
- `.github/workflows/release-pr.yml` (monthly release PR: push manifest updates + create PR)
- `.github/workflows/version-history.yml` (image version-history PR)

### Why
Microsoft open source now caps PAT lifetime at 8 days (down from 3 months), which would force an 8-day rotation cadence. The App private key has no forced expiry, and the installation token it mints is automatically short-lived (~1h) and rotated every run. A PR opened under the App identity still triggers downstream required checks (unlike the built-in `GITHUB_TOKEN`). See devcontainers/internal#343.

### How it works
Each job now:
1. Mints a token with `actions/create-github-app-token@v2` using `vars.DEVCONTAINERS_REPO_AUTOMATION_ID` (org variable) and `secrets.DEVCONTAINERS_REPO_AUTOMATION_PRIVATE_KEY` (org secret, scoped to this repo).
2. Uses that token for `actions/checkout` (so `git push` is attributed to the App) and for the `git push` / `gh api .../pulls` steps in place of `secrets.PAT`.

### Prerequisites (already completed)
- `devcontainers-repos-automation` GitHub App registered on the org and installed on `devcontainers/images` (Contents R/W, Pull requests R/W, Issues R/W, Metadata R).
- Org variable `DEVCONTAINERS_REPO_AUTOMATION_ID` and org secret `DEVCONTAINERS_REPO_AUTOMATION_PRIVATE_KEY` added, scoped to this repo.

### Rotation
Key rotation is documented in the runbook (see devcontainers/internal). Rotation is zero-downtime and does not require the old key.

### Testing

Validated the App-token setup in `devcontainers/images` before merge using two throwaway, push-triggered workflows (each on a temporary branch, auto-cleaned up — no changes to `main`):

1. **Token mint + read + `contents: write`** — [run 30457758847](https://github.com/devcontainers/images/actions/runs/30457758847)
   - `create-github-app-token` minted an installation token scoped to `devcontainers/images`.
   - Confirmed read access (`gh api /repos/...`).
   - Confirmed `contents: write` by creating and deleting a temporary ref.

2. **`pull-requests: write` (PR creation via the App token)** — [run 30538125085](https://github.com/devcontainers/images/actions/runs/30538125085)
   - Opened a draft PR via `gh api POST /pulls` (the exact step both `release-pr.yml` and `version-history.yml` rely on), then auto-closed it and deleted the temporary branches.

Together these exercise every privileged operation these workflows perform (token mint, `checkout`, `git push`, `gh api .../pulls`). All test branches and the temporary test PR were closed/deleted; no artifacts remain.

> Note: `version-history.yml` is a reusable workflow referenced by `push.yml` / `push-dev.yml` as `...version-history.yml@main`, so its change takes effect on the next `push.yml` run after merge.

### Notes / follow-ups
- `secrets.PAT` can be removed from the repo once this is merged and a release run is verified green.
- Consider pinning `actions/create-github-app-token` to a full commit SHA if the repo adopts action pinning.

