### PR TITLE
Fixing image extractor tool issues due to missing rvm and rbenv paths across images.

### DIFF
--- a/build/config.json
+++ b/build/config.json
@@ -146,11 +146,6 @@
 			"path": "/usr/local/sdkman",
 			"downloadUrl": "https://github.com/sdkman/sdkman-cli"
 		},
-		"rvm": {
-			"versionCommand": "cat /usr/local/rvm/VERSION",
-			"path": "/usr/local/rvm",
-			"downloadUrl": "https://github.com/rvm/rvm"
-		},
 		"kubectl": {
 			"versionCommand": "kubectl version --client --output=json | jq -r '.clientVersion .gitVersion'",
 			"path": "/usr/local/bin",

--- a/src/ruby/manifest.json
+++ b/src/ruby/manifest.json
@@ -104,8 +104,7 @@
 			"debase"
 		],
 		"other": {
-			"git": {},
-			"rvm": null
+			"git": {}
 		},
 		"languages": {
 			"Ruby": {

--- a/src/universal/manifest.json
+++ b/src/universal/manifest.json
@@ -87,7 +87,6 @@
 		"git": {
 			"Oh My Zsh!": "/home/codespace/.oh-my-zsh",
 			"nvm": "/usr/local/share/nvm",
-			"rbenv": "/usr/local/share/rbenv",
 			"ruby-build": "/usr/local/share/ruby-build"
 		},
 		"gem": [


### PR DESCRIPTION
## Description:

The image extractor tool responsible for creating the history documentation post images release [failed](https://github.com/devcontainers/images/actions/runs/33069662040/job/98630254391#step:5:14104) once again during the last monthly release due to missing ruby `rvm` and `rbenv` missing dependency paths. This is PR is for fixing all such issues across images originated due the ruby obsolete dependencies. There are are no CI test workflow as of now for image extractor tool and it doesn't exist due to it's design for all practical purposes. Therefore pasting below the extractor local runs after applying the fixes shipped in this PR.  

## Universal image extractor local run:

```
/usr/local/bin/node --experimental-network-inspection ./build/vscdc info universal --no-build --markdown --cg --overwrite --prune --release main --github-repo devcontainers/images --registry mcr.microsoft.com --registryPath devcontainers
devcontainers CLI
Copyright (c) Microsoft Corporation. All rights reserved.

(*) Generating image information files...
(*) Pulling image mcr.microsoft.com/devcontainers/universal:dev-noble...
(*) Spawn: docker pull mcr.microsoft.com/devcontainers/universal:dev-noble
(*) Spawn: docker run -d --rm --init --privileged --name vscdc--extract--1788193717056 mcr.microsoft.com/devcontainers/universal:dev-noble sh -c "while sleep 1000; do :; done"
(*) Spawn: docker exec -u root vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && cat /etc/os-release && echo && echo ~~~END~~~"
(*) Spawn: docker inspect --format='{{.Image}}' vscdc--extract--1788193717056
(*) Spawn: docker inspect --format='{{index .RepoDigests 0}}' sha256:99f7e94922b26c8c4b885e90b667e969e051fc03b54b38d1ebaac8ad3a4ec9ea

(*) Spawn: docker exec -u root vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && id -un 1000 && echo && echo ~~~END~~~"
(*) Gathering information about Linux package versions...
(*) Spawn: docker exec -u root vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && dpkg-query --show -f='\${Package} ~~v~~ \${Version}
' apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh moby-cli moby-engine git-lfs cmake build-essential cmake cppcheck valgrind lldb llvm gdb clang python3-dev vim vim-doc xtail software-properties-common libsecret-1-dev libnss3 libnspr4 libatk-bridge2.0-0 libatk1.0-0 libx11-6 libpangocairo-1.0-0 libx11-xcb1 libcups2 libxcomposite1 libxdamage1 libxfixes3 libpango-1.0-0 libgbm1 libgtk-3-0 openssh-server lxc pigz iptables tar g++ gcc libc6-dev make pkg-config sed python3-minimal || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(*) Gathering information about Linux package download URLs...
(*) Spawn: docker exec -u root vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && apt-get update && apt-get install -y --reinstall --print-uris apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh moby-cli moby-engine git-lfs cmake build-essential cmake cppcheck valgrind lldb llvm gdb clang python3-dev vim vim-doc xtail software-properties-common libsecret-1-dev libnss3 libnspr4 libatk-bridge2.0-0 libatk1.0-0 libx11-6 libpangocairo-1.0-0 libx11-xcb1 libcups2 libxcomposite1 libxdamage1 libxfixes3 libpango-1.0-0 libgbm1 libgtk-3-0 openssh-server lxc pigz iptables tar g++ gcc libc6-dev make pkg-config sed python3-minimal || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(*) Fallback pool URL for apt-transport-https is undefined
(!) No URI found for apt-transport-https 2.8.3.
(*) Fallback pool URL for apt-utils is undefined
(!) No URI found for apt-utils 2.8.3.
(*) Fallback pool URL for build-essential is undefined
(!) No URI found for build-essential 12.10ubuntu1.
(*) Fallback pool URL for ca-certificates is undefined
(!) No URI found for ca-certificates 20260601~24.04.1.
(*) Fallback pool URL for clang is undefined
(!) No URI found for clang 1:18.0-59~exp2.
(*) Fallback pool URL for cmake is undefined
(!) No URI found for cmake 3.28.3-1build7.
(*) Fallback pool URL for cppcheck is undefined
(!) No URI found for cppcheck 2.13.0-2ubuntu3.
(*) Fallback pool URL for curl is undefined
(!) No URI found for curl 8.5.0-2ubuntu10.13.
(*) Fallback pool URL for dialog is undefined
(!) No URI found for dialog 1.3-20240101-1.
(*) Fallback pool URL for g++ is undefined
(!) No URI found for g++ 4:13.2.0-7ubuntu1.
(*) Fallback pool URL for gcc is undefined
(!) No URI found for gcc 4:13.2.0-7ubuntu1.
(*) Fallback pool URL for gdb is undefined
(!) No URI found for gdb 15.1-1ubuntu1~24.04.1.
(*) Fallback pool URL for git is undefined
(!) No URI found for git 1:2.43.0-1ubuntu7.3.
(*) Fallback pool URL for gnupg2 is undefined
(!) No URI found for gnupg2 2.4.4-2ubuntu17.4.
(*) Fallback pool URL for htop is undefined
(!) No URI found for htop 3.3.0-4build1.
(*) Fallback pool URL for iproute2 is undefined
(!) No URI found for iproute2 6.1.0-1ubuntu6.4.
(*) Fallback pool URL for iptables is undefined
(!) No URI found for iptables 1.8.10-3ubuntu2.
(*) Fallback pool URL for jq is undefined
(!) No URI found for jq 1.7.1-3ubuntu0.24.04.2.
(*) Fallback pool URL for less is undefined
(!) No URI found for less 590-2ubuntu2.1.
(*) Fallback pool URL for libc6 is undefined
(!) No URI found for libc6 2.39-0ubuntu8.8.
(*) Fallback pool URL for libc6-dev is undefined
(!) No URI found for libc6-dev 2.39-0ubuntu8.8.
(!) Warning: Unable to parse output "libgcc1 ~~v~~" - skipping.
(*) Fallback pool URL for libgssapi-krb5-2 is undefined
(!) No URI found for libgssapi-krb5-2 1.20.1-6ubuntu2.8.
(*) Fallback pool URL for libicu74 is undefined
(!) No URI found for libicu74 74.2-1ubuntu3.1.
(*) Fallback pool URL for libkrb5-3 is undefined
(!) No URI found for libkrb5-3 1.20.1-6ubuntu2.8.
(!) Warning: Unable to parse output "liblttng-ust1 ~~v~~" - skipping.
(*) Fallback pool URL for libnspr4 is undefined
(!) No URI found for libnspr4 2:4.35-1.1build1.
(*) Fallback pool URL for libnss3 is undefined
(!) No URI found for libnss3 2:3.98-1ubuntu0.2.
(*) Fallback pool URL for libpango-1.0-0 is undefined
(!) No URI found for libpango-1.0-0 1.52.1+ds-1build1.
(*) Fallback pool URL for libpangocairo-1.0-0 is undefined
(!) No URI found for libpangocairo-1.0-0 1.52.1+ds-1build1.
(*) Fallback pool URL for libsecret-1-dev is undefined
(!) No URI found for libsecret-1-dev 0.21.4-1build3.
(*) Fallback pool URL for libstdc++6 is undefined
(!) No URI found for libstdc++6 14.2.0-4ubuntu2~24.04.1.
(*) Fallback pool URL for libx11-6 is undefined
(!) No URI found for libx11-6 2:1.8.7-1build1.
(!) Warning: Unable to parse output "libx11-xcb1 ~~v~~" - skipping.
(*) Fallback pool URL for lldb is undefined
(!) No URI found for lldb 1:18.0-59~exp2.
(*) Fallback pool URL for llvm is undefined
(!) No URI found for llvm 1:18.0-59~exp2.
(*) Fallback pool URL for locales is undefined
(!) No URI found for locales 2.39-0ubuntu8.8.
(*) Fallback pool URL for lsb-release is undefined
(!) No URI found for lsb-release 12.0-2.
(*) Fallback pool URL for lsof is undefined
(!) No URI found for lsof 4.95.0-1build3.
(*) Fallback pool URL for make is undefined
(!) No URI found for make 4.3-4.1build2.
(*) Fallback pool URL for man-db is undefined
(!) No URI found for man-db 2.12.0-4build2.
(*) Fallback pool URL for manpages is undefined
(!) No URI found for manpages 6.7-2.
(*) Fallback pool URL for manpages-dev is undefined
(!) No URI found for manpages-dev 6.7-2.
(*) Fallback pool URL for moby-cli is https://packages.microsoft.com/repos/microsoft-ubuntu-focal-prod
(*) Fallback pool URL for moby-engine is https://packages.microsoft.com/repos/microsoft-ubuntu-focal-prod
(*) Fallback pool URL for nano is undefined
(!) No URI found for nano 7.2-2ubuntu0.2.
(*) Fallback pool URL for ncdu is undefined
(!) No URI found for ncdu 1.19-0.1.
(*) Fallback pool URL for net-tools is undefined
(!) No URI found for net-tools 2.10-0.1ubuntu4.4.
(*) Fallback pool URL for openssh-client is undefined
(!) No URI found for openssh-client 1:9.6p1-3ubuntu13.18.
(*) Fallback pool URL for openssh-server is undefined
(!) No URI found for openssh-server 1:9.6p1-3ubuntu13.18.
(*) Fallback pool URL for pigz is undefined
(!) No URI found for pigz 2.8-1.
(*) Fallback pool URL for pkg-config is undefined
(!) No URI found for pkg-config 1.8.1-2build1.
(*) Fallback pool URL for procps is undefined
(!) No URI found for procps 2:4.0.4-4ubuntu3.3.
(*) Fallback pool URL for psmisc is undefined
(!) No URI found for psmisc 23.7-1build1.
(*) Fallback pool URL for python3-dev is undefined
(!) No URI found for python3-dev 3.12.3-0ubuntu2.1.
(*) Fallback pool URL for python3-minimal is undefined
(!) No URI found for python3-minimal 3.12.3-0ubuntu2.1.
(*) Fallback pool URL for rsync is undefined
(!) No URI found for rsync 3.2.7-1ubuntu1.5.
(*) Fallback pool URL for sed is undefined
(!) No URI found for sed 4.9-2ubuntu0.24.04.1.
(*) Fallback pool URL for software-properties-common is undefined
(!) No URI found for software-properties-common 0.99.49.4.
(*) Fallback pool URL for strace is undefined
(!) No URI found for strace 6.8-0ubuntu2.
(*) Fallback pool URL for sudo is undefined
(!) No URI found for sudo 1.9.15p5-3ubuntu5.24.04.2.
(*) Fallback pool URL for tar is undefined
(!) No URI found for tar 1.35+dfsg-3ubuntu0.4.
(*) Fallback pool URL for unzip is undefined
(!) No URI found for unzip 6.0-28ubuntu4.1.
(*) Fallback pool URL for valgrind is undefined
(!) No URI found for valgrind 1:3.22.0-0ubuntu3.
(*) Fallback pool URL for vim is undefined
(!) No URI found for vim 2:9.1.0016-1ubuntu7.20.
(*) Fallback pool URL for vim-doc is undefined
(!) No URI found for vim-doc 2:9.1.0016-1ubuntu7.20.
(*) Fallback pool URL for vim-tiny is undefined
(!) No URI found for vim-tiny 2:9.1.0016-1ubuntu7.20.
(*) Fallback pool URL for wget is undefined
(!) No URI found for wget 1.21.4-1ubuntu4.5.
(*) Fallback pool URL for xtail is undefined
(!) No URI found for xtail 2.1-9.
(*) Fallback pool URL for zip is undefined
(!) No URI found for zip 3.0-13ubuntu0.2.
(*) Fallback pool URL for zlib1g is undefined
(!) No URI found for zlib1g 1:1.3.dfsg-3.1ubuntu2.2.
(*) Fallback pool URL for zsh is undefined
(!) No URI found for zsh 5.9-6ubuntu2.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libssl1.1" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libssl1.0.[0-9]" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching manpages-posix" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching manpages-posix-dev" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching git-lfs" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libatk-bridge2.0-0" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libatk1.0-0" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libcups2" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libxcomposite1" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libxdamage1" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libxfixes3" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libgbm1" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libgtk-3-0" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching lxc" - skipping.
(!) Warning: Some specified packages were not found.
(*) Gathering information about pip packages...
(*) Spawn: docker exec -u codespace vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && pip list --disable-pip-version-check --format json && echo && echo ~~~END~~~"
(!) Warning: Could not determine version for pip package "numpy" - skipping.
(!) Warning: Could not determine version for pip package "pandas" - skipping.
(!) Warning: Could not determine version for pip package "scipy" - skipping.
(!) Warning: Could not determine version for pip package "matplotlib" - skipping.
(!) Warning: Could not determine version for pip package "seaborn" - skipping.
(!) Warning: Could not determine version for pip package "scikit-learn" - skipping.
(!) Warning: Could not determine version for pip package "torch" - skipping.
(!) Warning: Could not determine version for pip package "plotly" - skipping.
(!) Warning: Could not determine version for pip package "setuptools" - skipping.
(*) Gathering information about pip packages...
(*) Spawn: docker exec vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && pipx list && echo && echo ~~~END~~~"
(*) Gathering information about gems...
(*) Spawn: docker exec vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && bash -l -c 'set -e && gem list -d --local' 2>/dev/null && echo && echo ~~~END~~~"
(*) Gathering information about go modules and packages...
(*) Spawn: docker exec vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && cat /usr/local/etc/vscode-dev-containers/go.log && echo && echo ~~~END~~~"
(*) Getting remote and commit for Oh My Zsh! at /home/codespace/.oh-my-zsh...
(*) Spawn: docker exec -u root vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/home/codespace/.oh-my-zsh\" && cd \"/home/codespace/.oh-my-zsh\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for nvm at /usr/local/share/nvm...
(*) Spawn: docker exec -u root vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/nvm\" && cd \"/usr/local/share/nvm\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for ruby-build at /usr/local/share/ruby-build...
(*) Spawn: docker exec -u root vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/ruby-build\" && cd \"/usr/local/share/ruby-build\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for git...
(*) Spawn: docker exec vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && git --version | sed -n '/git version /s///p' && echo && echo ~~~END~~~"
(*) Getting version for Xdebug...
(*) Spawn: docker exec vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && php --version | grep -oP 'with\s+Xdebug\s+v\K[0-9]+\.[0-9]+\.[0-9]+' && echo && echo ~~~END~~~"
(*) Getting version for Composer...
(*) Spawn: docker exec vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && composer --no-ansi --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' && echo && echo ~~~END~~~"
(*) Getting version for kubectl...
(*) Spawn: docker exec vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && kubectl version --client --output=json | jq -r '.clientVersion .gitVersion' && echo && echo ~~~END~~~"
(*) Getting version for Helm...
(*) Spawn: docker exec vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && helm version | grep -oP 'Version\s*:\s*\"v\K[0-9]+\.[0-9]+\.[0-9]+' && echo && echo ~~~END~~~"
(*) Getting version for Docker Compose...
(*) Spawn: docker exec vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && docker-compose version | grep -m 1 -oE '[0-9]+\.[0-9]+\.[0-9]+[+0-9a-z]*' && echo && echo ~~~END~~~"
(*) Getting version for SDKMAN!...
(*) Spawn: docker exec vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && . /usr/local/sdkman/bin/sdkman-init.sh && echo 'n' | sdk version | grep -oP 'SDKMAN\s+\K[0-9]+\.[0-9]+\.[0-9]+[+0-9a-z]*' | tr -d '[:cntrl:]' && echo && echo ~~~END~~~"
(*) Getting version for GitHub CLI...
(*) Spawn: docker exec vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && gh version 2>&1 | grep -oP 'version\s\K[^ ]+' && echo && echo ~~~END~~~"
(*) Getting version for yarn...
(*) Spawn: docker exec vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && yarn --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' && echo && echo ~~~END~~~"
(*) Getting version for Maven...
(*) Spawn: docker exec vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && mvn -version | grep -oP '^Apache\sMaven\s+\K[0-9]+\.[0-9]+[\.+0-9a-z]*' && echo && echo ~~~END~~~"
(*) Getting version for Gradle...
(*) Spawn: docker exec vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && gradle --version | grep -oP '^Gradle\s+\K[0-9]+\.[0-9]+(\.[0-9]+)?$' && echo && echo ~~~END~~~"
(*) Getting version for Docker (Moby) CLI & Engine...
(*) Spawn: docker exec vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && docker --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+[+0-9a-z]*' && echo && echo ~~~END~~~"
(*) Getting version for conda...
(*) Spawn: docker exec vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && conda --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for Node.js...
(*) Spawn: docker exec -u codespace vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && ls /usr/local/share/nvm/versions/node | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' && echo && echo ~~~END~~~"
(*) Getting version for Python...
(*) Spawn: docker exec -u codespace vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && ls /usr/local/python | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' && echo && echo ~~~END~~~"
(*) Getting version for Java...
(*) Spawn: docker exec -u codespace vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && ls /usr/local/sdkman/candidates/java | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' && echo && echo ~~~END~~~"
(*) Getting version for .NET...
(*) Spawn: docker exec -u codespace vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && dotnet --version && echo && echo ~~~END~~~"
(*) Getting version for Ruby...
(*) Spawn: docker exec -u codespace vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && ls /usr/local/rubies | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' && echo && echo ~~~END~~~"
(*) Getting version for PHP...
(*) Spawn: docker exec -u codespace vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && ls /usr/local/php | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' && echo && echo ~~~END~~~"
(*) Getting version for GCC...
(*) Spawn: docker exec -u codespace vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && gcc --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+.*)' | tr -d ')' && echo && echo ~~~END~~~"
(*) Getting version for Clang...
(*) Spawn: docker exec -u codespace vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && clang --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+.*' && echo && echo ~~~END~~~"
(*) Getting version for Go...
(*) Spawn: docker exec -u codespace vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && go version | grep -oP -m 1 'version\sgo\K[^ ]+' && echo && echo ~~~END~~~"
(*) Getting version for Jekyll...
(*) Spawn: docker exec -u codespace vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && jekyll --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' && echo && echo ~~~END~~~"
(*) Getting version for Jupyter Lab...
(*) Spawn: docker exec -u codespace vscdc--extract--1788193717056 bash -c "set -e && echo ~~~BEGIN~~~ && jupyter-lab --version && echo && echo ~~~END~~~"
(*) Spawn: docker rm -f vscdc--extract--1788193717056
(!) Warning: No version for package undefined - skipping markdown output.
(!) Warning: No version for package undefined - skipping markdown output.
(!) Warning: No version for package SDKMAN! - skipping markdown output.
(*) Writing image history markdown...
(*) Spawn: docker image prune -a -f
(*) Writing cgmanifest.json...
(*) Done!
```

## Ruby 

```
/usr/local/bin/node --experimental-network-inspection ./build/vscdc info ruby --no-build --markdown --cg --overwrite --prune --release main --github-repo devcontainers/images --registry mcr.microsoft.com --registryPath devcontainers
devcontainers CLI
Copyright (c) Microsoft Corporation. All rights reserved.

(*) Generating image information files...

(*) Processing variant 4.0-trixie...
(*) Pulling image mcr.microsoft.com/devcontainers/ruby:dev-4.0-trixie...
(*) Spawn: docker pull mcr.microsoft.com/devcontainers/ruby:dev-4.0-trixie
(*) Spawn: docker run -d --rm --init --privileged --name vscdc--extract--1788194341215 mcr.microsoft.com/devcontainers/ruby:dev-4.0-trixie sh -c "while sleep 1000; do :; done"
(*) Spawn: docker exec -u root vscdc--extract--1788194341215 bash -c "set -e && echo ~~~BEGIN~~~ && cat /etc/os-release && echo && echo ~~~END~~~"
(*) Spawn: docker inspect --format='{{.Image}}' vscdc--extract--1788194341215
(*) Spawn: docker inspect --format='{{index .RepoDigests 0}}' sha256:f4650048459646513924d9a0c136dd544af25bd4728cb265a2422988c610001b

(*) Spawn: docker exec -u root vscdc--extract--1788194341215 bash -c "set -e && echo ~~~BEGIN~~~ && id -un 1000 && echo && echo ~~~END~~~"
(*) Gathering information about Linux package versions...
(*) Spawn: docker exec -u root vscdc--extract--1788194341215 bash -c "set -e && echo ~~~BEGIN~~~ && dpkg-query --show -f='\${Package} ~~v~~ \${Version}
' apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(*) Gathering information about Linux package download URLs...
(*) Spawn: docker exec -u root vscdc--extract--1788194341215 bash -c "set -e && echo ~~~BEGIN~~~ && apt-get update && apt-get install -y --reinstall --print-uris apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libssl1.1" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libssl1.0.[0-9]" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching manpages-posix" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching manpages-posix-dev" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching yarn" - skipping.
(*) Fallback pool URL for apt-transport-https is undefined
(!) No URI found for apt-transport-https 3.0.3.
(*) Fallback pool URL for apt-utils is undefined
(!) No URI found for apt-utils 3.0.3.
(*) Fallback pool URL for build-essential is undefined
(!) No URI found for build-essential 12.12.
(*) Fallback pool URL for ca-certificates is undefined
(!) No URI found for ca-certificates 20250419.
(*) Fallback pool URL for curl is undefined
(!) No URI found for curl 8.14.1-2+deb13u4.
(*) Fallback pool URL for dialog is undefined
(!) No URI found for dialog 1.3-20250116-1.
(*) Fallback pool URL for git is undefined
(!) No URI found for git 1:2.47.3-0+deb13u1.
(*) Fallback pool URL for gnupg2 is undefined
(!) No URI found for gnupg2 2.4.7-21+deb13u1.
(*) Fallback pool URL for htop is undefined
(!) No URI found for htop 3.4.1-5.
(*) Fallback pool URL for iproute2 is undefined
(!) No URI found for iproute2 6.15.0-1.
(*) Fallback pool URL for jq is undefined
(!) No URI found for jq 1.7.1-6+deb13u3.
(*) Fallback pool URL for less is undefined
(!) No URI found for less 668-1.
(*) Fallback pool URL for libc6 is undefined
(!) No URI found for libc6 2.41-12+deb13u3.
(!) Warning: Unable to parse output "libgcc1 ~~v~~" - skipping.
(*) Fallback pool URL for libgssapi-krb5-2 is undefined
(!) No URI found for libgssapi-krb5-2 1.21.3-5+deb13u1.
(*) Fallback pool URL for libicu76 is undefined
(!) No URI found for libicu76 76.1-4.
(*) Fallback pool URL for libkrb5-3 is undefined
(!) No URI found for libkrb5-3 1.21.3-5+deb13u1.
(!) Warning: Unable to parse output "liblttng-ust1 ~~v~~" - skipping.
(*) Fallback pool URL for libstdc++6 is undefined
(!) No URI found for libstdc++6 14.2.0-19.
(*) Fallback pool URL for locales is undefined
(!) No URI found for locales 2.41-12+deb13u3.
(*) Fallback pool URL for lsb-release is undefined
(!) No URI found for lsb-release 12.1-1.
(*) Fallback pool URL for lsof is undefined
(!) No URI found for lsof 4.99.4+dfsg-2.
(*) Fallback pool URL for man-db is undefined
(!) No URI found for man-db 2.13.1-1.
(*) Fallback pool URL for manpages is undefined
(!) No URI found for manpages 6.9.1-1.
(*) Fallback pool URL for manpages-dev is undefined
(!) No URI found for manpages-dev 6.9.1-1.
(*) Fallback pool URL for nano is undefined
(!) No URI found for nano 8.4-1+deb13u1.
(*) Fallback pool URL for ncdu is undefined
(!) No URI found for ncdu 1.22-1.
(*) Fallback pool URL for net-tools is undefined
(!) No URI found for net-tools 2.10-1.3.
(*) Fallback pool URL for openssh-client is undefined
(!) No URI found for openssh-client 1:10.0p1-7+deb13u4.
(*) Fallback pool URL for procps is undefined
(!) No URI found for procps 2:4.0.4-9.
(*) Fallback pool URL for psmisc is undefined
(!) No URI found for psmisc 23.7-2.
(*) Fallback pool URL for rsync is undefined
(!) No URI found for rsync 3.4.1+ds1-5+deb13u4.
(*) Fallback pool URL for strace is undefined
(!) No URI found for strace 6.13+ds-1.
(*) Fallback pool URL for sudo is undefined
(!) No URI found for sudo 1.9.16p2-3+deb13u2.
(*) Fallback pool URL for unzip is undefined
(!) No URI found for unzip 6.0-29+deb13u1.
(*) Fallback pool URL for vim-tiny is undefined
(!) No URI found for vim-tiny 2:9.1.1230-2.
(*) Fallback pool URL for wget is undefined
(!) No URI found for wget 1.25.0-2.
(*) Fallback pool URL for zip is undefined
(!) No URI found for zip 3.0-15+deb13u1.
(*) Fallback pool URL for zlib1g is undefined
(!) No URI found for zlib1g 1:1.3.dfsg+really1.3.1-1+b1.
(*) Fallback pool URL for zsh is undefined
(!) No URI found for zsh 5.9-8+b23.
(!) Warning: Some specified packages were not found.
(*) Gathering information about gems...
(*) Spawn: docker exec vscdc--extract--1788194341215 bash -c "set -e && echo ~~~BEGIN~~~ && bash -l -c 'set -e && gem list -d --local' 2>/dev/null && echo && echo ~~~END~~~"
(*) Getting remote and commit for Oh My Zsh! at /home/vscode/.oh-my-zsh...
(*) Spawn: docker exec -u root vscdc--extract--1788194341215 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/home/vscode/.oh-my-zsh\" && cd \"/home/vscode/.oh-my-zsh\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for nvm at /usr/local/share/nvm...
(*) Spawn: docker exec -u root vscdc--extract--1788194341215 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/nvm\" && cd \"/usr/local/share/nvm\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for ruby-build at /usr/local/share/ruby-build...
(*) Spawn: docker exec -u root vscdc--extract--1788194341215 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/ruby-build\" && cd \"/usr/local/share/ruby-build\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for git...
(*) Spawn: docker exec vscdc--extract--1788194341215 bash -c "set -e && echo ~~~BEGIN~~~ && git --version | sed -n '/git version /s///p' && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for Ruby...
(*) Spawn: docker exec vscdc--extract--1788194341215 bash -c "set -e && echo ~~~BEGIN~~~ && ruby --version | grep -oP '^ruby\s+\K[^\s]+' && echo && echo ~~~END~~~"
(*) Spawn: docker rm -f vscdc--extract--1788194341215
(!) Warning: No version for package undefined - skipping markdown output.
(!) Warning: No version for package undefined - skipping markdown output.

(*) Processing variant 3.4-trixie...
(*) Pulling image mcr.microsoft.com/devcontainers/ruby:dev-3.4-trixie...
(*) Spawn: docker pull mcr.microsoft.com/devcontainers/ruby:dev-3.4-trixie
(*) Spawn: docker run -d --rm --init --privileged --name vscdc--extract--1788194360592 mcr.microsoft.com/devcontainers/ruby:dev-3.4-trixie sh -c "while sleep 1000; do :; done"
(*) Spawn: docker exec -u root vscdc--extract--1788194360592 bash -c "set -e && echo ~~~BEGIN~~~ && cat /etc/os-release && echo && echo ~~~END~~~"
(*) Spawn: docker inspect --format='{{.Image}}' vscdc--extract--1788194360592
(*) Spawn: docker inspect --format='{{index .RepoDigests 0}}' sha256:7ba2587ffa59c5733b7c78112e020e653035d19c9daf499b4b98dc0fa103cddc

(*) Spawn: docker exec -u root vscdc--extract--1788194360592 bash -c "set -e && echo ~~~BEGIN~~~ && id -un 1000 && echo && echo ~~~END~~~"
(*) Gathering information about Linux package versions...
(*) Spawn: docker exec -u root vscdc--extract--1788194360592 bash -c "set -e && echo ~~~BEGIN~~~ && dpkg-query --show -f='\${Package} ~~v~~ \${Version}
' apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(*) Gathering information about Linux package download URLs...
(*) Spawn: docker exec -u root vscdc--extract--1788194360592 bash -c "set -e && echo ~~~BEGIN~~~ && apt-get update && apt-get install -y --reinstall --print-uris apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libssl1.1" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libssl1.0.[0-9]" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching manpages-posix" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching manpages-posix-dev" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching yarn" - skipping.
(*) Fallback pool URL for apt-transport-https is undefined
(!) No URI found for apt-transport-https 3.0.3.
(*) Fallback pool URL for apt-utils is undefined
(!) No URI found for apt-utils 3.0.3.
(*) Fallback pool URL for build-essential is undefined
(!) No URI found for build-essential 12.12.
(*) Fallback pool URL for ca-certificates is undefined
(!) No URI found for ca-certificates 20250419.
(*) Fallback pool URL for curl is undefined
(!) No URI found for curl 8.14.1-2+deb13u4.
(*) Fallback pool URL for dialog is undefined
(!) No URI found for dialog 1.3-20250116-1.
(*) Fallback pool URL for git is undefined
(!) No URI found for git 1:2.47.3-0+deb13u1.
(*) Fallback pool URL for gnupg2 is undefined
(!) No URI found for gnupg2 2.4.7-21+deb13u1.
(*) Fallback pool URL for htop is undefined
(!) No URI found for htop 3.4.1-5.
(*) Fallback pool URL for iproute2 is undefined
(!) No URI found for iproute2 6.15.0-1.
(*) Fallback pool URL for jq is undefined
(!) No URI found for jq 1.7.1-6+deb13u3.
(*) Fallback pool URL for less is undefined
(!) No URI found for less 668-1.
(*) Fallback pool URL for libc6 is undefined
(!) No URI found for libc6 2.41-12+deb13u3.
(!) Warning: Unable to parse output "libgcc1 ~~v~~" - skipping.
(*) Fallback pool URL for libgssapi-krb5-2 is undefined
(!) No URI found for libgssapi-krb5-2 1.21.3-5+deb13u1.
(*) Fallback pool URL for libicu76 is undefined
(!) No URI found for libicu76 76.1-4.
(*) Fallback pool URL for libkrb5-3 is undefined
(!) No URI found for libkrb5-3 1.21.3-5+deb13u1.
(!) Warning: Unable to parse output "liblttng-ust1 ~~v~~" - skipping.
(*) Fallback pool URL for libstdc++6 is undefined
(!) No URI found for libstdc++6 14.2.0-19.
(*) Fallback pool URL for locales is undefined
(!) No URI found for locales 2.41-12+deb13u3.
(*) Fallback pool URL for lsb-release is undefined
(!) No URI found for lsb-release 12.1-1.
(*) Fallback pool URL for lsof is undefined
(!) No URI found for lsof 4.99.4+dfsg-2.
(*) Fallback pool URL for man-db is undefined
(!) No URI found for man-db 2.13.1-1.
(*) Fallback pool URL for manpages is undefined
(!) No URI found for manpages 6.9.1-1.
(*) Fallback pool URL for manpages-dev is undefined
(!) No URI found for manpages-dev 6.9.1-1.
(*) Fallback pool URL for nano is undefined
(!) No URI found for nano 8.4-1+deb13u1.
(*) Fallback pool URL for ncdu is undefined
(!) No URI found for ncdu 1.22-1.
(*) Fallback pool URL for net-tools is undefined
(!) No URI found for net-tools 2.10-1.3.
(*) Fallback pool URL for openssh-client is undefined
(!) No URI found for openssh-client 1:10.0p1-7+deb13u4.
(*) Fallback pool URL for procps is undefined
(!) No URI found for procps 2:4.0.4-9.
(*) Fallback pool URL for psmisc is undefined
(!) No URI found for psmisc 23.7-2.
(*) Fallback pool URL for rsync is undefined
(!) No URI found for rsync 3.4.1+ds1-5+deb13u4.
(*) Fallback pool URL for strace is undefined
(!) No URI found for strace 6.13+ds-1.
(*) Fallback pool URL for sudo is undefined
(!) No URI found for sudo 1.9.16p2-3+deb13u2.
(*) Fallback pool URL for unzip is undefined
(!) No URI found for unzip 6.0-29+deb13u1.
(*) Fallback pool URL for vim-tiny is undefined
(!) No URI found for vim-tiny 2:9.1.1230-2.
(*) Fallback pool URL for wget is undefined
(!) No URI found for wget 1.25.0-2.
(*) Fallback pool URL for zip is undefined
(!) No URI found for zip 3.0-15+deb13u1.
(*) Fallback pool URL for zlib1g is undefined
(!) No URI found for zlib1g 1:1.3.dfsg+really1.3.1-1+b1.
(*) Fallback pool URL for zsh is undefined
(!) No URI found for zsh 5.9-8+b23.
(!) Warning: Some specified packages were not found.
(*) Gathering information about gems...
(*) Spawn: docker exec vscdc--extract--1788194360592 bash -c "set -e && echo ~~~BEGIN~~~ && bash -l -c 'set -e && gem list -d --local' 2>/dev/null && echo && echo ~~~END~~~"
(*) Getting remote and commit for Oh My Zsh! at /home/vscode/.oh-my-zsh...
(*) Spawn: docker exec -u root vscdc--extract--1788194360592 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/home/vscode/.oh-my-zsh\" && cd \"/home/vscode/.oh-my-zsh\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for nvm at /usr/local/share/nvm...
(*) Spawn: docker exec -u root vscdc--extract--1788194360592 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/nvm\" && cd \"/usr/local/share/nvm\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for ruby-build at /usr/local/share/ruby-build...
(*) Spawn: docker exec -u root vscdc--extract--1788194360592 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/ruby-build\" && cd \"/usr/local/share/ruby-build\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for git...
(*) Spawn: docker exec vscdc--extract--1788194360592 bash -c "set -e && echo ~~~BEGIN~~~ && git --version | sed -n '/git version /s///p' && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for Ruby...
(*) Spawn: docker exec vscdc--extract--1788194360592 bash -c "set -e && echo ~~~BEGIN~~~ && ruby --version | grep -oP '^ruby\s+\K[^\s]+' && echo && echo ~~~END~~~"
(*) Spawn: docker rm -f vscdc--extract--1788194360592
(!) Warning: No version for package undefined - skipping markdown output.
(!) Warning: No version for package undefined - skipping markdown output.

(*) Processing variant 3.3-trixie...
(*) Pulling image mcr.microsoft.com/devcontainers/ruby:dev-3.3-trixie...
(*) Spawn: docker pull mcr.microsoft.com/devcontainers/ruby:dev-3.3-trixie
(*) Spawn: docker run -d --rm --init --privileged --name vscdc--extract--1788194381310 mcr.microsoft.com/devcontainers/ruby:dev-3.3-trixie sh -c "while sleep 1000; do :; done"
(*) Spawn: docker exec -u root vscdc--extract--1788194381310 bash -c "set -e && echo ~~~BEGIN~~~ && cat /etc/os-release && echo && echo ~~~END~~~"
(*) Spawn: docker inspect --format='{{.Image}}' vscdc--extract--1788194381310
(*) Spawn: docker inspect --format='{{index .RepoDigests 0}}' sha256:967daa1ec377791ba134e52801060f54af9788f88f5aea1f7945e222c48ee150

(*) Spawn: docker exec -u root vscdc--extract--1788194381310 bash -c "set -e && echo ~~~BEGIN~~~ && id -un 1000 && echo && echo ~~~END~~~"
(*) Gathering information about Linux package versions...
(*) Spawn: docker exec -u root vscdc--extract--1788194381310 bash -c "set -e && echo ~~~BEGIN~~~ && dpkg-query --show -f='\${Package} ~~v~~ \${Version}
' apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(*) Gathering information about Linux package download URLs...
(*) Spawn: docker exec -u root vscdc--extract--1788194381310 bash -c "set -e && echo ~~~BEGIN~~~ && apt-get update && apt-get install -y --reinstall --print-uris apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libssl1.1" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libssl1.0.[0-9]" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching manpages-posix" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching manpages-posix-dev" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching yarn" - skipping.
(*) Fallback pool URL for apt-transport-https is undefined
(!) No URI found for apt-transport-https 3.0.3.
(*) Fallback pool URL for apt-utils is undefined
(!) No URI found for apt-utils 3.0.3.
(*) Fallback pool URL for build-essential is undefined
(!) No URI found for build-essential 12.12.
(*) Fallback pool URL for ca-certificates is undefined
(!) No URI found for ca-certificates 20250419.
(*) Fallback pool URL for curl is undefined
(!) No URI found for curl 8.14.1-2+deb13u4.
(*) Fallback pool URL for dialog is undefined
(!) No URI found for dialog 1.3-20250116-1.
(*) Fallback pool URL for git is undefined
(!) No URI found for git 1:2.47.3-0+deb13u1.
(*) Fallback pool URL for gnupg2 is undefined
(!) No URI found for gnupg2 2.4.7-21+deb13u1.
(*) Fallback pool URL for htop is undefined
(!) No URI found for htop 3.4.1-5.
(*) Fallback pool URL for iproute2 is undefined
(!) No URI found for iproute2 6.15.0-1.
(*) Fallback pool URL for jq is undefined
(!) No URI found for jq 1.7.1-6+deb13u3.
(*) Fallback pool URL for less is undefined
(!) No URI found for less 668-1.
(*) Fallback pool URL for libc6 is undefined
(!) No URI found for libc6 2.41-12+deb13u3.
(!) Warning: Unable to parse output "libgcc1 ~~v~~" - skipping.
(*) Fallback pool URL for libgssapi-krb5-2 is undefined
(!) No URI found for libgssapi-krb5-2 1.21.3-5+deb13u1.
(*) Fallback pool URL for libicu76 is undefined
(!) No URI found for libicu76 76.1-4.
(*) Fallback pool URL for libkrb5-3 is undefined
(!) No URI found for libkrb5-3 1.21.3-5+deb13u1.
(!) Warning: Unable to parse output "liblttng-ust1 ~~v~~" - skipping.
(*) Fallback pool URL for libstdc++6 is undefined
(!) No URI found for libstdc++6 14.2.0-19.
(*) Fallback pool URL for locales is undefined
(!) No URI found for locales 2.41-12+deb13u3.
(*) Fallback pool URL for lsb-release is undefined
(!) No URI found for lsb-release 12.1-1.
(*) Fallback pool URL for lsof is undefined
(!) No URI found for lsof 4.99.4+dfsg-2.
(*) Fallback pool URL for man-db is undefined
(!) No URI found for man-db 2.13.1-1.
(*) Fallback pool URL for manpages is undefined
(!) No URI found for manpages 6.9.1-1.
(*) Fallback pool URL for manpages-dev is undefined
(!) No URI found for manpages-dev 6.9.1-1.
(*) Fallback pool URL for nano is undefined
(!) No URI found for nano 8.4-1+deb13u1.
(*) Fallback pool URL for ncdu is undefined
(!) No URI found for ncdu 1.22-1.
(*) Fallback pool URL for net-tools is undefined
(!) No URI found for net-tools 2.10-1.3.
(*) Fallback pool URL for openssh-client is undefined
(!) No URI found for openssh-client 1:10.0p1-7+deb13u4.
(*) Fallback pool URL for procps is undefined
(!) No URI found for procps 2:4.0.4-9.
(*) Fallback pool URL for psmisc is undefined
(!) No URI found for psmisc 23.7-2.
(*) Fallback pool URL for rsync is undefined
(!) No URI found for rsync 3.4.1+ds1-5+deb13u4.
(*) Fallback pool URL for strace is undefined
(!) No URI found for strace 6.13+ds-1.
(*) Fallback pool URL for sudo is undefined
(!) No URI found for sudo 1.9.16p2-3+deb13u2.
(*) Fallback pool URL for unzip is undefined
(!) No URI found for unzip 6.0-29+deb13u1.
(*) Fallback pool URL for vim-tiny is undefined
(!) No URI found for vim-tiny 2:9.1.1230-2.
(*) Fallback pool URL for wget is undefined
(!) No URI found for wget 1.25.0-2.
(*) Fallback pool URL for zip is undefined
(!) No URI found for zip 3.0-15+deb13u1.
(*) Fallback pool URL for zlib1g is undefined
(!) No URI found for zlib1g 1:1.3.dfsg+really1.3.1-1+b1.
(*) Fallback pool URL for zsh is undefined
(!) No URI found for zsh 5.9-8+b23.
(!) Warning: Some specified packages were not found.
(*) Gathering information about gems...
(*) Spawn: docker exec vscdc--extract--1788194381310 bash -c "set -e && echo ~~~BEGIN~~~ && bash -l -c 'set -e && gem list -d --local' 2>/dev/null && echo && echo ~~~END~~~"
(*) Getting remote and commit for Oh My Zsh! at /home/vscode/.oh-my-zsh...
(*) Spawn: docker exec -u root vscdc--extract--1788194381310 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/home/vscode/.oh-my-zsh\" && cd \"/home/vscode/.oh-my-zsh\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for nvm at /usr/local/share/nvm...
(*) Spawn: docker exec -u root vscdc--extract--1788194381310 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/nvm\" && cd \"/usr/local/share/nvm\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for ruby-build at /usr/local/share/ruby-build...
(*) Spawn: docker exec -u root vscdc--extract--1788194381310 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/ruby-build\" && cd \"/usr/local/share/ruby-build\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for git...
(*) Spawn: docker exec vscdc--extract--1788194381310 bash -c "set -e && echo ~~~BEGIN~~~ && git --version | sed -n '/git version /s///p' && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for Ruby...
(*) Spawn: docker exec vscdc--extract--1788194381310 bash -c "set -e && echo ~~~BEGIN~~~ && ruby --version | grep -oP '^ruby\s+\K[^\s]+' && echo && echo ~~~END~~~"
(*) Spawn: docker rm -f vscdc--extract--1788194381310
(!) Warning: No version for package undefined - skipping markdown output.
(!) Warning: No version for package undefined - skipping markdown output.

(*) Processing variant 4.0-bookworm...
(*) Pulling image mcr.microsoft.com/devcontainers/ruby:dev-4.0-bookworm...
(*) Spawn: docker pull mcr.microsoft.com/devcontainers/ruby:dev-4.0-bookworm
(*) Spawn: docker run -d --rm --init --privileged --name vscdc--extract--1788194422677 mcr.microsoft.com/devcontainers/ruby:dev-4.0-bookworm sh -c "while sleep 1000; do :; done"
(*) Spawn: docker exec -u root vscdc--extract--1788194422677 bash -c "set -e && echo ~~~BEGIN~~~ && cat /etc/os-release && echo && echo ~~~END~~~"
(*) Spawn: docker inspect --format='{{.Image}}' vscdc--extract--1788194422677
(*) Spawn: docker inspect --format='{{index .RepoDigests 0}}' sha256:cbc114ca2d974766147a2f6a5a61728fe4c99854637585e8f27c8d96f7d74ca7

(*) Spawn: docker exec -u root vscdc--extract--1788194422677 bash -c "set -e && echo ~~~BEGIN~~~ && id -un 1000 && echo && echo ~~~END~~~"
(*) Gathering information about Linux package versions...
(*) Spawn: docker exec -u root vscdc--extract--1788194422677 bash -c "set -e && echo ~~~BEGIN~~~ && dpkg-query --show -f='\${Package} ~~v~~ \${Version}
' apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(*) Gathering information about Linux package download URLs...
(*) Spawn: docker exec -u root vscdc--extract--1788194422677 bash -c "set -e && echo ~~~BEGIN~~~ && apt-get update && apt-get install -y --reinstall --print-uris apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(*) Fallback pool URL for apt-transport-https is undefined
(!) No URI found for apt-transport-https 2.6.1.
(*) Fallback pool URL for apt-utils is undefined
(!) No URI found for apt-utils 2.6.1.
(*) Fallback pool URL for build-essential is undefined
(!) No URI found for build-essential 12.9.
(*) Fallback pool URL for ca-certificates is undefined
(!) No URI found for ca-certificates 20250419~deb12u1.
(*) Fallback pool URL for curl is undefined
(!) No URI found for curl 7.88.1-10+deb12u15.
(*) Fallback pool URL for dialog is undefined
(!) No URI found for dialog 1.3-20230209-1.
(*) Fallback pool URL for git is undefined
(!) No URI found for git 1:2.39.5-0+deb12u3.
(*) Fallback pool URL for gnupg2 is undefined
(!) No URI found for gnupg2 2.2.40-1.1+deb12u2.
(*) Fallback pool URL for htop is undefined
(!) No URI found for htop 3.2.2-2.
(*) Fallback pool URL for iproute2 is undefined
(!) No URI found for iproute2 6.1.0-3.
(*) Fallback pool URL for jq is undefined
(!) No URI found for jq 1.6-2.1+deb12u2.
(*) Fallback pool URL for less is undefined
(!) No URI found for less 590-2.1~deb12u2.
(*) Fallback pool URL for libc6 is undefined
(!) No URI found for libc6 2.36-9+deb12u14.
(!) Warning: Unable to parse output "libgcc1 ~~v~~" - skipping.
(*) Fallback pool URL for libgssapi-krb5-2 is undefined
(!) No URI found for libgssapi-krb5-2 1.20.1-2+deb12u5.
(*) Fallback pool URL for libicu72 is undefined
(!) No URI found for libicu72 72.1-3+deb12u1.
(*) Fallback pool URL for libkrb5-3 is undefined
(!) No URI found for libkrb5-3 1.20.1-2+deb12u5.
(*) Fallback pool URL for liblttng-ust1 is undefined
(!) No URI found for liblttng-ust1 2.13.5-1.
(*) Fallback pool URL for libstdc++6 is undefined
(!) No URI found for libstdc++6 12.2.0-14+deb12u1.
(*) Fallback pool URL for locales is undefined
(!) No URI found for locales 2.36-9+deb12u14.
(*) Fallback pool URL for lsb-release is undefined
(!) No URI found for lsb-release 12.0-1.
(*) Fallback pool URL for lsof is undefined
(!) No URI found for lsof 4.95.0-1.
(*) Fallback pool URL for man-db is undefined
(!) No URI found for man-db 2.11.2-2.
(*) Fallback pool URL for manpages is undefined
(!) No URI found for manpages 6.03-2.
(*) Fallback pool URL for manpages-dev is undefined
(!) No URI found for manpages-dev 6.03-2.
(*) Fallback pool URL for nano is undefined
(!) No URI found for nano 7.2-1+deb12u1.
(*) Fallback pool URL for ncdu is undefined
(!) No URI found for ncdu 1.18-0.2.
(*) Fallback pool URL for net-tools is undefined
(!) No URI found for net-tools 2.10-0.1+deb12u2.
(*) Fallback pool URL for openssh-client is undefined
(!) No URI found for openssh-client 1:9.2p1-2+deb12u10.
(*) Fallback pool URL for procps is undefined
(!) No URI found for procps 2:4.0.2-3.
(*) Fallback pool URL for psmisc is undefined
(!) No URI found for psmisc 23.6-1.
(*) Fallback pool URL for rsync is undefined
(!) No URI found for rsync 3.2.7-1+deb12u6.
(*) Fallback pool URL for strace is undefined
(!) No URI found for strace 6.1-0.1.
(*) Fallback pool URL for sudo is undefined
(!) No URI found for sudo 1.9.13p3-1+deb12u4.
(*) Fallback pool URL for unzip is undefined
(!) No URI found for unzip 6.0-28+deb12u1.
(*) Fallback pool URL for vim-tiny is undefined
(!) No URI found for vim-tiny 2:9.0.1378-2+deb12u2.
(*) Fallback pool URL for wget is undefined
(!) No URI found for wget 1.21.3-1+deb12u1.
(*) Fallback pool URL for zip is undefined
(!) No URI found for zip 3.0-13.
(*) Fallback pool URL for zlib1g is undefined
(!) No URI found for zlib1g 1:1.2.13.dfsg-1.
(*) Fallback pool URL for zsh is undefined
(!) No URI found for zsh 5.9-4+b15.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libssl1.1" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libssl1.0.[0-9]" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching manpages-posix" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching manpages-posix-dev" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching yarn" - skipping.
(!) Warning: Some specified packages were not found.
(*) Gathering information about gems...
(*) Spawn: docker exec vscdc--extract--1788194422677 bash -c "set -e && echo ~~~BEGIN~~~ && bash -l -c 'set -e && gem list -d --local' 2>/dev/null && echo && echo ~~~END~~~"
(*) Getting remote and commit for Oh My Zsh! at /home/vscode/.oh-my-zsh...
(*) Spawn: docker exec -u root vscdc--extract--1788194422677 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/home/vscode/.oh-my-zsh\" && cd \"/home/vscode/.oh-my-zsh\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for nvm at /usr/local/share/nvm...
(*) Spawn: docker exec -u root vscdc--extract--1788194422677 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/nvm\" && cd \"/usr/local/share/nvm\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for ruby-build at /usr/local/share/ruby-build...
(*) Spawn: docker exec -u root vscdc--extract--1788194422677 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/ruby-build\" && cd \"/usr/local/share/ruby-build\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for git...
(*) Spawn: docker exec vscdc--extract--1788194422677 bash -c "set -e && echo ~~~BEGIN~~~ && git --version | sed -n '/git version /s///p' && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for Ruby...
(*) Spawn: docker exec vscdc--extract--1788194422677 bash -c "set -e && echo ~~~BEGIN~~~ && ruby --version | grep -oP '^ruby\s+\K[^\s]+' && echo && echo ~~~END~~~"
(*) Spawn: docker rm -f vscdc--extract--1788194422677
(!) Warning: No version for package undefined - skipping markdown output.
(!) Warning: No version for package undefined - skipping markdown output.

(*) Processing variant 3.4-bookworm...
(*) Pulling image mcr.microsoft.com/devcontainers/ruby:dev-3.4-bookworm...
(*) Spawn: docker pull mcr.microsoft.com/devcontainers/ruby:dev-3.4-bookworm
(*) Spawn: docker run -d --rm --init --privileged --name vscdc--extract--1788194452812 mcr.microsoft.com/devcontainers/ruby:dev-3.4-bookworm sh -c "while sleep 1000; do :; done"
(*) Spawn: docker exec -u root vscdc--extract--1788194452812 bash -c "set -e && echo ~~~BEGIN~~~ && cat /etc/os-release && echo && echo ~~~END~~~"
(*) Spawn: docker inspect --format='{{.Image}}' vscdc--extract--1788194452812
(*) Spawn: docker inspect --format='{{index .RepoDigests 0}}' sha256:2455bb556d1b17e1bcfb2f5bd6ab4dddec7cc7fec9808043e7d861b1585569d8

(*) Spawn: docker exec -u root vscdc--extract--1788194452812 bash -c "set -e && echo ~~~BEGIN~~~ && id -un 1000 && echo && echo ~~~END~~~"
(*) Gathering information about Linux package versions...
(*) Spawn: docker exec -u root vscdc--extract--1788194452812 bash -c "set -e && echo ~~~BEGIN~~~ && dpkg-query --show -f='\${Package} ~~v~~ \${Version}
' apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(*) Gathering information about Linux package download URLs...
(*) Spawn: docker exec -u root vscdc--extract--1788194452812 bash -c "set -e && echo ~~~BEGIN~~~ && apt-get update && apt-get install -y --reinstall --print-uris apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libssl1.1" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libssl1.0.[0-9]" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching manpages-posix" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching manpages-posix-dev" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching yarn" - skipping.
(*) Fallback pool URL for apt-transport-https is undefined
(!) No URI found for apt-transport-https 2.6.1.
(*) Fallback pool URL for apt-utils is undefined
(!) No URI found for apt-utils 2.6.1.
(*) Fallback pool URL for build-essential is undefined
(!) No URI found for build-essential 12.9.
(*) Fallback pool URL for ca-certificates is undefined
(!) No URI found for ca-certificates 20250419~deb12u1.
(*) Fallback pool URL for curl is undefined
(!) No URI found for curl 7.88.1-10+deb12u15.
(*) Fallback pool URL for dialog is undefined
(!) No URI found for dialog 1.3-20230209-1.
(*) Fallback pool URL for git is undefined
(!) No URI found for git 1:2.39.5-0+deb12u3.
(*) Fallback pool URL for gnupg2 is undefined
(!) No URI found for gnupg2 2.2.40-1.1+deb12u2.
(*) Fallback pool URL for htop is undefined
(!) No URI found for htop 3.2.2-2.
(*) Fallback pool URL for iproute2 is undefined
(!) No URI found for iproute2 6.1.0-3.
(*) Fallback pool URL for jq is undefined
(!) No URI found for jq 1.6-2.1+deb12u2.
(*) Fallback pool URL for less is undefined
(!) No URI found for less 590-2.1~deb12u2.
(*) Fallback pool URL for libc6 is undefined
(!) No URI found for libc6 2.36-9+deb12u14.
(!) Warning: Unable to parse output "libgcc1 ~~v~~" - skipping.
(*) Fallback pool URL for libgssapi-krb5-2 is undefined
(!) No URI found for libgssapi-krb5-2 1.20.1-2+deb12u5.
(*) Fallback pool URL for libicu72 is undefined
(!) No URI found for libicu72 72.1-3+deb12u1.
(*) Fallback pool URL for libkrb5-3 is undefined
(!) No URI found for libkrb5-3 1.20.1-2+deb12u5.
(*) Fallback pool URL for liblttng-ust1 is undefined
(!) No URI found for liblttng-ust1 2.13.5-1.
(*) Fallback pool URL for libstdc++6 is undefined
(!) No URI found for libstdc++6 12.2.0-14+deb12u1.
(*) Fallback pool URL for locales is undefined
(!) No URI found for locales 2.36-9+deb12u14.
(*) Fallback pool URL for lsb-release is undefined
(!) No URI found for lsb-release 12.0-1.
(*) Fallback pool URL for lsof is undefined
(!) No URI found for lsof 4.95.0-1.
(*) Fallback pool URL for man-db is undefined
(!) No URI found for man-db 2.11.2-2.
(*) Fallback pool URL for manpages is undefined
(!) No URI found for manpages 6.03-2.
(*) Fallback pool URL for manpages-dev is undefined
(!) No URI found for manpages-dev 6.03-2.
(*) Fallback pool URL for nano is undefined
(!) No URI found for nano 7.2-1+deb12u1.
(*) Fallback pool URL for ncdu is undefined
(!) No URI found for ncdu 1.18-0.2.
(*) Fallback pool URL for net-tools is undefined
(!) No URI found for net-tools 2.10-0.1+deb12u2.
(*) Fallback pool URL for openssh-client is undefined
(!) No URI found for openssh-client 1:9.2p1-2+deb12u10.
(*) Fallback pool URL for procps is undefined
(!) No URI found for procps 2:4.0.2-3.
(*) Fallback pool URL for psmisc is undefined
(!) No URI found for psmisc 23.6-1.
(*) Fallback pool URL for rsync is undefined
(!) No URI found for rsync 3.2.7-1+deb12u6.
(*) Fallback pool URL for strace is undefined
(!) No URI found for strace 6.1-0.1.
(*) Fallback pool URL for sudo is undefined
(!) No URI found for sudo 1.9.13p3-1+deb12u4.
(*) Fallback pool URL for unzip is undefined
(!) No URI found for unzip 6.0-28+deb12u1.
(*) Fallback pool URL for vim-tiny is undefined
(!) No URI found for vim-tiny 2:9.0.1378-2+deb12u2.
(*) Fallback pool URL for wget is undefined
(!) No URI found for wget 1.21.3-1+deb12u1.
(*) Fallback pool URL for zip is undefined
(!) No URI found for zip 3.0-13.
(*) Fallback pool URL for zlib1g is undefined
(!) No URI found for zlib1g 1:1.2.13.dfsg-1.
(*) Fallback pool URL for zsh is undefined
(!) No URI found for zsh 5.9-4+b15.
(!) Warning: Some specified packages were not found.
(*) Gathering information about gems...
(*) Spawn: docker exec vscdc--extract--1788194452812 bash -c "set -e && echo ~~~BEGIN~~~ && bash -l -c 'set -e && gem list -d --local' 2>/dev/null && echo && echo ~~~END~~~"
(*) Getting remote and commit for Oh My Zsh! at /home/vscode/.oh-my-zsh...
(*) Spawn: docker exec -u root vscdc--extract--1788194452812 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/home/vscode/.oh-my-zsh\" && cd \"/home/vscode/.oh-my-zsh\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for nvm at /usr/local/share/nvm...
(*) Spawn: docker exec -u root vscdc--extract--1788194452812 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/nvm\" && cd \"/usr/local/share/nvm\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for ruby-build at /usr/local/share/ruby-build...
(*) Spawn: docker exec -u root vscdc--extract--1788194452812 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/ruby-build\" && cd \"/usr/local/share/ruby-build\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for git...
(*) Spawn: docker exec vscdc--extract--1788194452812 bash -c "set -e && echo ~~~BEGIN~~~ && git --version | sed -n '/git version /s///p' && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for Ruby...
(*) Spawn: docker exec vscdc--extract--1788194452812 bash -c "set -e && echo ~~~BEGIN~~~ && ruby --version | grep -oP '^ruby\s+\K[^\s]+' && echo && echo ~~~END~~~"
(*) Spawn: docker rm -f vscdc--extract--1788194452812
(!) Warning: No version for package undefined - skipping markdown output.
(!) Warning: No version for package undefined - skipping markdown output.

(*) Processing variant 3.3-bookworm...
(*) Pulling image mcr.microsoft.com/devcontainers/ruby:dev-3.3-bookworm...
(*) Spawn: docker pull mcr.microsoft.com/devcontainers/ruby:dev-3.3-bookworm
(*) Spawn: docker run -d --rm --init --privileged --name vscdc--extract--1788194474384 mcr.microsoft.com/devcontainers/ruby:dev-3.3-bookworm sh -c "while sleep 1000; do :; done"
(*) Spawn: docker exec -u root vscdc--extract--1788194474384 bash -c "set -e && echo ~~~BEGIN~~~ && cat /etc/os-release && echo && echo ~~~END~~~"
(*) Spawn: docker inspect --format='{{.Image}}' vscdc--extract--1788194474384
(*) Spawn: docker inspect --format='{{index .RepoDigests 0}}' sha256:55b4090f740e404d20273c17a315c18336d01c754958e0493b04ae6f42adc19f

(*) Spawn: docker exec -u root vscdc--extract--1788194474384 bash -c "set -e && echo ~~~BEGIN~~~ && id -un 1000 && echo && echo ~~~END~~~"
(*) Gathering information about Linux package versions...
(*) Spawn: docker exec -u root vscdc--extract--1788194474384 bash -c "set -e && echo ~~~BEGIN~~~ && dpkg-query --show -f='\${Package} ~~v~~ \${Version}
' apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(*) Gathering information about Linux package download URLs...
(*) Spawn: docker exec -u root vscdc--extract--1788194474384 bash -c "set -e && echo ~~~BEGIN~~~ && apt-get update && apt-get install -y --reinstall --print-uris apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libssl1.1" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libssl1.0.[0-9]" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching manpages-posix" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching manpages-posix-dev" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching yarn" - skipping.
(*) Fallback pool URL for apt-transport-https is undefined
(!) No URI found for apt-transport-https 2.6.1.
(*) Fallback pool URL for apt-utils is undefined
(!) No URI found for apt-utils 2.6.1.
(*) Fallback pool URL for build-essential is undefined
(!) No URI found for build-essential 12.9.
(*) Fallback pool URL for ca-certificates is undefined
(!) No URI found for ca-certificates 20250419~deb12u1.
(*) Fallback pool URL for curl is undefined
(!) No URI found for curl 7.88.1-10+deb12u15.
(*) Fallback pool URL for dialog is undefined
(!) No URI found for dialog 1.3-20230209-1.
(*) Fallback pool URL for git is undefined
(!) No URI found for git 1:2.39.5-0+deb12u3.
(*) Fallback pool URL for gnupg2 is undefined
(!) No URI found for gnupg2 2.2.40-1.1+deb12u2.
(*) Fallback pool URL for htop is undefined
(!) No URI found for htop 3.2.2-2.
(*) Fallback pool URL for iproute2 is undefined
(!) No URI found for iproute2 6.1.0-3.
(*) Fallback pool URL for jq is undefined
(!) No URI found for jq 1.6-2.1+deb12u2.
(*) Fallback pool URL for less is undefined
(!) No URI found for less 590-2.1~deb12u2.
(*) Fallback pool URL for libc6 is undefined
(!) No URI found for libc6 2.36-9+deb12u14.
(!) Warning: Unable to parse output "libgcc1 ~~v~~" - skipping.
(*) Fallback pool URL for libgssapi-krb5-2 is undefined
(!) No URI found for libgssapi-krb5-2 1.20.1-2+deb12u5.
(*) Fallback pool URL for libicu72 is undefined
(!) No URI found for libicu72 72.1-3+deb12u1.
(*) Fallback pool URL for libkrb5-3 is undefined
(!) No URI found for libkrb5-3 1.20.1-2+deb12u5.
(*) Fallback pool URL for liblttng-ust1 is undefined
(!) No URI found for liblttng-ust1 2.13.5-1.
(*) Fallback pool URL for libstdc++6 is undefined
(!) No URI found for libstdc++6 12.2.0-14+deb12u1.
(*) Fallback pool URL for locales is undefined
(!) No URI found for locales 2.36-9+deb12u14.
(*) Fallback pool URL for lsb-release is undefined
(!) No URI found for lsb-release 12.0-1.
(*) Fallback pool URL for lsof is undefined
(!) No URI found for lsof 4.95.0-1.
(*) Fallback pool URL for man-db is undefined
(!) No URI found for man-db 2.11.2-2.
(*) Fallback pool URL for manpages is undefined
(!) No URI found for manpages 6.03-2.
(*) Fallback pool URL for manpages-dev is undefined
(!) No URI found for manpages-dev 6.03-2.
(*) Fallback pool URL for nano is undefined
(!) No URI found for nano 7.2-1+deb12u1.
(*) Fallback pool URL for ncdu is undefined
(!) No URI found for ncdu 1.18-0.2.
(*) Fallback pool URL for net-tools is undefined
(!) No URI found for net-tools 2.10-0.1+deb12u2.
(*) Fallback pool URL for openssh-client is undefined
(!) No URI found for openssh-client 1:9.2p1-2+deb12u10.
(*) Fallback pool URL for procps is undefined
(!) No URI found for procps 2:4.0.2-3.
(*) Fallback pool URL for psmisc is undefined
(!) No URI found for psmisc 23.6-1.
(*) Fallback pool URL for rsync is undefined
(!) No URI found for rsync 3.2.7-1+deb12u6.
(*) Fallback pool URL for strace is undefined
(!) No URI found for strace 6.1-0.1.
(*) Fallback pool URL for sudo is undefined
(!) No URI found for sudo 1.9.13p3-1+deb12u4.
(*) Fallback pool URL for unzip is undefined
(!) No URI found for unzip 6.0-28+deb12u1.
(*) Fallback pool URL for vim-tiny is undefined
(!) No URI found for vim-tiny 2:9.0.1378-2+deb12u2.
(*) Fallback pool URL for wget is undefined
(!) No URI found for wget 1.21.3-1+deb12u1.
(*) Fallback pool URL for zip is undefined
(!) No URI found for zip 3.0-13.
(*) Fallback pool URL for zlib1g is undefined
(!) No URI found for zlib1g 1:1.2.13.dfsg-1.
(*) Fallback pool URL for zsh is undefined
(!) No URI found for zsh 5.9-4+b15.
(!) Warning: Some specified packages were not found.
(*) Gathering information about gems...
(*) Spawn: docker exec vscdc--extract--1788194474384 bash -c "set -e && echo ~~~BEGIN~~~ && bash -l -c 'set -e && gem list -d --local' 2>/dev/null && echo && echo ~~~END~~~"
(*) Getting remote and commit for Oh My Zsh! at /home/vscode/.oh-my-zsh...
(*) Spawn: docker exec -u root vscdc--extract--1788194474384 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/home/vscode/.oh-my-zsh\" && cd \"/home/vscode/.oh-my-zsh\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for nvm at /usr/local/share/nvm...
(*) Spawn: docker exec -u root vscdc--extract--1788194474384 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/nvm\" && cd \"/usr/local/share/nvm\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for ruby-build at /usr/local/share/ruby-build...
(*) Spawn: docker exec -u root vscdc--extract--1788194474384 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/ruby-build\" && cd \"/usr/local/share/ruby-build\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for git...
(*) Spawn: docker exec vscdc--extract--1788194474384 bash -c "set -e && echo ~~~BEGIN~~~ && git --version | sed -n '/git version /s///p' && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for Ruby...
(*) Spawn: docker exec vscdc--extract--1788194474384 bash -c "set -e && echo ~~~BEGIN~~~ && ruby --version | grep -oP '^ruby\s+\K[^\s]+' && echo && echo ~~~END~~~"
(*) Spawn: docker rm -f vscdc--extract--1788194474384
(!) Warning: No version for package undefined - skipping markdown output.
(!) Warning: No version for package undefined - skipping markdown output.

(*) Processing variant 3.4-bullseye...
(*) Pulling image mcr.microsoft.com/devcontainers/ruby:dev-3.4-bullseye...
(*) Spawn: docker pull mcr.microsoft.com/devcontainers/ruby:dev-3.4-bullseye
(*) Spawn: docker run -d --rm --init --privileged --name vscdc--extract--1788194529559 mcr.microsoft.com/devcontainers/ruby:dev-3.4-bullseye sh -c "while sleep 1000; do :; done"
(*) Spawn: docker exec -u root vscdc--extract--1788194529559 bash -c "set -e && echo ~~~BEGIN~~~ && cat /etc/os-release && echo && echo ~~~END~~~"
(*) Spawn: docker inspect --format='{{.Image}}' vscdc--extract--1788194529559
(*) Spawn: docker inspect --format='{{index .RepoDigests 0}}' sha256:80d4ae09b3163d1bfaac1392beac7fef37287c1824828e4553d0d70df52cc007

(*) Spawn: docker exec -u root vscdc--extract--1788194529559 bash -c "set -e && echo ~~~BEGIN~~~ && id -un 1000 && echo && echo ~~~END~~~"
(*) Gathering information about Linux package versions...
(*) Spawn: docker exec -u root vscdc--extract--1788194529559 bash -c "set -e && echo ~~~BEGIN~~~ && dpkg-query --show -f='\${Package} ~~v~~ \${Version}
' apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(*) Gathering information about Linux package download URLs...
(*) Spawn: docker exec -u root vscdc--extract--1788194529559 bash -c "set -e && echo ~~~BEGIN~~~ && apt-get update && apt-get install -y --reinstall --print-uris apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(*) Fallback pool URL for apt-transport-https is undefined
(!) No URI found for apt-transport-https 2.2.4.
(*) Fallback pool URL for apt-utils is undefined
(!) No URI found for apt-utils 2.2.4.
(*) Fallback pool URL for build-essential is undefined
(!) No URI found for build-essential 12.9.
(*) Fallback pool URL for ca-certificates is undefined
(!) No URI found for ca-certificates 20250419~deb12u1~deb11u1.
(*) Fallback pool URL for curl is undefined
(!) No URI found for curl 7.74.0-1.3+deb11u16.
(*) Fallback pool URL for dialog is undefined
(!) No URI found for dialog 1.3-20201126-1.
(*) Fallback pool URL for git is undefined
(!) No URI found for git 1:2.30.2-1+deb11u5.
(*) Fallback pool URL for gnupg2 is undefined
(!) No URI found for gnupg2 2.2.27-2+deb11u3.
(*) Fallback pool URL for htop is undefined
(!) No URI found for htop 3.0.5-7.
(*) Fallback pool URL for iproute2 is undefined
(!) No URI found for iproute2 5.10.0-4.
(*) Fallback pool URL for jq is undefined
(!) No URI found for jq 1.6-2.1+deb11u3.
(*) Fallback pool URL for less is undefined
(!) No URI found for less 551-2+deb11u2.
(*) Fallback pool URL for libc6 is undefined
(!) No URI found for libc6 2.31-13+deb11u14.
(!) Warning: Unable to parse output "libgcc1 ~~v~~" - skipping.
(*) Fallback pool URL for libgssapi-krb5-2 is undefined
(!) No URI found for libgssapi-krb5-2 1.18.3-6+deb11u8.
(*) Fallback pool URL for libicu67 is undefined
(!) No URI found for libicu67 67.1-7+deb11u1.
(*) Fallback pool URL for libkrb5-3 is undefined
(!) No URI found for libkrb5-3 1.18.3-6+deb11u8.
(*) Fallback pool URL for liblttng-ust0 is undefined
(!) No URI found for liblttng-ust0 2.12.1-1.
(!) Warning: Unable to parse output "liblttng-ust2 ~~v~~" - skipping.
(*) Fallback pool URL for libssl1.1 is undefined
(!) No URI found for libssl1.1 1.1.1w-0+deb11u8.
(*) Fallback pool URL for libstdc++6 is undefined
(!) No URI found for libstdc++6 10.2.1-6.
(*) Fallback pool URL for locales is undefined
(!) No URI found for locales 2.31-13+deb11u14.
(*) Fallback pool URL for lsb-release is undefined
(!) No URI found for lsb-release 11.1.0.
(*) Fallback pool URL for lsof is undefined
(!) No URI found for lsof 4.93.2+dfsg-1.1.
(*) Fallback pool URL for man-db is undefined
(!) No URI found for man-db 2.9.4-2.
(*) Fallback pool URL for manpages is undefined
(!) No URI found for manpages 5.10-1.
(*) Fallback pool URL for manpages-dev is undefined
(!) No URI found for manpages-dev 5.10-1.
(*) Fallback pool URL for nano is undefined
(!) No URI found for nano 5.4-2+deb11u3.
(*) Fallback pool URL for ncdu is undefined
(!) No URI found for ncdu 1.15.1-1.
(*) Fallback pool URL for net-tools is undefined
(!) No URI found for net-tools 1.60+git20181103.0eebece-1+deb11u2.
(*) Fallback pool URL for openssh-client is undefined
(!) No URI found for openssh-client 1:8.4p1-5+deb11u7.
(*) Fallback pool URL for procps is undefined
(!) No URI found for procps 2:3.3.17-5.
(*) Fallback pool URL for psmisc is undefined
(!) No URI found for psmisc 23.4-2.
(*) Fallback pool URL for rsync is undefined
(!) No URI found for rsync 3.2.3-4+deb11u4.
(*) Fallback pool URL for strace is undefined
(!) No URI found for strace 5.10-1.
(*) Fallback pool URL for sudo is undefined
(!) No URI found for sudo 1.9.5p2-3+deb11u4.
(*) Fallback pool URL for unzip is undefined
(!) No URI found for unzip 6.0-26+deb11u2.
(*) Fallback pool URL for vim-tiny is undefined
(!) No URI found for vim-tiny 2:8.2.2434-3+deb11u3.
(*) Fallback pool URL for wget is undefined
(!) No URI found for wget 1.21-1+deb11u2.
(*) Fallback pool URL for zip is undefined
(!) No URI found for zip 3.0-12.
(*) Fallback pool URL for zlib1g is undefined
(!) No URI found for zlib1g 1:1.2.11.dfsg-2+deb11u2.
(*) Fallback pool URL for zsh is undefined
(!) No URI found for zsh 5.8-6+deb11u1.
(!) Warning: Some specified packages were not found.
(*) Gathering information about gems...
(*) Spawn: docker exec vscdc--extract--1788194529559 bash -c "set -e && echo ~~~BEGIN~~~ && bash -l -c 'set -e && gem list -d --local' 2>/dev/null && echo && echo ~~~END~~~"
(*) Getting remote and commit for Oh My Zsh! at /home/vscode/.oh-my-zsh...
(*) Spawn: docker exec -u root vscdc--extract--1788194529559 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/home/vscode/.oh-my-zsh\" && cd \"/home/vscode/.oh-my-zsh\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for nvm at /usr/local/share/nvm...
(*) Spawn: docker exec -u root vscdc--extract--1788194529559 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/nvm\" && cd \"/usr/local/share/nvm\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for ruby-build at /usr/local/share/ruby-build...
(*) Spawn: docker exec -u root vscdc--extract--1788194529559 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/ruby-build\" && cd \"/usr/local/share/ruby-build\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for git...
(*) Spawn: docker exec vscdc--extract--1788194529559 bash -c "set -e && echo ~~~BEGIN~~~ && git --version | sed -n '/git version /s///p' && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for Ruby...
(*) Spawn: docker exec vscdc--extract--1788194529559 bash -c "set -e && echo ~~~BEGIN~~~ && ruby --version | grep -oP '^ruby\s+\K[^\s]+' && echo && echo ~~~END~~~"
(*) Spawn: docker rm -f vscdc--extract--1788194529559
(!) Warning: No version for package undefined - skipping markdown output.
(!) Warning: No version for package undefined - skipping markdown output.

(*) Processing variant 3.3-bullseye...
(*) Pulling image mcr.microsoft.com/devcontainers/ruby:dev-3.3-bullseye...
(*) Spawn: docker pull mcr.microsoft.com/devcontainers/ruby:dev-3.3-bullseye
(*) Spawn: docker run -d --rm --init --privileged --name vscdc--extract--1788194557004 mcr.microsoft.com/devcontainers/ruby:dev-3.3-bullseye sh -c "while sleep 1000; do :; done"
(*) Spawn: docker exec -u root vscdc--extract--1788194557004 bash -c "set -e && echo ~~~BEGIN~~~ && cat /etc/os-release && echo && echo ~~~END~~~"
(*) Spawn: docker inspect --format='{{.Image}}' vscdc--extract--1788194557004
(*) Spawn: docker inspect --format='{{index .RepoDigests 0}}' sha256:21f6659091da3c8af9022f208cd2d323ee7fb65646734723299d4e242c5335ef

(*) Spawn: docker exec -u root vscdc--extract--1788194557004 bash -c "set -e && echo ~~~BEGIN~~~ && id -un 1000 && echo && echo ~~~END~~~"
(*) Gathering information about Linux package versions...
(*) Spawn: docker exec -u root vscdc--extract--1788194557004 bash -c "set -e && echo ~~~BEGIN~~~ && dpkg-query --show -f='\${Package} ~~v~~ \${Version}
' apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(*) Gathering information about Linux package download URLs...
(*) Spawn: docker exec -u root vscdc--extract--1788194557004 bash -c "set -e && echo ~~~BEGIN~~~ && apt-get update && apt-get install -y --reinstall --print-uris apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libssl1.0.[0-9]" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching manpages-posix" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching manpages-posix-dev" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching yarn" - skipping.
(*) Fallback pool URL for apt-transport-https is undefined
(!) No URI found for apt-transport-https 2.2.4.
(*) Fallback pool URL for apt-utils is undefined
(!) No URI found for apt-utils 2.2.4.
(*) Fallback pool URL for build-essential is undefined
(!) No URI found for build-essential 12.9.
(*) Fallback pool URL for ca-certificates is undefined
(!) No URI found for ca-certificates 20250419~deb12u1~deb11u1.
(*) Fallback pool URL for curl is undefined
(!) No URI found for curl 7.74.0-1.3+deb11u16.
(*) Fallback pool URL for dialog is undefined
(!) No URI found for dialog 1.3-20201126-1.
(*) Fallback pool URL for git is undefined
(!) No URI found for git 1:2.30.2-1+deb11u5.
(*) Fallback pool URL for gnupg2 is undefined
(!) No URI found for gnupg2 2.2.27-2+deb11u3.
(*) Fallback pool URL for htop is undefined
(!) No URI found for htop 3.0.5-7.
(*) Fallback pool URL for iproute2 is undefined
(!) No URI found for iproute2 5.10.0-4.
(*) Fallback pool URL for jq is undefined
(!) No URI found for jq 1.6-2.1+deb11u3.
(*) Fallback pool URL for less is undefined
(!) No URI found for less 551-2+deb11u2.
(*) Fallback pool URL for libc6 is undefined
(!) No URI found for libc6 2.31-13+deb11u14.
(!) Warning: Unable to parse output "libgcc1 ~~v~~" - skipping.
(*) Fallback pool URL for libgssapi-krb5-2 is undefined
(!) No URI found for libgssapi-krb5-2 1.18.3-6+deb11u8.
(*) Fallback pool URL for libicu67 is undefined
(!) No URI found for libicu67 67.1-7+deb11u1.
(*) Fallback pool URL for libkrb5-3 is undefined
(!) No URI found for libkrb5-3 1.18.3-6+deb11u8.
(*) Fallback pool URL for liblttng-ust0 is undefined
(!) No URI found for liblttng-ust0 2.12.1-1.
(!) Warning: Unable to parse output "liblttng-ust2 ~~v~~" - skipping.
(*) Fallback pool URL for libssl1.1 is undefined
(!) No URI found for libssl1.1 1.1.1w-0+deb11u8.
(*) Fallback pool URL for libstdc++6 is undefined
(!) No URI found for libstdc++6 10.2.1-6.
(*) Fallback pool URL for locales is undefined
(!) No URI found for locales 2.31-13+deb11u14.
(*) Fallback pool URL for lsb-release is undefined
(!) No URI found for lsb-release 11.1.0.
(*) Fallback pool URL for lsof is undefined
(!) No URI found for lsof 4.93.2+dfsg-1.1.
(*) Fallback pool URL for man-db is undefined
(!) No URI found for man-db 2.9.4-2.
(*) Fallback pool URL for manpages is undefined
(!) No URI found for manpages 5.10-1.
(*) Fallback pool URL for manpages-dev is undefined
(!) No URI found for manpages-dev 5.10-1.
(*) Fallback pool URL for nano is undefined
(!) No URI found for nano 5.4-2+deb11u3.
(*) Fallback pool URL for ncdu is undefined
(!) No URI found for ncdu 1.15.1-1.
(*) Fallback pool URL for net-tools is undefined
(!) No URI found for net-tools 1.60+git20181103.0eebece-1+deb11u2.
(*) Fallback pool URL for openssh-client is undefined
(!) No URI found for openssh-client 1:8.4p1-5+deb11u7.
(*) Fallback pool URL for procps is undefined
(!) No URI found for procps 2:3.3.17-5.
(*) Fallback pool URL for psmisc is undefined
(!) No URI found for psmisc 23.4-2.
(*) Fallback pool URL for rsync is undefined
(!) No URI found for rsync 3.2.3-4+deb11u4.
(*) Fallback pool URL for strace is undefined
(!) No URI found for strace 5.10-1.
(*) Fallback pool URL for sudo is undefined
(!) No URI found for sudo 1.9.5p2-3+deb11u4.
(*) Fallback pool URL for unzip is undefined
(!) No URI found for unzip 6.0-26+deb11u2.
(*) Fallback pool URL for vim-tiny is undefined
(!) No URI found for vim-tiny 2:8.2.2434-3+deb11u3.
(*) Fallback pool URL for wget is undefined
(!) No URI found for wget 1.21-1+deb11u2.
(*) Fallback pool URL for zip is undefined
(!) No URI found for zip 3.0-12.
(*) Fallback pool URL for zlib1g is undefined
(!) No URI found for zlib1g 1:1.2.11.dfsg-2+deb11u2.
(*) Fallback pool URL for zsh is undefined
(!) No URI found for zsh 5.8-6+deb11u1.
(!) Warning: Some specified packages were not found.
(*) Gathering information about gems...
(*) Spawn: docker exec vscdc--extract--1788194557004 bash -c "set -e && echo ~~~BEGIN~~~ && bash -l -c 'set -e && gem list -d --local' 2>/dev/null && echo && echo ~~~END~~~"
(*) Getting remote and commit for Oh My Zsh! at /home/vscode/.oh-my-zsh...
(*) Spawn: docker exec -u root vscdc--extract--1788194557004 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/home/vscode/.oh-my-zsh\" && cd \"/home/vscode/.oh-my-zsh\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for nvm at /usr/local/share/nvm...
(*) Spawn: docker exec -u root vscdc--extract--1788194557004 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/nvm\" && cd \"/usr/local/share/nvm\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for ruby-build at /usr/local/share/ruby-build...
(*) Spawn: docker exec -u root vscdc--extract--1788194557004 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/ruby-build\" && cd \"/usr/local/share/ruby-build\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for git...
(*) Spawn: docker exec vscdc--extract--1788194557004 bash -c "set -e && echo ~~~BEGIN~~~ && git --version | sed -n '/git version /s///p' && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for Ruby...
(*) Spawn: docker exec vscdc--extract--1788194557004 bash -c "set -e && echo ~~~BEGIN~~~ && ruby --version | grep -oP '^ruby\s+\K[^\s]+' && echo && echo ~~~END~~~"
(*) Spawn: docker rm -f vscdc--extract--1788194557004
(!) Warning: No version for package undefined - skipping markdown output.
(!) Warning: No version for package undefined - skipping markdown output.
(*) Writing image history markdown...
(*) Spawn: docker image prune -a -f
(*) Writing cgmanifest.json...
(*) Done!

```

## Ruby image extractor run:

```
/usr/local/bin/node --experimental-network-inspection ./build/vscdc info ruby --no-build --markdown --cg --overwrite --prune --release main --github-repo devcontainers/images --registry mcr.microsoft.com --registryPath devcontainers
devcontainers CLI
Copyright (c) Microsoft Corporation. All rights reserved.

(*) Generating image information files...

(*) Processing variant 4.0-trixie...
(*) Pulling image mcr.microsoft.com/devcontainers/ruby:dev-4.0-trixie...
(*) Spawn: docker pull mcr.microsoft.com/devcontainers/ruby:dev-4.0-trixie
(*) Spawn: docker run -d --rm --init --privileged --name vscdc--extract--1788194341215 mcr.microsoft.com/devcontainers/ruby:dev-4.0-trixie sh -c "while sleep 1000; do :; done"
(*) Spawn: docker exec -u root vscdc--extract--1788194341215 bash -c "set -e && echo ~~~BEGIN~~~ && cat /etc/os-release && echo && echo ~~~END~~~"
(*) Spawn: docker inspect --format='{{.Image}}' vscdc--extract--1788194341215
(*) Spawn: docker inspect --format='{{index .RepoDigests 0}}' sha256:f4650048459646513924d9a0c136dd544af25bd4728cb265a2422988c610001b

(*) Spawn: docker exec -u root vscdc--extract--1788194341215 bash -c "set -e && echo ~~~BEGIN~~~ && id -un 1000 && echo && echo ~~~END~~~"
(*) Gathering information about Linux package versions...
(*) Spawn: docker exec -u root vscdc--extract--1788194341215 bash -c "set -e && echo ~~~BEGIN~~~ && dpkg-query --show -f='\${Package} ~~v~~ \${Version}
' apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(*) Gathering information about Linux package download URLs...
(*) Spawn: docker exec -u root vscdc--extract--1788194341215 bash -c "set -e && echo ~~~BEGIN~~~ && apt-get update && apt-get install -y --reinstall --print-uris apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libssl1.1" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libssl1.0.[0-9]" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching manpages-posix" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching manpages-posix-dev" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching yarn" - skipping.
(*) Fallback pool URL for apt-transport-https is undefined
(!) No URI found for apt-transport-https 3.0.3.
(*) Fallback pool URL for apt-utils is undefined
(!) No URI found for apt-utils 3.0.3.
(*) Fallback pool URL for build-essential is undefined
(!) No URI found for build-essential 12.12.
(*) Fallback pool URL for ca-certificates is undefined
(!) No URI found for ca-certificates 20250419.
(*) Fallback pool URL for curl is undefined
(!) No URI found for curl 8.14.1-2+deb13u4.
(*) Fallback pool URL for dialog is undefined
(!) No URI found for dialog 1.3-20250116-1.
(*) Fallback pool URL for git is undefined
(!) No URI found for git 1:2.47.3-0+deb13u1.
(*) Fallback pool URL for gnupg2 is undefined
(!) No URI found for gnupg2 2.4.7-21+deb13u1.
(*) Fallback pool URL for htop is undefined
(!) No URI found for htop 3.4.1-5.
(*) Fallback pool URL for iproute2 is undefined
(!) No URI found for iproute2 6.15.0-1.
(*) Fallback pool URL for jq is undefined
(!) No URI found for jq 1.7.1-6+deb13u3.
(*) Fallback pool URL for less is undefined
(!) No URI found for less 668-1.
(*) Fallback pool URL for libc6 is undefined
(!) No URI found for libc6 2.41-12+deb13u3.
(!) Warning: Unable to parse output "libgcc1 ~~v~~" - skipping.
(*) Fallback pool URL for libgssapi-krb5-2 is undefined
(!) No URI found for libgssapi-krb5-2 1.21.3-5+deb13u1.
(*) Fallback pool URL for libicu76 is undefined
(!) No URI found for libicu76 76.1-4.
(*) Fallback pool URL for libkrb5-3 is undefined
(!) No URI found for libkrb5-3 1.21.3-5+deb13u1.
(!) Warning: Unable to parse output "liblttng-ust1 ~~v~~" - skipping.
(*) Fallback pool URL for libstdc++6 is undefined
(!) No URI found for libstdc++6 14.2.0-19.
(*) Fallback pool URL for locales is undefined
(!) No URI found for locales 2.41-12+deb13u3.
(*) Fallback pool URL for lsb-release is undefined
(!) No URI found for lsb-release 12.1-1.
(*) Fallback pool URL for lsof is undefined
(!) No URI found for lsof 4.99.4+dfsg-2.
(*) Fallback pool URL for man-db is undefined
(!) No URI found for man-db 2.13.1-1.
(*) Fallback pool URL for manpages is undefined
(!) No URI found for manpages 6.9.1-1.
(*) Fallback pool URL for manpages-dev is undefined
(!) No URI found for manpages-dev 6.9.1-1.
(*) Fallback pool URL for nano is undefined
(!) No URI found for nano 8.4-1+deb13u1.
(*) Fallback pool URL for ncdu is undefined
(!) No URI found for ncdu 1.22-1.
(*) Fallback pool URL for net-tools is undefined
(!) No URI found for net-tools 2.10-1.3.
(*) Fallback pool URL for openssh-client is undefined
(!) No URI found for openssh-client 1:10.0p1-7+deb13u4.
(*) Fallback pool URL for procps is undefined
(!) No URI found for procps 2:4.0.4-9.
(*) Fallback pool URL for psmisc is undefined
(!) No URI found for psmisc 23.7-2.
(*) Fallback pool URL for rsync is undefined
(!) No URI found for rsync 3.4.1+ds1-5+deb13u4.
(*) Fallback pool URL for strace is undefined
(!) No URI found for strace 6.13+ds-1.
(*) Fallback pool URL for sudo is undefined
(!) No URI found for sudo 1.9.16p2-3+deb13u2.
(*) Fallback pool URL for unzip is undefined
(!) No URI found for unzip 6.0-29+deb13u1.
(*) Fallback pool URL for vim-tiny is undefined
(!) No URI found for vim-tiny 2:9.1.1230-2.
(*) Fallback pool URL for wget is undefined
(!) No URI found for wget 1.25.0-2.
(*) Fallback pool URL for zip is undefined
(!) No URI found for zip 3.0-15+deb13u1.
(*) Fallback pool URL for zlib1g is undefined
(!) No URI found for zlib1g 1:1.3.dfsg+really1.3.1-1+b1.
(*) Fallback pool URL for zsh is undefined
(!) No URI found for zsh 5.9-8+b23.
(!) Warning: Some specified packages were not found.
(*) Gathering information about gems...
(*) Spawn: docker exec vscdc--extract--1788194341215 bash -c "set -e && echo ~~~BEGIN~~~ && bash -l -c 'set -e && gem list -d --local' 2>/dev/null && echo && echo ~~~END~~~"
(*) Getting remote and commit for Oh My Zsh! at /home/vscode/.oh-my-zsh...
(*) Spawn: docker exec -u root vscdc--extract--1788194341215 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/home/vscode/.oh-my-zsh\" && cd \"/home/vscode/.oh-my-zsh\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for nvm at /usr/local/share/nvm...
(*) Spawn: docker exec -u root vscdc--extract--1788194341215 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/nvm\" && cd \"/usr/local/share/nvm\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for ruby-build at /usr/local/share/ruby-build...
(*) Spawn: docker exec -u root vscdc--extract--1788194341215 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/ruby-build\" && cd \"/usr/local/share/ruby-build\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for git...
(*) Spawn: docker exec vscdc--extract--1788194341215 bash -c "set -e && echo ~~~BEGIN~~~ && git --version | sed -n '/git version /s///p' && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for Ruby...
(*) Spawn: docker exec vscdc--extract--1788194341215 bash -c "set -e && echo ~~~BEGIN~~~ && ruby --version | grep -oP '^ruby\s+\K[^\s]+' && echo && echo ~~~END~~~"
(*) Spawn: docker rm -f vscdc--extract--1788194341215
(!) Warning: No version for package undefined - skipping markdown output.
(!) Warning: No version for package undefined - skipping markdown output.

(*) Processing variant 3.4-trixie...
(*) Pulling image mcr.microsoft.com/devcontainers/ruby:dev-3.4-trixie...
(*) Spawn: docker pull mcr.microsoft.com/devcontainers/ruby:dev-3.4-trixie
(*) Spawn: docker run -d --rm --init --privileged --name vscdc--extract--1788194360592 mcr.microsoft.com/devcontainers/ruby:dev-3.4-trixie sh -c "while sleep 1000; do :; done"
(*) Spawn: docker exec -u root vscdc--extract--1788194360592 bash -c "set -e && echo ~~~BEGIN~~~ && cat /etc/os-release && echo && echo ~~~END~~~"
(*) Spawn: docker inspect --format='{{.Image}}' vscdc--extract--1788194360592
(*) Spawn: docker inspect --format='{{index .RepoDigests 0}}' sha256:7ba2587ffa59c5733b7c78112e020e653035d19c9daf499b4b98dc0fa103cddc

(*) Spawn: docker exec -u root vscdc--extract--1788194360592 bash -c "set -e && echo ~~~BEGIN~~~ && id -un 1000 && echo && echo ~~~END~~~"
(*) Gathering information about Linux package versions...
(*) Spawn: docker exec -u root vscdc--extract--1788194360592 bash -c "set -e && echo ~~~BEGIN~~~ && dpkg-query --show -f='\${Package} ~~v~~ \${Version}
' apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(*) Gathering information about Linux package download URLs...
(*) Spawn: docker exec -u root vscdc--extract--1788194360592 bash -c "set -e && echo ~~~BEGIN~~~ && apt-get update && apt-get install -y --reinstall --print-uris apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libssl1.1" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libssl1.0.[0-9]" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching manpages-posix" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching manpages-posix-dev" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching yarn" - skipping.
(*) Fallback pool URL for apt-transport-https is undefined
(!) No URI found for apt-transport-https 3.0.3.
(*) Fallback pool URL for apt-utils is undefined
(!) No URI found for apt-utils 3.0.3.
(*) Fallback pool URL for build-essential is undefined
(!) No URI found for build-essential 12.12.
(*) Fallback pool URL for ca-certificates is undefined
(!) No URI found for ca-certificates 20250419.
(*) Fallback pool URL for curl is undefined
(!) No URI found for curl 8.14.1-2+deb13u4.
(*) Fallback pool URL for dialog is undefined
(!) No URI found for dialog 1.3-20250116-1.
(*) Fallback pool URL for git is undefined
(!) No URI found for git 1:2.47.3-0+deb13u1.
(*) Fallback pool URL for gnupg2 is undefined
(!) No URI found for gnupg2 2.4.7-21+deb13u1.
(*) Fallback pool URL for htop is undefined
(!) No URI found for htop 3.4.1-5.
(*) Fallback pool URL for iproute2 is undefined
(!) No URI found for iproute2 6.15.0-1.
(*) Fallback pool URL for jq is undefined
(!) No URI found for jq 1.7.1-6+deb13u3.
(*) Fallback pool URL for less is undefined
(!) No URI found for less 668-1.
(*) Fallback pool URL for libc6 is undefined
(!) No URI found for libc6 2.41-12+deb13u3.
(!) Warning: Unable to parse output "libgcc1 ~~v~~" - skipping.
(*) Fallback pool URL for libgssapi-krb5-2 is undefined
(!) No URI found for libgssapi-krb5-2 1.21.3-5+deb13u1.
(*) Fallback pool URL for libicu76 is undefined
(!) No URI found for libicu76 76.1-4.
(*) Fallback pool URL for libkrb5-3 is undefined
(!) No URI found for libkrb5-3 1.21.3-5+deb13u1.
(!) Warning: Unable to parse output "liblttng-ust1 ~~v~~" - skipping.
(*) Fallback pool URL for libstdc++6 is undefined
(!) No URI found for libstdc++6 14.2.0-19.
(*) Fallback pool URL for locales is undefined
(!) No URI found for locales 2.41-12+deb13u3.
(*) Fallback pool URL for lsb-release is undefined
(!) No URI found for lsb-release 12.1-1.
(*) Fallback pool URL for lsof is undefined
(!) No URI found for lsof 4.99.4+dfsg-2.
(*) Fallback pool URL for man-db is undefined
(!) No URI found for man-db 2.13.1-1.
(*) Fallback pool URL for manpages is undefined
(!) No URI found for manpages 6.9.1-1.
(*) Fallback pool URL for manpages-dev is undefined
(!) No URI found for manpages-dev 6.9.1-1.
(*) Fallback pool URL for nano is undefined
(!) No URI found for nano 8.4-1+deb13u1.
(*) Fallback pool URL for ncdu is undefined
(!) No URI found for ncdu 1.22-1.
(*) Fallback pool URL for net-tools is undefined
(!) No URI found for net-tools 2.10-1.3.
(*) Fallback pool URL for openssh-client is undefined
(!) No URI found for openssh-client 1:10.0p1-7+deb13u4.
(*) Fallback pool URL for procps is undefined
(!) No URI found for procps 2:4.0.4-9.
(*) Fallback pool URL for psmisc is undefined
(!) No URI found for psmisc 23.7-2.
(*) Fallback pool URL for rsync is undefined
(!) No URI found for rsync 3.4.1+ds1-5+deb13u4.
(*) Fallback pool URL for strace is undefined
(!) No URI found for strace 6.13+ds-1.
(*) Fallback pool URL for sudo is undefined
(!) No URI found for sudo 1.9.16p2-3+deb13u2.
(*) Fallback pool URL for unzip is undefined
(!) No URI found for unzip 6.0-29+deb13u1.
(*) Fallback pool URL for vim-tiny is undefined
(!) No URI found for vim-tiny 2:9.1.1230-2.
(*) Fallback pool URL for wget is undefined
(!) No URI found for wget 1.25.0-2.
(*) Fallback pool URL for zip is undefined
(!) No URI found for zip 3.0-15+deb13u1.
(*) Fallback pool URL for zlib1g is undefined
(!) No URI found for zlib1g 1:1.3.dfsg+really1.3.1-1+b1.
(*) Fallback pool URL for zsh is undefined
(!) No URI found for zsh 5.9-8+b23.
(!) Warning: Some specified packages were not found.
(*) Gathering information about gems...
(*) Spawn: docker exec vscdc--extract--1788194360592 bash -c "set -e && echo ~~~BEGIN~~~ && bash -l -c 'set -e && gem list -d --local' 2>/dev/null && echo && echo ~~~END~~~"
(*) Getting remote and commit for Oh My Zsh! at /home/vscode/.oh-my-zsh...
(*) Spawn: docker exec -u root vscdc--extract--1788194360592 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/home/vscode/.oh-my-zsh\" && cd \"/home/vscode/.oh-my-zsh\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for nvm at /usr/local/share/nvm...
(*) Spawn: docker exec -u root vscdc--extract--1788194360592 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/nvm\" && cd \"/usr/local/share/nvm\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for ruby-build at /usr/local/share/ruby-build...
(*) Spawn: docker exec -u root vscdc--extract--1788194360592 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/ruby-build\" && cd \"/usr/local/share/ruby-build\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for git...
(*) Spawn: docker exec vscdc--extract--1788194360592 bash -c "set -e && echo ~~~BEGIN~~~ && git --version | sed -n '/git version /s///p' && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for Ruby...
(*) Spawn: docker exec vscdc--extract--1788194360592 bash -c "set -e && echo ~~~BEGIN~~~ && ruby --version | grep -oP '^ruby\s+\K[^\s]+' && echo && echo ~~~END~~~"
(*) Spawn: docker rm -f vscdc--extract--1788194360592
(!) Warning: No version for package undefined - skipping markdown output.
(!) Warning: No version for package undefined - skipping markdown output.

(*) Processing variant 3.3-trixie...
(*) Pulling image mcr.microsoft.com/devcontainers/ruby:dev-3.3-trixie...
(*) Spawn: docker pull mcr.microsoft.com/devcontainers/ruby:dev-3.3-trixie
(*) Spawn: docker run -d --rm --init --privileged --name vscdc--extract--1788194381310 mcr.microsoft.com/devcontainers/ruby:dev-3.3-trixie sh -c "while sleep 1000; do :; done"
(*) Spawn: docker exec -u root vscdc--extract--1788194381310 bash -c "set -e && echo ~~~BEGIN~~~ && cat /etc/os-release && echo && echo ~~~END~~~"
(*) Spawn: docker inspect --format='{{.Image}}' vscdc--extract--1788194381310
(*) Spawn: docker inspect --format='{{index .RepoDigests 0}}' sha256:967daa1ec377791ba134e52801060f54af9788f88f5aea1f7945e222c48ee150

(*) Spawn: docker exec -u root vscdc--extract--1788194381310 bash -c "set -e && echo ~~~BEGIN~~~ && id -un 1000 && echo && echo ~~~END~~~"
(*) Gathering information about Linux package versions...
(*) Spawn: docker exec -u root vscdc--extract--1788194381310 bash -c "set -e && echo ~~~BEGIN~~~ && dpkg-query --show -f='\${Package} ~~v~~ \${Version}
' apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(*) Gathering information about Linux package download URLs...
(*) Spawn: docker exec -u root vscdc--extract--1788194381310 bash -c "set -e && echo ~~~BEGIN~~~ && apt-get update && apt-get install -y --reinstall --print-uris apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libssl1.1" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libssl1.0.[0-9]" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching manpages-posix" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching manpages-posix-dev" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching yarn" - skipping.
(*) Fallback pool URL for apt-transport-https is undefined
(!) No URI found for apt-transport-https 3.0.3.
(*) Fallback pool URL for apt-utils is undefined
(!) No URI found for apt-utils 3.0.3.
(*) Fallback pool URL for build-essential is undefined
(!) No URI found for build-essential 12.12.
(*) Fallback pool URL for ca-certificates is undefined
(!) No URI found for ca-certificates 20250419.
(*) Fallback pool URL for curl is undefined
(!) No URI found for curl 8.14.1-2+deb13u4.
(*) Fallback pool URL for dialog is undefined
(!) No URI found for dialog 1.3-20250116-1.
(*) Fallback pool URL for git is undefined
(!) No URI found for git 1:2.47.3-0+deb13u1.
(*) Fallback pool URL for gnupg2 is undefined
(!) No URI found for gnupg2 2.4.7-21+deb13u1.
(*) Fallback pool URL for htop is undefined
(!) No URI found for htop 3.4.1-5.
(*) Fallback pool URL for iproute2 is undefined
(!) No URI found for iproute2 6.15.0-1.
(*) Fallback pool URL for jq is undefined
(!) No URI found for jq 1.7.1-6+deb13u3.
(*) Fallback pool URL for less is undefined
(!) No URI found for less 668-1.
(*) Fallback pool URL for libc6 is undefined
(!) No URI found for libc6 2.41-12+deb13u3.
(!) Warning: Unable to parse output "libgcc1 ~~v~~" - skipping.
(*) Fallback pool URL for libgssapi-krb5-2 is undefined
(!) No URI found for libgssapi-krb5-2 1.21.3-5+deb13u1.
(*) Fallback pool URL for libicu76 is undefined
(!) No URI found for libicu76 76.1-4.
(*) Fallback pool URL for libkrb5-3 is undefined
(!) No URI found for libkrb5-3 1.21.3-5+deb13u1.
(!) Warning: Unable to parse output "liblttng-ust1 ~~v~~" - skipping.
(*) Fallback pool URL for libstdc++6 is undefined
(!) No URI found for libstdc++6 14.2.0-19.
(*) Fallback pool URL for locales is undefined
(!) No URI found for locales 2.41-12+deb13u3.
(*) Fallback pool URL for lsb-release is undefined
(!) No URI found for lsb-release 12.1-1.
(*) Fallback pool URL for lsof is undefined
(!) No URI found for lsof 4.99.4+dfsg-2.
(*) Fallback pool URL for man-db is undefined
(!) No URI found for man-db 2.13.1-1.
(*) Fallback pool URL for manpages is undefined
(!) No URI found for manpages 6.9.1-1.
(*) Fallback pool URL for manpages-dev is undefined
(!) No URI found for manpages-dev 6.9.1-1.
(*) Fallback pool URL for nano is undefined
(!) No URI found for nano 8.4-1+deb13u1.
(*) Fallback pool URL for ncdu is undefined
(!) No URI found for ncdu 1.22-1.
(*) Fallback pool URL for net-tools is undefined
(!) No URI found for net-tools 2.10-1.3.
(*) Fallback pool URL for openssh-client is undefined
(!) No URI found for openssh-client 1:10.0p1-7+deb13u4.
(*) Fallback pool URL for procps is undefined
(!) No URI found for procps 2:4.0.4-9.
(*) Fallback pool URL for psmisc is undefined
(!) No URI found for psmisc 23.7-2.
(*) Fallback pool URL for rsync is undefined
(!) No URI found for rsync 3.4.1+ds1-5+deb13u4.
(*) Fallback pool URL for strace is undefined
(!) No URI found for strace 6.13+ds-1.
(*) Fallback pool URL for sudo is undefined
(!) No URI found for sudo 1.9.16p2-3+deb13u2.
(*) Fallback pool URL for unzip is undefined
(!) No URI found for unzip 6.0-29+deb13u1.
(*) Fallback pool URL for vim-tiny is undefined
(!) No URI found for vim-tiny 2:9.1.1230-2.
(*) Fallback pool URL for wget is undefined
(!) No URI found for wget 1.25.0-2.
(*) Fallback pool URL for zip is undefined
(!) No URI found for zip 3.0-15+deb13u1.
(*) Fallback pool URL for zlib1g is undefined
(!) No URI found for zlib1g 1:1.3.dfsg+really1.3.1-1+b1.
(*) Fallback pool URL for zsh is undefined
(!) No URI found for zsh 5.9-8+b23.
(!) Warning: Some specified packages were not found.
(*) Gathering information about gems...
(*) Spawn: docker exec vscdc--extract--1788194381310 bash -c "set -e && echo ~~~BEGIN~~~ && bash -l -c 'set -e && gem list -d --local' 2>/dev/null && echo && echo ~~~END~~~"
(*) Getting remote and commit for Oh My Zsh! at /home/vscode/.oh-my-zsh...
(*) Spawn: docker exec -u root vscdc--extract--1788194381310 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/home/vscode/.oh-my-zsh\" && cd \"/home/vscode/.oh-my-zsh\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for nvm at /usr/local/share/nvm...
(*) Spawn: docker exec -u root vscdc--extract--1788194381310 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/nvm\" && cd \"/usr/local/share/nvm\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for ruby-build at /usr/local/share/ruby-build...
(*) Spawn: docker exec -u root vscdc--extract--1788194381310 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/ruby-build\" && cd \"/usr/local/share/ruby-build\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for git...
(*) Spawn: docker exec vscdc--extract--1788194381310 bash -c "set -e && echo ~~~BEGIN~~~ && git --version | sed -n '/git version /s///p' && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for Ruby...
(*) Spawn: docker exec vscdc--extract--1788194381310 bash -c "set -e && echo ~~~BEGIN~~~ && ruby --version | grep -oP '^ruby\s+\K[^\s]+' && echo && echo ~~~END~~~"
(*) Spawn: docker rm -f vscdc--extract--1788194381310
(!) Warning: No version for package undefined - skipping markdown output.
(!) Warning: No version for package undefined - skipping markdown output.

(*) Processing variant 4.0-bookworm...
(*) Pulling image mcr.microsoft.com/devcontainers/ruby:dev-4.0-bookworm...
(*) Spawn: docker pull mcr.microsoft.com/devcontainers/ruby:dev-4.0-bookworm
(*) Spawn: docker run -d --rm --init --privileged --name vscdc--extract--1788194422677 mcr.microsoft.com/devcontainers/ruby:dev-4.0-bookworm sh -c "while sleep 1000; do :; done"
(*) Spawn: docker exec -u root vscdc--extract--1788194422677 bash -c "set -e && echo ~~~BEGIN~~~ && cat /etc/os-release && echo && echo ~~~END~~~"
(*) Spawn: docker inspect --format='{{.Image}}' vscdc--extract--1788194422677
(*) Spawn: docker inspect --format='{{index .RepoDigests 0}}' sha256:cbc114ca2d974766147a2f6a5a61728fe4c99854637585e8f27c8d96f7d74ca7

(*) Spawn: docker exec -u root vscdc--extract--1788194422677 bash -c "set -e && echo ~~~BEGIN~~~ && id -un 1000 && echo && echo ~~~END~~~"
(*) Gathering information about Linux package versions...
(*) Spawn: docker exec -u root vscdc--extract--1788194422677 bash -c "set -e && echo ~~~BEGIN~~~ && dpkg-query --show -f='\${Package} ~~v~~ \${Version}
' apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(*) Gathering information about Linux package download URLs...
(*) Spawn: docker exec -u root vscdc--extract--1788194422677 bash -c "set -e && echo ~~~BEGIN~~~ && apt-get update && apt-get install -y --reinstall --print-uris apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(*) Fallback pool URL for apt-transport-https is undefined
(!) No URI found for apt-transport-https 2.6.1.
(*) Fallback pool URL for apt-utils is undefined
(!) No URI found for apt-utils 2.6.1.
(*) Fallback pool URL for build-essential is undefined
(!) No URI found for build-essential 12.9.
(*) Fallback pool URL for ca-certificates is undefined
(!) No URI found for ca-certificates 20250419~deb12u1.
(*) Fallback pool URL for curl is undefined
(!) No URI found for curl 7.88.1-10+deb12u15.
(*) Fallback pool URL for dialog is undefined
(!) No URI found for dialog 1.3-20230209-1.
(*) Fallback pool URL for git is undefined
(!) No URI found for git 1:2.39.5-0+deb12u3.
(*) Fallback pool URL for gnupg2 is undefined
(!) No URI found for gnupg2 2.2.40-1.1+deb12u2.
(*) Fallback pool URL for htop is undefined
(!) No URI found for htop 3.2.2-2.
(*) Fallback pool URL for iproute2 is undefined
(!) No URI found for iproute2 6.1.0-3.
(*) Fallback pool URL for jq is undefined
(!) No URI found for jq 1.6-2.1+deb12u2.
(*) Fallback pool URL for less is undefined
(!) No URI found for less 590-2.1~deb12u2.
(*) Fallback pool URL for libc6 is undefined
(!) No URI found for libc6 2.36-9+deb12u14.
(!) Warning: Unable to parse output "libgcc1 ~~v~~" - skipping.
(*) Fallback pool URL for libgssapi-krb5-2 is undefined
(!) No URI found for libgssapi-krb5-2 1.20.1-2+deb12u5.
(*) Fallback pool URL for libicu72 is undefined
(!) No URI found for libicu72 72.1-3+deb12u1.
(*) Fallback pool URL for libkrb5-3 is undefined
(!) No URI found for libkrb5-3 1.20.1-2+deb12u5.
(*) Fallback pool URL for liblttng-ust1 is undefined
(!) No URI found for liblttng-ust1 2.13.5-1.
(*) Fallback pool URL for libstdc++6 is undefined
(!) No URI found for libstdc++6 12.2.0-14+deb12u1.
(*) Fallback pool URL for locales is undefined
(!) No URI found for locales 2.36-9+deb12u14.
(*) Fallback pool URL for lsb-release is undefined
(!) No URI found for lsb-release 12.0-1.
(*) Fallback pool URL for lsof is undefined
(!) No URI found for lsof 4.95.0-1.
(*) Fallback pool URL for man-db is undefined
(!) No URI found for man-db 2.11.2-2.
(*) Fallback pool URL for manpages is undefined
(!) No URI found for manpages 6.03-2.
(*) Fallback pool URL for manpages-dev is undefined
(!) No URI found for manpages-dev 6.03-2.
(*) Fallback pool URL for nano is undefined
(!) No URI found for nano 7.2-1+deb12u1.
(*) Fallback pool URL for ncdu is undefined
(!) No URI found for ncdu 1.18-0.2.
(*) Fallback pool URL for net-tools is undefined
(!) No URI found for net-tools 2.10-0.1+deb12u2.
(*) Fallback pool URL for openssh-client is undefined
(!) No URI found for openssh-client 1:9.2p1-2+deb12u10.
(*) Fallback pool URL for procps is undefined
(!) No URI found for procps 2:4.0.2-3.
(*) Fallback pool URL for psmisc is undefined
(!) No URI found for psmisc 23.6-1.
(*) Fallback pool URL for rsync is undefined
(!) No URI found for rsync 3.2.7-1+deb12u6.
(*) Fallback pool URL for strace is undefined
(!) No URI found for strace 6.1-0.1.
(*) Fallback pool URL for sudo is undefined
(!) No URI found for sudo 1.9.13p3-1+deb12u4.
(*) Fallback pool URL for unzip is undefined
(!) No URI found for unzip 6.0-28+deb12u1.
(*) Fallback pool URL for vim-tiny is undefined
(!) No URI found for vim-tiny 2:9.0.1378-2+deb12u2.
(*) Fallback pool URL for wget is undefined
(!) No URI found for wget 1.21.3-1+deb12u1.
(*) Fallback pool URL for zip is undefined
(!) No URI found for zip 3.0-13.
(*) Fallback pool URL for zlib1g is undefined
(!) No URI found for zlib1g 1:1.2.13.dfsg-1.
(*) Fallback pool URL for zsh is undefined
(!) No URI found for zsh 5.9-4+b15.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libssl1.1" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libssl1.0.[0-9]" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching manpages-posix" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching manpages-posix-dev" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching yarn" - skipping.
(!) Warning: Some specified packages were not found.
(*) Gathering information about gems...
(*) Spawn: docker exec vscdc--extract--1788194422677 bash -c "set -e && echo ~~~BEGIN~~~ && bash -l -c 'set -e && gem list -d --local' 2>/dev/null && echo && echo ~~~END~~~"
(*) Getting remote and commit for Oh My Zsh! at /home/vscode/.oh-my-zsh...
(*) Spawn: docker exec -u root vscdc--extract--1788194422677 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/home/vscode/.oh-my-zsh\" && cd \"/home/vscode/.oh-my-zsh\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for nvm at /usr/local/share/nvm...
(*) Spawn: docker exec -u root vscdc--extract--1788194422677 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/nvm\" && cd \"/usr/local/share/nvm\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for ruby-build at /usr/local/share/ruby-build...
(*) Spawn: docker exec -u root vscdc--extract--1788194422677 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/ruby-build\" && cd \"/usr/local/share/ruby-build\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for git...
(*) Spawn: docker exec vscdc--extract--1788194422677 bash -c "set -e && echo ~~~BEGIN~~~ && git --version | sed -n '/git version /s///p' && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for Ruby...
(*) Spawn: docker exec vscdc--extract--1788194422677 bash -c "set -e && echo ~~~BEGIN~~~ && ruby --version | grep -oP '^ruby\s+\K[^\s]+' && echo && echo ~~~END~~~"
(*) Spawn: docker rm -f vscdc--extract--1788194422677
(!) Warning: No version for package undefined - skipping markdown output.
(!) Warning: No version for package undefined - skipping markdown output.

(*) Processing variant 3.4-bookworm...
(*) Pulling image mcr.microsoft.com/devcontainers/ruby:dev-3.4-bookworm...
(*) Spawn: docker pull mcr.microsoft.com/devcontainers/ruby:dev-3.4-bookworm
(*) Spawn: docker run -d --rm --init --privileged --name vscdc--extract--1788194452812 mcr.microsoft.com/devcontainers/ruby:dev-3.4-bookworm sh -c "while sleep 1000; do :; done"
(*) Spawn: docker exec -u root vscdc--extract--1788194452812 bash -c "set -e && echo ~~~BEGIN~~~ && cat /etc/os-release && echo && echo ~~~END~~~"
(*) Spawn: docker inspect --format='{{.Image}}' vscdc--extract--1788194452812
(*) Spawn: docker inspect --format='{{index .RepoDigests 0}}' sha256:2455bb556d1b17e1bcfb2f5bd6ab4dddec7cc7fec9808043e7d861b1585569d8

(*) Spawn: docker exec -u root vscdc--extract--1788194452812 bash -c "set -e && echo ~~~BEGIN~~~ && id -un 1000 && echo && echo ~~~END~~~"
(*) Gathering information about Linux package versions...
(*) Spawn: docker exec -u root vscdc--extract--1788194452812 bash -c "set -e && echo ~~~BEGIN~~~ && dpkg-query --show -f='\${Package} ~~v~~ \${Version}
' apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(*) Gathering information about Linux package download URLs...
(*) Spawn: docker exec -u root vscdc--extract--1788194452812 bash -c "set -e && echo ~~~BEGIN~~~ && apt-get update && apt-get install -y --reinstall --print-uris apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libssl1.1" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libssl1.0.[0-9]" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching manpages-posix" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching manpages-posix-dev" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching yarn" - skipping.
(*) Fallback pool URL for apt-transport-https is undefined
(!) No URI found for apt-transport-https 2.6.1.
(*) Fallback pool URL for apt-utils is undefined
(!) No URI found for apt-utils 2.6.1.
(*) Fallback pool URL for build-essential is undefined
(!) No URI found for build-essential 12.9.
(*) Fallback pool URL for ca-certificates is undefined
(!) No URI found for ca-certificates 20250419~deb12u1.
(*) Fallback pool URL for curl is undefined
(!) No URI found for curl 7.88.1-10+deb12u15.
(*) Fallback pool URL for dialog is undefined
(!) No URI found for dialog 1.3-20230209-1.
(*) Fallback pool URL for git is undefined
(!) No URI found for git 1:2.39.5-0+deb12u3.
(*) Fallback pool URL for gnupg2 is undefined
(!) No URI found for gnupg2 2.2.40-1.1+deb12u2.
(*) Fallback pool URL for htop is undefined
(!) No URI found for htop 3.2.2-2.
(*) Fallback pool URL for iproute2 is undefined
(!) No URI found for iproute2 6.1.0-3.
(*) Fallback pool URL for jq is undefined
(!) No URI found for jq 1.6-2.1+deb12u2.
(*) Fallback pool URL for less is undefined
(!) No URI found for less 590-2.1~deb12u2.
(*) Fallback pool URL for libc6 is undefined
(!) No URI found for libc6 2.36-9+deb12u14.
(!) Warning: Unable to parse output "libgcc1 ~~v~~" - skipping.
(*) Fallback pool URL for libgssapi-krb5-2 is undefined
(!) No URI found for libgssapi-krb5-2 1.20.1-2+deb12u5.
(*) Fallback pool URL for libicu72 is undefined
(!) No URI found for libicu72 72.1-3+deb12u1.
(*) Fallback pool URL for libkrb5-3 is undefined
(!) No URI found for libkrb5-3 1.20.1-2+deb12u5.
(*) Fallback pool URL for liblttng-ust1 is undefined
(!) No URI found for liblttng-ust1 2.13.5-1.
(*) Fallback pool URL for libstdc++6 is undefined
(!) No URI found for libstdc++6 12.2.0-14+deb12u1.
(*) Fallback pool URL for locales is undefined
(!) No URI found for locales 2.36-9+deb12u14.
(*) Fallback pool URL for lsb-release is undefined
(!) No URI found for lsb-release 12.0-1.
(*) Fallback pool URL for lsof is undefined
(!) No URI found for lsof 4.95.0-1.
(*) Fallback pool URL for man-db is undefined
(!) No URI found for man-db 2.11.2-2.
(*) Fallback pool URL for manpages is undefined
(!) No URI found for manpages 6.03-2.
(*) Fallback pool URL for manpages-dev is undefined
(!) No URI found for manpages-dev 6.03-2.
(*) Fallback pool URL for nano is undefined
(!) No URI found for nano 7.2-1+deb12u1.
(*) Fallback pool URL for ncdu is undefined
(!) No URI found for ncdu 1.18-0.2.
(*) Fallback pool URL for net-tools is undefined
(!) No URI found for net-tools 2.10-0.1+deb12u2.
(*) Fallback pool URL for openssh-client is undefined
(!) No URI found for openssh-client 1:9.2p1-2+deb12u10.
(*) Fallback pool URL for procps is undefined
(!) No URI found for procps 2:4.0.2-3.
(*) Fallback pool URL for psmisc is undefined
(!) No URI found for psmisc 23.6-1.
(*) Fallback pool URL for rsync is undefined
(!) No URI found for rsync 3.2.7-1+deb12u6.
(*) Fallback pool URL for strace is undefined
(!) No URI found for strace 6.1-0.1.
(*) Fallback pool URL for sudo is undefined
(!) No URI found for sudo 1.9.13p3-1+deb12u4.
(*) Fallback pool URL for unzip is undefined
(!) No URI found for unzip 6.0-28+deb12u1.
(*) Fallback pool URL for vim-tiny is undefined
(!) No URI found for vim-tiny 2:9.0.1378-2+deb12u2.
(*) Fallback pool URL for wget is undefined
(!) No URI found for wget 1.21.3-1+deb12u1.
(*) Fallback pool URL for zip is undefined
(!) No URI found for zip 3.0-13.
(*) Fallback pool URL for zlib1g is undefined
(!) No URI found for zlib1g 1:1.2.13.dfsg-1.
(*) Fallback pool URL for zsh is undefined
(!) No URI found for zsh 5.9-4+b15.
(!) Warning: Some specified packages were not found.
(*) Gathering information about gems...
(*) Spawn: docker exec vscdc--extract--1788194452812 bash -c "set -e && echo ~~~BEGIN~~~ && bash -l -c 'set -e && gem list -d --local' 2>/dev/null && echo && echo ~~~END~~~"
(*) Getting remote and commit for Oh My Zsh! at /home/vscode/.oh-my-zsh...
(*) Spawn: docker exec -u root vscdc--extract--1788194452812 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/home/vscode/.oh-my-zsh\" && cd \"/home/vscode/.oh-my-zsh\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for nvm at /usr/local/share/nvm...
(*) Spawn: docker exec -u root vscdc--extract--1788194452812 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/nvm\" && cd \"/usr/local/share/nvm\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for ruby-build at /usr/local/share/ruby-build...
(*) Spawn: docker exec -u root vscdc--extract--1788194452812 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/ruby-build\" && cd \"/usr/local/share/ruby-build\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for git...
(*) Spawn: docker exec vscdc--extract--1788194452812 bash -c "set -e && echo ~~~BEGIN~~~ && git --version | sed -n '/git version /s///p' && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for Ruby...
(*) Spawn: docker exec vscdc--extract--1788194452812 bash -c "set -e && echo ~~~BEGIN~~~ && ruby --version | grep -oP '^ruby\s+\K[^\s]+' && echo && echo ~~~END~~~"
(*) Spawn: docker rm -f vscdc--extract--1788194452812
(!) Warning: No version for package undefined - skipping markdown output.
(!) Warning: No version for package undefined - skipping markdown output.

(*) Processing variant 3.3-bookworm...
(*) Pulling image mcr.microsoft.com/devcontainers/ruby:dev-3.3-bookworm...
(*) Spawn: docker pull mcr.microsoft.com/devcontainers/ruby:dev-3.3-bookworm
(*) Spawn: docker run -d --rm --init --privileged --name vscdc--extract--1788194474384 mcr.microsoft.com/devcontainers/ruby:dev-3.3-bookworm sh -c "while sleep 1000; do :; done"
(*) Spawn: docker exec -u root vscdc--extract--1788194474384 bash -c "set -e && echo ~~~BEGIN~~~ && cat /etc/os-release && echo && echo ~~~END~~~"
(*) Spawn: docker inspect --format='{{.Image}}' vscdc--extract--1788194474384
(*) Spawn: docker inspect --format='{{index .RepoDigests 0}}' sha256:55b4090f740e404d20273c17a315c18336d01c754958e0493b04ae6f42adc19f

(*) Spawn: docker exec -u root vscdc--extract--1788194474384 bash -c "set -e && echo ~~~BEGIN~~~ && id -un 1000 && echo && echo ~~~END~~~"
(*) Gathering information about Linux package versions...
(*) Spawn: docker exec -u root vscdc--extract--1788194474384 bash -c "set -e && echo ~~~BEGIN~~~ && dpkg-query --show -f='\${Package} ~~v~~ \${Version}
' apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(*) Gathering information about Linux package download URLs...
(*) Spawn: docker exec -u root vscdc--extract--1788194474384 bash -c "set -e && echo ~~~BEGIN~~~ && apt-get update && apt-get install -y --reinstall --print-uris apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libssl1.1" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libssl1.0.[0-9]" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching manpages-posix" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching manpages-posix-dev" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching yarn" - skipping.
(*) Fallback pool URL for apt-transport-https is undefined
(!) No URI found for apt-transport-https 2.6.1.
(*) Fallback pool URL for apt-utils is undefined
(!) No URI found for apt-utils 2.6.1.
(*) Fallback pool URL for build-essential is undefined
(!) No URI found for build-essential 12.9.
(*) Fallback pool URL for ca-certificates is undefined
(!) No URI found for ca-certificates 20250419~deb12u1.
(*) Fallback pool URL for curl is undefined
(!) No URI found for curl 7.88.1-10+deb12u15.
(*) Fallback pool URL for dialog is undefined
(!) No URI found for dialog 1.3-20230209-1.
(*) Fallback pool URL for git is undefined
(!) No URI found for git 1:2.39.5-0+deb12u3.
(*) Fallback pool URL for gnupg2 is undefined
(!) No URI found for gnupg2 2.2.40-1.1+deb12u2.
(*) Fallback pool URL for htop is undefined
(!) No URI found for htop 3.2.2-2.
(*) Fallback pool URL for iproute2 is undefined
(!) No URI found for iproute2 6.1.0-3.
(*) Fallback pool URL for jq is undefined
(!) No URI found for jq 1.6-2.1+deb12u2.
(*) Fallback pool URL for less is undefined
(!) No URI found for less 590-2.1~deb12u2.
(*) Fallback pool URL for libc6 is undefined
(!) No URI found for libc6 2.36-9+deb12u14.
(!) Warning: Unable to parse output "libgcc1 ~~v~~" - skipping.
(*) Fallback pool URL for libgssapi-krb5-2 is undefined
(!) No URI found for libgssapi-krb5-2 1.20.1-2+deb12u5.
(*) Fallback pool URL for libicu72 is undefined
(!) No URI found for libicu72 72.1-3+deb12u1.
(*) Fallback pool URL for libkrb5-3 is undefined
(!) No URI found for libkrb5-3 1.20.1-2+deb12u5.
(*) Fallback pool URL for liblttng-ust1 is undefined
(!) No URI found for liblttng-ust1 2.13.5-1.
(*) Fallback pool URL for libstdc++6 is undefined
(!) No URI found for libstdc++6 12.2.0-14+deb12u1.
(*) Fallback pool URL for locales is undefined
(!) No URI found for locales 2.36-9+deb12u14.
(*) Fallback pool URL for lsb-release is undefined
(!) No URI found for lsb-release 12.0-1.
(*) Fallback pool URL for lsof is undefined
(!) No URI found for lsof 4.95.0-1.
(*) Fallback pool URL for man-db is undefined
(!) No URI found for man-db 2.11.2-2.
(*) Fallback pool URL for manpages is undefined
(!) No URI found for manpages 6.03-2.
(*) Fallback pool URL for manpages-dev is undefined
(!) No URI found for manpages-dev 6.03-2.
(*) Fallback pool URL for nano is undefined
(!) No URI found for nano 7.2-1+deb12u1.
(*) Fallback pool URL for ncdu is undefined
(!) No URI found for ncdu 1.18-0.2.
(*) Fallback pool URL for net-tools is undefined
(!) No URI found for net-tools 2.10-0.1+deb12u2.
(*) Fallback pool URL for openssh-client is undefined
(!) No URI found for openssh-client 1:9.2p1-2+deb12u10.
(*) Fallback pool URL for procps is undefined
(!) No URI found for procps 2:4.0.2-3.
(*) Fallback pool URL for psmisc is undefined
(!) No URI found for psmisc 23.6-1.
(*) Fallback pool URL for rsync is undefined
(!) No URI found for rsync 3.2.7-1+deb12u6.
(*) Fallback pool URL for strace is undefined
(!) No URI found for strace 6.1-0.1.
(*) Fallback pool URL for sudo is undefined
(!) No URI found for sudo 1.9.13p3-1+deb12u4.
(*) Fallback pool URL for unzip is undefined
(!) No URI found for unzip 6.0-28+deb12u1.
(*) Fallback pool URL for vim-tiny is undefined
(!) No URI found for vim-tiny 2:9.0.1378-2+deb12u2.
(*) Fallback pool URL for wget is undefined
(!) No URI found for wget 1.21.3-1+deb12u1.
(*) Fallback pool URL for zip is undefined
(!) No URI found for zip 3.0-13.
(*) Fallback pool URL for zlib1g is undefined
(!) No URI found for zlib1g 1:1.2.13.dfsg-1.
(*) Fallback pool URL for zsh is undefined
(!) No URI found for zsh 5.9-4+b15.
(!) Warning: Some specified packages were not found.
(*) Gathering information about gems...
(*) Spawn: docker exec vscdc--extract--1788194474384 bash -c "set -e && echo ~~~BEGIN~~~ && bash -l -c 'set -e && gem list -d --local' 2>/dev/null && echo && echo ~~~END~~~"
(*) Getting remote and commit for Oh My Zsh! at /home/vscode/.oh-my-zsh...
(*) Spawn: docker exec -u root vscdc--extract--1788194474384 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/home/vscode/.oh-my-zsh\" && cd \"/home/vscode/.oh-my-zsh\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for nvm at /usr/local/share/nvm...
(*) Spawn: docker exec -u root vscdc--extract--1788194474384 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/nvm\" && cd \"/usr/local/share/nvm\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for ruby-build at /usr/local/share/ruby-build...
(*) Spawn: docker exec -u root vscdc--extract--1788194474384 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/ruby-build\" && cd \"/usr/local/share/ruby-build\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for git...
(*) Spawn: docker exec vscdc--extract--1788194474384 bash -c "set -e && echo ~~~BEGIN~~~ && git --version | sed -n '/git version /s///p' && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for Ruby...
(*) Spawn: docker exec vscdc--extract--1788194474384 bash -c "set -e && echo ~~~BEGIN~~~ && ruby --version | grep -oP '^ruby\s+\K[^\s]+' && echo && echo ~~~END~~~"
(*) Spawn: docker rm -f vscdc--extract--1788194474384
(!) Warning: No version for package undefined - skipping markdown output.
(!) Warning: No version for package undefined - skipping markdown output.

(*) Processing variant 3.4-bullseye...
(*) Pulling image mcr.microsoft.com/devcontainers/ruby:dev-3.4-bullseye...
(*) Spawn: docker pull mcr.microsoft.com/devcontainers/ruby:dev-3.4-bullseye
(*) Spawn: docker run -d --rm --init --privileged --name vscdc--extract--1788194529559 mcr.microsoft.com/devcontainers/ruby:dev-3.4-bullseye sh -c "while sleep 1000; do :; done"
(*) Spawn: docker exec -u root vscdc--extract--1788194529559 bash -c "set -e && echo ~~~BEGIN~~~ && cat /etc/os-release && echo && echo ~~~END~~~"
(*) Spawn: docker inspect --format='{{.Image}}' vscdc--extract--1788194529559
(*) Spawn: docker inspect --format='{{index .RepoDigests 0}}' sha256:80d4ae09b3163d1bfaac1392beac7fef37287c1824828e4553d0d70df52cc007

(*) Spawn: docker exec -u root vscdc--extract--1788194529559 bash -c "set -e && echo ~~~BEGIN~~~ && id -un 1000 && echo && echo ~~~END~~~"
(*) Gathering information about Linux package versions...
(*) Spawn: docker exec -u root vscdc--extract--1788194529559 bash -c "set -e && echo ~~~BEGIN~~~ && dpkg-query --show -f='\${Package} ~~v~~ \${Version}
' apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(*) Gathering information about Linux package download URLs...
(*) Spawn: docker exec -u root vscdc--extract--1788194529559 bash -c "set -e && echo ~~~BEGIN~~~ && apt-get update && apt-get install -y --reinstall --print-uris apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(*) Fallback pool URL for apt-transport-https is undefined
(!) No URI found for apt-transport-https 2.2.4.
(*) Fallback pool URL for apt-utils is undefined
(!) No URI found for apt-utils 2.2.4.
(*) Fallback pool URL for build-essential is undefined
(!) No URI found for build-essential 12.9.
(*) Fallback pool URL for ca-certificates is undefined
(!) No URI found for ca-certificates 20250419~deb12u1~deb11u1.
(*) Fallback pool URL for curl is undefined
(!) No URI found for curl 7.74.0-1.3+deb11u16.
(*) Fallback pool URL for dialog is undefined
(!) No URI found for dialog 1.3-20201126-1.
(*) Fallback pool URL for git is undefined
(!) No URI found for git 1:2.30.2-1+deb11u5.
(*) Fallback pool URL for gnupg2 is undefined
(!) No URI found for gnupg2 2.2.27-2+deb11u3.
(*) Fallback pool URL for htop is undefined
(!) No URI found for htop 3.0.5-7.
(*) Fallback pool URL for iproute2 is undefined
(!) No URI found for iproute2 5.10.0-4.
(*) Fallback pool URL for jq is undefined
(!) No URI found for jq 1.6-2.1+deb11u3.
(*) Fallback pool URL for less is undefined
(!) No URI found for less 551-2+deb11u2.
(*) Fallback pool URL for libc6 is undefined
(!) No URI found for libc6 2.31-13+deb11u14.
(!) Warning: Unable to parse output "libgcc1 ~~v~~" - skipping.
(*) Fallback pool URL for libgssapi-krb5-2 is undefined
(!) No URI found for libgssapi-krb5-2 1.18.3-6+deb11u8.
(*) Fallback pool URL for libicu67 is undefined
(!) No URI found for libicu67 67.1-7+deb11u1.
(*) Fallback pool URL for libkrb5-3 is undefined
(!) No URI found for libkrb5-3 1.18.3-6+deb11u8.
(*) Fallback pool URL for liblttng-ust0 is undefined
(!) No URI found for liblttng-ust0 2.12.1-1.
(!) Warning: Unable to parse output "liblttng-ust2 ~~v~~" - skipping.
(*) Fallback pool URL for libssl1.1 is undefined
(!) No URI found for libssl1.1 1.1.1w-0+deb11u8.
(*) Fallback pool URL for libstdc++6 is undefined
(!) No URI found for libstdc++6 10.2.1-6.
(*) Fallback pool URL for locales is undefined
(!) No URI found for locales 2.31-13+deb11u14.
(*) Fallback pool URL for lsb-release is undefined
(!) No URI found for lsb-release 11.1.0.
(*) Fallback pool URL for lsof is undefined
(!) No URI found for lsof 4.93.2+dfsg-1.1.
(*) Fallback pool URL for man-db is undefined
(!) No URI found for man-db 2.9.4-2.
(*) Fallback pool URL for manpages is undefined
(!) No URI found for manpages 5.10-1.
(*) Fallback pool URL for manpages-dev is undefined
(!) No URI found for manpages-dev 5.10-1.
(*) Fallback pool URL for nano is undefined
(!) No URI found for nano 5.4-2+deb11u3.
(*) Fallback pool URL for ncdu is undefined
(!) No URI found for ncdu 1.15.1-1.
(*) Fallback pool URL for net-tools is undefined
(!) No URI found for net-tools 1.60+git20181103.0eebece-1+deb11u2.
(*) Fallback pool URL for openssh-client is undefined
(!) No URI found for openssh-client 1:8.4p1-5+deb11u7.
(*) Fallback pool URL for procps is undefined
(!) No URI found for procps 2:3.3.17-5.
(*) Fallback pool URL for psmisc is undefined
(!) No URI found for psmisc 23.4-2.
(*) Fallback pool URL for rsync is undefined
(!) No URI found for rsync 3.2.3-4+deb11u4.
(*) Fallback pool URL for strace is undefined
(!) No URI found for strace 5.10-1.
(*) Fallback pool URL for sudo is undefined
(!) No URI found for sudo 1.9.5p2-3+deb11u4.
(*) Fallback pool URL for unzip is undefined
(!) No URI found for unzip 6.0-26+deb11u2.
(*) Fallback pool URL for vim-tiny is undefined
(!) No URI found for vim-tiny 2:8.2.2434-3+deb11u3.
(*) Fallback pool URL for wget is undefined
(!) No URI found for wget 1.21-1+deb11u2.
(*) Fallback pool URL for zip is undefined
(!) No URI found for zip 3.0-12.
(*) Fallback pool URL for zlib1g is undefined
(!) No URI found for zlib1g 1:1.2.11.dfsg-2+deb11u2.
(*) Fallback pool URL for zsh is undefined
(!) No URI found for zsh 5.8-6+deb11u1.
(!) Warning: Some specified packages were not found.
(*) Gathering information about gems...
(*) Spawn: docker exec vscdc--extract--1788194529559 bash -c "set -e && echo ~~~BEGIN~~~ && bash -l -c 'set -e && gem list -d --local' 2>/dev/null && echo && echo ~~~END~~~"
(*) Getting remote and commit for Oh My Zsh! at /home/vscode/.oh-my-zsh...
(*) Spawn: docker exec -u root vscdc--extract--1788194529559 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/home/vscode/.oh-my-zsh\" && cd \"/home/vscode/.oh-my-zsh\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for nvm at /usr/local/share/nvm...
(*) Spawn: docker exec -u root vscdc--extract--1788194529559 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/nvm\" && cd \"/usr/local/share/nvm\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for ruby-build at /usr/local/share/ruby-build...
(*) Spawn: docker exec -u root vscdc--extract--1788194529559 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/ruby-build\" && cd \"/usr/local/share/ruby-build\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for git...
(*) Spawn: docker exec vscdc--extract--1788194529559 bash -c "set -e && echo ~~~BEGIN~~~ && git --version | sed -n '/git version /s///p' && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for Ruby...
(*) Spawn: docker exec vscdc--extract--1788194529559 bash -c "set -e && echo ~~~BEGIN~~~ && ruby --version | grep -oP '^ruby\s+\K[^\s]+' && echo && echo ~~~END~~~"
(*) Spawn: docker rm -f vscdc--extract--1788194529559
(!) Warning: No version for package undefined - skipping markdown output.
(!) Warning: No version for package undefined - skipping markdown output.

(*) Processing variant 3.3-bullseye...
(*) Pulling image mcr.microsoft.com/devcontainers/ruby:dev-3.3-bullseye...
(*) Spawn: docker pull mcr.microsoft.com/devcontainers/ruby:dev-3.3-bullseye
(*) Spawn: docker run -d --rm --init --privileged --name vscdc--extract--1788194557004 mcr.microsoft.com/devcontainers/ruby:dev-3.3-bullseye sh -c "while sleep 1000; do :; done"
(*) Spawn: docker exec -u root vscdc--extract--1788194557004 bash -c "set -e && echo ~~~BEGIN~~~ && cat /etc/os-release && echo && echo ~~~END~~~"
(*) Spawn: docker inspect --format='{{.Image}}' vscdc--extract--1788194557004
(*) Spawn: docker inspect --format='{{index .RepoDigests 0}}' sha256:21f6659091da3c8af9022f208cd2d323ee7fb65646734723299d4e242c5335ef

(*) Spawn: docker exec -u root vscdc--extract--1788194557004 bash -c "set -e && echo ~~~BEGIN~~~ && id -un 1000 && echo && echo ~~~END~~~"
(*) Gathering information about Linux package versions...
(*) Spawn: docker exec -u root vscdc--extract--1788194557004 bash -c "set -e && echo ~~~BEGIN~~~ && dpkg-query --show -f='\${Package} ~~v~~ \${Version}
' apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(*) Gathering information about Linux package download URLs...
(*) Spawn: docker exec -u root vscdc--extract--1788194557004 bash -c "set -e && echo ~~~BEGIN~~~ && apt-get update && apt-get install -y --reinstall --print-uris apt-utils git openssh-client gnupg2 iproute2 procps lsof htop net-tools psmisc curl wget rsync ca-certificates unzip zip nano vim-tiny less jq lsb-release apt-transport-https dialog libc6 libgcc1 libkrb5-3 libgssapi-krb5-2 libicu[0-9][0-9] liblttng-ust[0-9] libstdc++6 zlib1g locales sudo ncdu man-db strace libssl1.1 libssl1.0.[0-9] manpages manpages-dev manpages-posix manpages-posix-dev zsh yarn build-essential || echo 'Some packages were not found.' && echo && echo ~~~END~~~"
(!) Warning: Unable to parse output "dpkg-query: no packages found matching libssl1.0.[0-9]" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching manpages-posix" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching manpages-posix-dev" - skipping.
(!) Warning: Unable to parse output "dpkg-query: no packages found matching yarn" - skipping.
(*) Fallback pool URL for apt-transport-https is undefined
(!) No URI found for apt-transport-https 2.2.4.
(*) Fallback pool URL for apt-utils is undefined
(!) No URI found for apt-utils 2.2.4.
(*) Fallback pool URL for build-essential is undefined
(!) No URI found for build-essential 12.9.
(*) Fallback pool URL for ca-certificates is undefined
(!) No URI found for ca-certificates 20250419~deb12u1~deb11u1.
(*) Fallback pool URL for curl is undefined
(!) No URI found for curl 7.74.0-1.3+deb11u16.
(*) Fallback pool URL for dialog is undefined
(!) No URI found for dialog 1.3-20201126-1.
(*) Fallback pool URL for git is undefined
(!) No URI found for git 1:2.30.2-1+deb11u5.
(*) Fallback pool URL for gnupg2 is undefined
(!) No URI found for gnupg2 2.2.27-2+deb11u3.
(*) Fallback pool URL for htop is undefined
(!) No URI found for htop 3.0.5-7.
(*) Fallback pool URL for iproute2 is undefined
(!) No URI found for iproute2 5.10.0-4.
(*) Fallback pool URL for jq is undefined
(!) No URI found for jq 1.6-2.1+deb11u3.
(*) Fallback pool URL for less is undefined
(!) No URI found for less 551-2+deb11u2.
(*) Fallback pool URL for libc6 is undefined
(!) No URI found for libc6 2.31-13+deb11u14.
(!) Warning: Unable to parse output "libgcc1 ~~v~~" - skipping.
(*) Fallback pool URL for libgssapi-krb5-2 is undefined
(!) No URI found for libgssapi-krb5-2 1.18.3-6+deb11u8.
(*) Fallback pool URL for libicu67 is undefined
(!) No URI found for libicu67 67.1-7+deb11u1.
(*) Fallback pool URL for libkrb5-3 is undefined
(!) No URI found for libkrb5-3 1.18.3-6+deb11u8.
(*) Fallback pool URL for liblttng-ust0 is undefined
(!) No URI found for liblttng-ust0 2.12.1-1.
(!) Warning: Unable to parse output "liblttng-ust2 ~~v~~" - skipping.
(*) Fallback pool URL for libssl1.1 is undefined
(!) No URI found for libssl1.1 1.1.1w-0+deb11u8.
(*) Fallback pool URL for libstdc++6 is undefined
(!) No URI found for libstdc++6 10.2.1-6.
(*) Fallback pool URL for locales is undefined
(!) No URI found for locales 2.31-13+deb11u14.
(*) Fallback pool URL for lsb-release is undefined
(!) No URI found for lsb-release 11.1.0.
(*) Fallback pool URL for lsof is undefined
(!) No URI found for lsof 4.93.2+dfsg-1.1.
(*) Fallback pool URL for man-db is undefined
(!) No URI found for man-db 2.9.4-2.
(*) Fallback pool URL for manpages is undefined
(!) No URI found for manpages 5.10-1.
(*) Fallback pool URL for manpages-dev is undefined
(!) No URI found for manpages-dev 5.10-1.
(*) Fallback pool URL for nano is undefined
(!) No URI found for nano 5.4-2+deb11u3.
(*) Fallback pool URL for ncdu is undefined
(!) No URI found for ncdu 1.15.1-1.
(*) Fallback pool URL for net-tools is undefined
(!) No URI found for net-tools 1.60+git20181103.0eebece-1+deb11u2.
(*) Fallback pool URL for openssh-client is undefined
(!) No URI found for openssh-client 1:8.4p1-5+deb11u7.
(*) Fallback pool URL for procps is undefined
(!) No URI found for procps 2:3.3.17-5.
(*) Fallback pool URL for psmisc is undefined
(!) No URI found for psmisc 23.4-2.
(*) Fallback pool URL for rsync is undefined
(!) No URI found for rsync 3.2.3-4+deb11u4.
(*) Fallback pool URL for strace is undefined
(!) No URI found for strace 5.10-1.
(*) Fallback pool URL for sudo is undefined
(!) No URI found for sudo 1.9.5p2-3+deb11u4.
(*) Fallback pool URL for unzip is undefined
(!) No URI found for unzip 6.0-26+deb11u2.
(*) Fallback pool URL for vim-tiny is undefined
(!) No URI found for vim-tiny 2:8.2.2434-3+deb11u3.
(*) Fallback pool URL for wget is undefined
(!) No URI found for wget 1.21-1+deb11u2.
(*) Fallback pool URL for zip is undefined
(!) No URI found for zip 3.0-12.
(*) Fallback pool URL for zlib1g is undefined
(!) No URI found for zlib1g 1:1.2.11.dfsg-2+deb11u2.
(*) Fallback pool URL for zsh is undefined
(!) No URI found for zsh 5.8-6+deb11u1.
(!) Warning: Some specified packages were not found.
(*) Gathering information about gems...
(*) Spawn: docker exec vscdc--extract--1788194557004 bash -c "set -e && echo ~~~BEGIN~~~ && bash -l -c 'set -e && gem list -d --local' 2>/dev/null && echo && echo ~~~END~~~"
(*) Getting remote and commit for Oh My Zsh! at /home/vscode/.oh-my-zsh...
(*) Spawn: docker exec -u root vscdc--extract--1788194557004 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/home/vscode/.oh-my-zsh\" && cd \"/home/vscode/.oh-my-zsh\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for nvm at /usr/local/share/nvm...
(*) Spawn: docker exec -u root vscdc--extract--1788194557004 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/nvm\" && cd \"/usr/local/share/nvm\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Getting remote and commit for ruby-build at /usr/local/share/ruby-build...
(*) Spawn: docker exec -u root vscdc--extract--1788194557004 bash -c "set -e && echo ~~~BEGIN~~~ && git config --global --add safe.directory \"/usr/local/share/ruby-build\" && cd \"/usr/local/share/ruby-build\" && if [ -f \".git-remote-and-commit\" ]; then cat .git-remote-and-commit; else git remote get-url origin && git log -n 1 --pretty=format:%H -- . | tee /dev/null; fi && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for git...
(*) Spawn: docker exec vscdc--extract--1788194557004 bash -c "set -e && echo ~~~BEGIN~~~ && git --version | sed -n '/git version /s///p' && echo && echo ~~~END~~~"
(*) Gathering information about "other" components...
(*) Getting version for Ruby...
(*) Spawn: docker exec vscdc--extract--1788194557004 bash -c "set -e && echo ~~~BEGIN~~~ && ruby --version | grep -oP '^ruby\s+\K[^\s]+' && echo && echo ~~~END~~~"
(*) Spawn: docker rm -f vscdc--extract--1788194557004
(!) Warning: No version for package undefined - skipping markdown output.
(!) Warning: No version for package undefined - skipping markdown output.
(*) Writing image history markdown...
(*) Spawn: docker image prune -a -f
(*) Writing cgmanifest.json...
(*) Done!
```