### PR TITLE
[universal] - Internal cleanup to save disk space and pinning jdkDistro as `open` as workaround for java feature installation failure.

### DIFF
--- a/src/universal/.devcontainer/Dockerfile
+++ b/src/universal/.devcontainer/Dockerfile
@@ -82,7 +82,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && printf "$FISH_PROMPT" >> /etc/fish/functions/fish_prompt.fish \
     && printf "if type code-insiders > /dev/null 2>&1; and not type code > /dev/null 2>&1\n  alias code=code-insiders\nend" >> /etc/fish/conf.d/code_alias.fish \   
     # Remove scripts now that we're done with them
-    && apt-get clean -y && rm -rf /tmp/scripts
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/scripts
 
 # Default to bash shell (other shells available at /usr/bin/fish and /usr/bin/zsh)
 ENV SHELL=/bin/bash \

--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -44,7 +44,8 @@
             "version": "25",
             "additionalVersions": "21",
             "installGradle": "true",
-            "installMaven": "true"
+            "installMaven": "true",
+			"jdkDistro": "open"
         },
         "ghcr.io/devcontainers/features/sshd:1": {
             "version": "latest"

--- a/src/universal/.devcontainer/devcontainer.json
+++ b/src/universal/.devcontainer/devcontainer.json
@@ -45,7 +45,7 @@
             "additionalVersions": "21",
             "installGradle": "true",
             "installMaven": "true",
-			"jdkDistro": "open"
+            "jdkDistro": "open"
         },
         "ghcr.io/devcontainers/features/sshd:1": {
             "version": "latest"

--- a/src/universal/.devcontainer/local-features/jekyll/install.sh
+++ b/src/universal/.devcontainer/local-features/jekyll/install.sh
@@ -22,9 +22,9 @@ if ! jekyll --version > /dev/null ; then
     GEMS_DIR=/usr/local/rubies/current/bin
     PATH="${GEMS_DIR}:${PATH}"
     if [ "${VERSION}" = "latest" ]; then
-        gem install jekyll
+        gem install jekyll --no-document
     else
-        gem install jekyll -v "${VERSION}"
+        gem install jekyll -v "${VERSION}" --no-document
     fi
 
     chown -R "${USERNAME}:ruby" "${GEMS_DIR}/"
@@ -33,7 +33,8 @@ if ! jekyll --version > /dev/null ; then
 
     # Make sure the user has the necessary permissions to install the gems
     RUBY_GEMS_DIR=/usr/local/rubies/current/lib/ruby/gems
-    
+
+    find "${RUBY_GEMS_DIR}" -type f -path '*/cache/*.gem' -delete
     chown -R "${USERNAME}:ruby" "${RUBY_GEMS_DIR}/"
     chmod -R g+r+w "${RUBY_GEMS_DIR}/"
     find "${RUBY_GEMS_DIR}" -type d | xargs -n 1 chmod g+s

--- a/src/universal/.devcontainer/local-features/patch-conda/install.sh
+++ b/src/universal/.devcontainer/local-features/patch-conda/install.sh
@@ -77,3 +77,5 @@ update_conda_package brotli "1.2.0"
 # https://github.com/advisories/GHSA-mf9w-mj56-hr94
 update_python_package /opt/conda/bin/python3 python-dotenv "1.2.2"
 
+sudo_if "conda clean --all --yes"
+

--- a/src/universal/.devcontainer/local-features/patch-conda/install.sh
+++ b/src/universal/.devcontainer/local-features/patch-conda/install.sh
@@ -25,7 +25,7 @@ sudo_if() {
     if [ "$(id -u)" -eq 0 ] && [ "$USERNAME" != "root" ]; then
         su - "$USERNAME" -c "$COMMAND"
     else
-        "$COMMAND"
+        bash -c "$COMMAND"
     fi
 }
 

--- a/src/universal/README.md
+++ b/src/universal/README.md
@@ -29,7 +29,7 @@ For example:
 
 - `mcr.microsoft.com/devcontainers/universal:6-noble`
 - `mcr.microsoft.com/devcontainers/universal:6.1-noble`
-- `mcr.microsoft.com/devcontainers/universal:6.1.1-noble`
+- `mcr.microsoft.com/devcontainers/universal:6.1.3-noble`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/devcontainers/universal/tags/list).
 

--- a/src/universal/manifest.json
+++ b/src/universal/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "6.1.2",
+	"version": "6.1.3",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",


### PR DESCRIPTION
## Summary

Reduce the disk footprint of the Universal image by removing package-manager caches and unnecessary generated documentation after installation.

This is an internal cleanup only. It does not intentionally remove any supported tools or change the image's user-facing functionality.

## Changes

- Remove `/var/lib/apt/lists/*` after the final `apt-get` operation.
- Run `conda clean --all --yes` after applying Conda and Python package updates.
- Install Jekyll gems with `--no-document`.
- Remove cached `.gem` packages after installing Jekyll.
- Explicitly configure the Java feature to use the OpenJDK distribution. This is to provide a workaround solution for [this failure](https://github.com/devcontainers/images/actions/runs/32737385074/job/97463364871#step:4:15198). Permanent solution to be implemented in java dev container feature.
- Bump the Universal image patch version from `6.1.2` to `6.1.3`.
- Update the Universal README's versioned image example to `6.1.3-noble`.

## Motivation

Package-manager metadata, downloaded package archives, gem documentation, and installation caches are not needed at runtime. Removing these artifacts from the final image reduces its stored size while preserving the installed development tools.

## Validation

- [x] Confirmed the change contains no whitespace errors with `git diff --check`.
- [x] Confirmed the Universal manifest uses version `6.1.3`.
- [x] Updated the README version reference to match the manifest.
- [x] Confirmed Git LFS and the repository pre-push hook work locally.
- [x] `./.github/actions/smoke-test/test.sh universal 10`
  - The current run exits during the existing in-container tool checks before reaching image-size validation.
  - No smoke-test behavior was changed by this PR.

## Expected Impact

- Smaller Universal image layers and reduced final image disk usage.
- No intentional change to the set of supported development tools.
- No breaking user-facing changes.