### PR TITLE
[jekyll] - Fix failing build pipeline

### DIFF
--- a/src/jekyll/.devcontainer/Dockerfile
+++ b/src/jekyll/.devcontainer/Dockerfile
@@ -19,10 +19,6 @@ RUN gem install sass-embedded -v 1.62.1
 RUN gem install jekyll-sass-converter -v 3.0.0
 RUN gem install bundler jekyll github-pages
 
-RUN chown -R "vscode:rvm" "/usr/local/rvm/" \
-    && chmod -R g+r+w "/usr/local/rvm/" \
-    && find "/usr/local/rvm/" -type d | xargs -n 1 chmod g+s
-
 COPY post-create.sh /usr/local/post-create.sh
 
 # Fixing vulnerability issue by upgrading svn to 1.14.5. Ref https://subversion.apache.org/security/CVE-2024-46901-advisory.txt

--- a/src/jekyll/README.md
+++ b/src/jekyll/README.md
@@ -37,7 +37,7 @@ You can directly reference pre-built versions of `Dockerfile` by using the `imag
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 - `mcr.microsoft.com/devcontainers/jekyll:2` (or `2-bookworm`, `2-bullseye` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/jekyll:2.3` (or `2.3-bookworm`, `2.3-bullseye`  to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/jekyll:2.3.0` (or `2.3.0-bookworm`, `2.3.0-bullseye` to pin to an OS version)
+- `mcr.microsoft.com/devcontainers/jekyll:2.3.1` (or `2.3.1-bookworm`, `2.3.1-bullseye` to pin to an OS version)
 
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `2-bullseye`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.

--- a/src/jekyll/manifest.json
+++ b/src/jekyll/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.3.0",
+	"version": "2.3.1",
 	"variants": [
 		"3.4-bookworm",
 		"3.3-bookworm",
@@ -63,8 +63,7 @@
 			"github-pages"
 		],
 		"other": {
-			"git": {},
-			"rvm": null
+			"git": {}
 		},
 		"languages": {
 			"Ruby": {


### PR DESCRIPTION
## Description

The Jekyll image build was failing with the following error:

```text
chown: invalid group: 'vscode:rvm'
```

The Ruby image no longer creates the `rvm` group or uses `/usr/local/rvm` following these changes:

- https://github.com/devcontainers/images/pull/1957
- https://github.com/devcontainers/features/pull/1654

This PR removes the obsolete RVM ownership and permission commands from the Jekyll image.

## Changes

- Removed the ownership and permission operations targeting `/usr/local/rvm`.
- Removed the stale RVM dependency metadata from the Jekyll manifest.
- Bumped the Jekyll image version from `2.3.0` to `2.3.1`.

## Validation

- Verified that the Jekyll image no longer references the removed `rvm` group or `/usr/local/rvm`.
- Confirmed that the updated manifest is valid JSON.