### PR TITLE
[ruby, jekyll] - Fixing image extractor issue with invalid path

### DIFF
--- a/src/jekyll/manifest.json
+++ b/src/jekyll/manifest.json
@@ -51,7 +51,6 @@
 		"git": {
 			"Oh My Zsh!": "/home/vscode/.oh-my-zsh",
 			"nvm": "/usr/local/share/nvm",
-			"rbenv": "/usr/local/share/rbenv",
 			"ruby-build": "/usr/local/share/ruby-build"
 		},
 		"gem": [

--- a/src/ruby/manifest.json
+++ b/src/ruby/manifest.json
@@ -96,7 +96,6 @@
 		"git": {
 			"Oh My Zsh!": "/home/vscode/.oh-my-zsh",
 			"nvm": "/usr/local/share/nvm",
-			"rbenv": "/usr/local/share/rbenv",
 			"ruby-build": "/usr/local/share/ruby-build"
 		},
 		"gem": [


### PR DESCRIPTION
## Description

PR [#1957](https://github.com/devcontainers/images/pull/1957) changed the Ruby image base to the official `ruby` image. Following that change, `/usr/local/share/rbenv` is no longer available in the Ruby or Jekyll images.

The stale manifest entry caused image content extraction to [fail](https://github.com/devcontainers/images/actions/runs/32837828279/job/98140120166#step:5:9238) when it attempted to inspect the nonexistent directory.

This PR removes the invalid `/usr/local/share/rbenv` Git dependency from the Ruby and Jekyll manifests. The `/usr/local/share/ruby-build` entry is retained because it remains a valid Git checkout.

## Testing

- Confirmed `/usr/local/share/rbenv` is absent from the images.
- Confirmed `/usr/local/share/ruby-build` exists and points to `https://github.com/rbenv/ruby-build.git`.
- Validated both modified manifests parse successfully and no longer declare the `rbenv` path.