### PR TITLE
[typescript]: Add support for Node26 (trixie&bookworm)

### DIFF
--- a/src/typescript-node/README.md
+++ b/src/typescript-node/README.md
@@ -29,7 +29,7 @@ Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/devcontainers/typescript-node:5-24` (or `5-24-trixie`, `5-24-bookworm`, `5-24-bullseye`)
-- `mcr.microsoft.com/devcontainers/typescript-node:5.0-24` (or `5.0-24-trixie`,  `5.0-24-bookworm`, `5.0-24-bullseye`)
+- `mcr.microsoft.com/devcontainers/typescript-node:5.1-24` (or `5.1-24-trixie`, `5.1-24-bookworm`, `5.1-24-bullseye`)
 - `mcr.microsoft.com/devcontainers/typescript-node:5.1.0-24` (or `5.1.0-24-trixie`, `5.1.0-24-bookworm`, `5.1.0-24-bullseye`)
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `5-24`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.

--- a/src/typescript-node/README.md
+++ b/src/typescript-node/README.md
@@ -9,8 +9,8 @@
 | *Categories* | Core, Languages |
 | *Image type* | Dockerfile |
 | *Published image* | mcr.microsoft.com/devcontainers/typescript-node |
-| *Available image variants* | 24 /24-trixie, 22 / 22-trixie, 24-bookworm, 22-bookworm, 24-bullseye, 22-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/typescript-node/tags/list)) |
-| *Published image architecture(s)* | x86-64, arm64/aarch64 for `bookworm`, and `bullseye` variants |
+| *Available image variants* | 26 / 26-trixie, 24 / 24-trixie, 22 / 22-trixie, 26-bookworm, 24-bookworm, 22-bookworm, 24-bullseye, 22-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/typescript-node/tags/list)) |
+| *Published image architecture(s)* | x86-64, arm64/aarch64 for `trixie`, `bookworm`, and `bullseye` variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
 | *Languages, platforms* | Node.js, TypeScript |
@@ -20,6 +20,7 @@
 You can directly reference pre-built versions of `Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
 
 - `mcr.microsoft.com/devcontainers/typescript-node` (latest)
+- `mcr.microsoft.com/devcontainers/typescript-node:26` (or `26-trixie`, `26-bookworm` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/typescript-node:24` (or `24-trixie`, `24-bookworm`, `24-bullseye` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/typescript-node:22` (or `22-trixie`, `22-bookworm`, `22-bullseye` to pin to an OS version)
 
@@ -29,7 +30,7 @@ You can decide how often you want updates by referencing a [semantic version](ht
 
 - `mcr.microsoft.com/devcontainers/typescript-node:5-24` (or `5-24-trixie`, `5-24-bookworm`, `5-24-bullseye`)
 - `mcr.microsoft.com/devcontainers/typescript-node:5.0-24` (or `5.0-24-trixie`,  `5.0-24-bookworm`, `5.0-24-bullseye`)
-- `mcr.microsoft.com/devcontainers/typescript-node:5.0.3-24` (or `5.0.3-24-trixie`, `5.0.3-24-bookworm`, `5.0.3-24-bullseye`)
+- `mcr.microsoft.com/devcontainers/typescript-node:5.1.0-24` (or `5.1.0-24-trixie`, `5.1.0-24-bookworm`, `5.1.0-24-bullseye`)
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `5-24`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 

--- a/src/typescript-node/manifest.json
+++ b/src/typescript-node/manifest.json
@@ -1,8 +1,10 @@
 {
-	"version": "5.0.3",
+	"version": "5.1.0",
 	"variants": [
+		"26-trixie",
 		"24-trixie",
 		"22-trixie",
+		"26-bookworm",
 		"24-bookworm",
 		"22-bookworm",
 		"24-bullseye",
@@ -13,11 +15,19 @@
 		"rootDistro": "debian",
 		"parent": "javascript-node",
 		"architectures": {
+			"26-trixie": [
+				"linux/amd64",
+				"linux/arm64"
+			],
 			"24-trixie": [
 				"linux/amd64",
 				"linux/arm64"
 			],
 			"22-trixie": [
+				"linux/amd64",
+				"linux/arm64"
+			],
+			"26-bookworm": [
 				"linux/amd64",
 				"linux/arm64"
 			],
@@ -42,6 +52,9 @@
 			"typescript-node:${VERSION}-${VARIANT}"
 		],
 		"variantTags": {
+			"26-trixie": [
+				"typescript-node:${VERSION}-26"
+			],
 			"24-trixie": [
 				"typescript-node:${VERSION}-24",
 				"typescript-node:${VERSION}-trixie"


### PR DESCRIPTION
# [typescript]: Add support for Node26 (trixie&bookworm)

## Summary
Introduce Node 26 for the `typescript-node` image; version `5.0.3` → `5.1.0`. Purely additive , no variants removed, no defaults changed.

## Changes

- Add `26-trixie`, `26-bookworm` to `manifest.json` (variants, architectures, variantTags) with `linux/amd64` + `linux/arm64`; `26-trixie` owns the `-26` tag.
- Bump manifest version to `5.1.0` and sync the README variant table, architecture line, OS-pin list, and version examples.

## Notes

- Minor bump — the addition is non-breaking and nothing was removed or retargeted.
- `latest` stays `24-trixie` , Node 26 isn't Active LTS until Oct 2026. This matches `javascript-node`, which also ships Node 26 without making it `latest`.
- `26-bookworm` intentionally has no `variantTags` entry, mirroring `22-bookworm`/`22-bullseye`. It still publishes `5.1.0-26-bookworm`, `5.1-26-bookworm`, `5-26-bookworm` from the base `tags` array. The short `-26` alias points at trixie by design, exactly as `-24` → `24-trixie`; assigning it to both variants would make two variants claim one tag.
- No Dockerfile change. Since the manifest declares `parent: javascript-node`, `prepDockerFile` rewrites the `ARG VARIANT`/`FROM` block at build time from the parent's own manifest version, so the checked-in `FROM ...javascript-node:4-${VARIANT}` literal is not used during a release build and Node 26 resolves on its own.
- Depends on the parent image: `javascript-node` already publishes `5-26-trixie` and `5-26-bookworm` (v5.0.2).

## Tests

- `manifest.json` validates as JSON; variants, architectures and variantTags are consistent.
- Upstream base tag validation: 8/8 variants valid, including `node:26-trixie` and `node:26-bookworm`.
- Clean local build from a pruned cache succeeded (exit 0); all 26 default smoke tests passed.
- Node 26 verified on both new variants using release-equivalent parent tags ,`node v26.5.0`, `tsc 7.0.2` on trixie and bookworm.

## Impact

- New: `:26`, `:26-trixie`, `:26-bookworm` tags available.
- No breaking changes , `latest` and all existing Node 22/24 tags are unaffected.